### PR TITLE
REVIEWING: Actually use recipe step products

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -29,9 +29,6 @@ jobs:
        linter-version: [ 'v1.42' ]
    runs-on: ubuntu-latest
    steps:
-     - name: vendor
-       run: go mod vendor
-
      - uses: actions/checkout@v2
      - name: golangci-lint
        uses: golangci/golangci-lint-action@v2

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -31,7 +31,7 @@ jobs:
    steps:
      - uses: actions/checkout@v2
      - name: golangci-lint
-       uses: golangci/golangci-lint-action@v2
+       uses: golangci/golangci-lint-action@v3
        with:
          # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
          version: ${{ matrix.linter-version }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -21,6 +21,9 @@ jobs:
      - name: Checkout code
        uses: actions/checkout@v2
 
+     - name: vendor
+       run: go mod vendor
+
      - name: check formatting
        run: if [ $(gofmt -l . | grep -Ev '^vendor\/' | head -c1 | wc -c) -ne 0 ]; then exit 1; fi
  lint:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -21,9 +21,6 @@ jobs:
      - name: Checkout code
        uses: actions/checkout@v2
 
-     - name: vendor
-       run: go mod vendor
-
      - name: check formatting
        run: if [ $(gofmt -l . | grep -Ev '^vendor\/' | head -c1 | wc -c) -ne 0 ]; then exit 1; fi
  lint:
@@ -32,6 +29,9 @@ jobs:
        linter-version: [ 'v1.42' ]
    runs-on: ubuntu-latest
    steps:
+     - name: vendor
+       run: go mod vendor
+
      - uses: actions/checkout@v2
      - name: golangci-lint
        uses: golangci/golangci-lint-action@v2

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -222,7 +222,7 @@ linters:
     - goconst          # Finds repeated strings that could be replaced by a constant
     - gocritic         # Provides many diagnostics that check for bugs, performance and style issues.
     - godot            # Check if comments end in a period
-    - godox            # Tool for detection of FIXME, TODO and other comment keywords
+    # - godox            # Tool for detection of FIXME, TODO and other comment keywords
     - gofmt            # Gofmt checks whether code was gofmt-ed. By default this tool runs with -s option to check for code simplification
     # - gofumpt          # Gofumpt checks whether code was gofumpt-ed.
     - goheader         # Checks is file header matches to pattern

--- a/environments/testing/dockerfiles/integration-tests.Dockerfile
+++ b/environments/testing/dockerfiles/integration-tests.Dockerfile
@@ -10,6 +10,6 @@ COPY . .
 ENV SKIP_PASETO_TESTS=FALSE
 
 # to debug a specific test:
-# ENTRYPOINT [ "go", "test", "-parallel", "1", "-v", "-failfast", "github.com/prixfixeco/api_server/tests/integration", "-run", "TestIntegration/TestMealPlanOptions_Listing" ]
+# ENTRYPOINT [ "go", "test", "-parallel", "1", "-v", "-failfast", "github.com/prixfixeco/api_server/tests/integration", "-run", "TestIntegration/TestRecipeSteps_Listing" ]
 
 ENTRYPOINT [ "go", "test", "-v", "-failfast", "github.com/prixfixeco/api_server/tests/integration" ]

--- a/environments/testing/dockerfiles/integration-tests.Dockerfile
+++ b/environments/testing/dockerfiles/integration-tests.Dockerfile
@@ -10,6 +10,6 @@ COPY . .
 ENV SKIP_PASETO_TESTS=FALSE
 
 # to debug a specific test:
-# ENTRYPOINT [ "go", "test", "-parallel", "1", "-v", "-failfast", "github.com/prixfixeco/api_server/tests/integration", "-run", "TestIntegration/TestRecipeSteps_Listing" ]
+# ENTRYPOINT [ "go", "test", "-parallel", "1", "-v", "-failfast", "github.com/prixfixeco/api_server/tests/integration", "-run", "TestIntegration/TestRecipeStepIngredients_Listing" ]
 
 ENTRYPOINT [ "go", "test", "-v", "-failfast", "github.com/prixfixeco/api_server/tests/integration" ]

--- a/internal/database/queriers/postgres/api_clients.go
+++ b/internal/database/queriers/postgres/api_clients.go
@@ -220,7 +220,7 @@ func (q *SQLQuerier) GetAPIClients(ctx context.Context, userID string, filter *t
 		x.Page, x.Limit = filter.Page, filter.Limit
 	}
 
-	query, args := q.buildListQuery(ctx, "api_clients", nil, nil, nil, userOwnershipColumn, apiClientsTableColumns, userID, false, filter)
+	query, args := q.buildListQuery(ctx, "api_clients", nil, nil, nil, userOwnershipColumn, apiClientsTableColumns, userID, false, filter, true)
 
 	rows, err := q.performReadQuery(ctx, q.db, "API clients", query, args)
 	if err != nil {

--- a/internal/database/queriers/postgres/api_clients_test.go
+++ b/internal/database/queriers/postgres/api_clients_test.go
@@ -309,7 +309,7 @@ func TestQuerier_GetAPIClients(T *testing.T) {
 		ctx := context.Background()
 		c, db := buildTestClient(t)
 
-		query, args := c.buildListQuery(ctx, "api_clients", nil, nil, nil, userOwnershipColumn, apiClientsTableColumns, exampleUserID, false, filter)
+		query, args := c.buildListQuery(ctx, "api_clients", nil, nil, nil, userOwnershipColumn, apiClientsTableColumns, exampleUserID, false, filter, true)
 
 		db.ExpectQuery(formatQueryForSQLMock(query)).
 			WithArgs(interfaceToDriverValue(args)...).
@@ -345,7 +345,7 @@ func TestQuerier_GetAPIClients(T *testing.T) {
 
 		ctx := context.Background()
 		c, db := buildTestClient(t)
-		query, args := c.buildListQuery(ctx, "api_clients", nil, nil, nil, userOwnershipColumn, apiClientsTableColumns, exampleUserID, false, filter)
+		query, args := c.buildListQuery(ctx, "api_clients", nil, nil, nil, userOwnershipColumn, apiClientsTableColumns, exampleUserID, false, filter, true)
 
 		db.ExpectQuery(formatQueryForSQLMock(query)).
 			WithArgs(interfaceToDriverValue(args)...).
@@ -366,7 +366,7 @@ func TestQuerier_GetAPIClients(T *testing.T) {
 		ctx := context.Background()
 		c, db := buildTestClient(t)
 
-		query, args := c.buildListQuery(ctx, "api_clients", nil, nil, nil, userOwnershipColumn, apiClientsTableColumns, exampleUserID, false, filter)
+		query, args := c.buildListQuery(ctx, "api_clients", nil, nil, nil, userOwnershipColumn, apiClientsTableColumns, exampleUserID, false, filter, true)
 
 		db.ExpectQuery(formatQueryForSQLMock(query)).
 			WithArgs(interfaceToDriverValue(args)...).
@@ -388,7 +388,7 @@ func TestQuerier_GetAPIClients(T *testing.T) {
 		ctx := context.Background()
 		c, db := buildTestClient(t)
 
-		query, args := c.buildListQuery(ctx, "api_clients", nil, nil, nil, userOwnershipColumn, apiClientsTableColumns, exampleUserID, false, filter)
+		query, args := c.buildListQuery(ctx, "api_clients", nil, nil, nil, userOwnershipColumn, apiClientsTableColumns, exampleUserID, false, filter, true)
 
 		db.ExpectQuery(formatQueryForSQLMock(query)).
 			WithArgs(interfaceToDriverValue(args)...).
@@ -409,7 +409,7 @@ func TestQuerier_GetAPIClients(T *testing.T) {
 		ctx := context.Background()
 		c, db := buildTestClient(t)
 
-		query, args := c.buildListQuery(ctx, "api_clients", nil, nil, nil, userOwnershipColumn, apiClientsTableColumns, exampleUserID, false, filter)
+		query, args := c.buildListQuery(ctx, "api_clients", nil, nil, nil, userOwnershipColumn, apiClientsTableColumns, exampleUserID, false, filter, true)
 
 		db.ExpectQuery(formatQueryForSQLMock(query)).
 			WithArgs(interfaceToDriverValue(args)...).

--- a/internal/database/queriers/postgres/meal_plan_option_votes.go
+++ b/internal/database/queriers/postgres/meal_plan_option_votes.go
@@ -249,7 +249,7 @@ func (q *SQLQuerier) GetMealPlanOptionVotes(ctx context.Context, mealPlanID, mea
 		x.Page, x.Limit = filter.Page, filter.Limit
 	}
 
-	query, args := q.buildListQuery(ctx, "meal_plan_option_votes", getMealPlanOptionVotesJoins, nil, nil, householdOwnershipColumn, mealPlanOptionVotesTableColumns, "", false, filter)
+	query, args := q.buildListQuery(ctx, "meal_plan_option_votes", getMealPlanOptionVotesJoins, nil, nil, householdOwnershipColumn, mealPlanOptionVotesTableColumns, "", false, filter, true)
 
 	rows, err := q.performReadQuery(ctx, q.db, "mealPlanOptionVotes", query, args)
 	if err != nil {

--- a/internal/database/queriers/postgres/meal_plan_option_votes_test.go
+++ b/internal/database/queriers/postgres/meal_plan_option_votes_test.go
@@ -376,7 +376,7 @@ func TestQuerier_GetMealPlanOptionVotes(T *testing.T) {
 		ctx := context.Background()
 		c, db := buildTestClient(t)
 
-		query, args := c.buildListQuery(ctx, "meal_plan_option_votes", getMealPlanOptionVotesJoins, nil, nil, householdOwnershipColumn, mealPlanOptionVotesTableColumns, "", false, filter)
+		query, args := c.buildListQuery(ctx, "meal_plan_option_votes", getMealPlanOptionVotesJoins, nil, nil, householdOwnershipColumn, mealPlanOptionVotesTableColumns, "", false, filter, true)
 
 		db.ExpectQuery(formatQueryForSQLMock(query)).
 			WithArgs(interfaceToDriverValue(args)...).
@@ -430,7 +430,7 @@ func TestQuerier_GetMealPlanOptionVotes(T *testing.T) {
 		ctx := context.Background()
 		c, db := buildTestClient(t)
 
-		query, args := c.buildListQuery(ctx, "meal_plan_option_votes", getMealPlanOptionVotesJoins, nil, nil, householdOwnershipColumn, mealPlanOptionVotesTableColumns, "", false, filter)
+		query, args := c.buildListQuery(ctx, "meal_plan_option_votes", getMealPlanOptionVotesJoins, nil, nil, householdOwnershipColumn, mealPlanOptionVotesTableColumns, "", false, filter, true)
 
 		db.ExpectQuery(formatQueryForSQLMock(query)).
 			WithArgs(interfaceToDriverValue(args)...).
@@ -453,7 +453,7 @@ func TestQuerier_GetMealPlanOptionVotes(T *testing.T) {
 		ctx := context.Background()
 		c, db := buildTestClient(t)
 
-		query, args := c.buildListQuery(ctx, "meal_plan_option_votes", getMealPlanOptionVotesJoins, nil, nil, householdOwnershipColumn, mealPlanOptionVotesTableColumns, "", false, filter)
+		query, args := c.buildListQuery(ctx, "meal_plan_option_votes", getMealPlanOptionVotesJoins, nil, nil, householdOwnershipColumn, mealPlanOptionVotesTableColumns, "", false, filter, true)
 
 		db.ExpectQuery(formatQueryForSQLMock(query)).
 			WithArgs(interfaceToDriverValue(args)...).
@@ -476,7 +476,7 @@ func TestQuerier_GetMealPlanOptionVotes(T *testing.T) {
 		ctx := context.Background()
 		c, db := buildTestClient(t)
 
-		query, args := c.buildListQuery(ctx, "meal_plan_option_votes", getMealPlanOptionVotesJoins, nil, nil, householdOwnershipColumn, mealPlanOptionVotesTableColumns, "", false, filter)
+		query, args := c.buildListQuery(ctx, "meal_plan_option_votes", getMealPlanOptionVotesJoins, nil, nil, householdOwnershipColumn, mealPlanOptionVotesTableColumns, "", false, filter, true)
 
 		db.ExpectQuery(formatQueryForSQLMock(query)).
 			WithArgs(interfaceToDriverValue(args)...).

--- a/internal/database/queriers/postgres/meal_plan_options.go
+++ b/internal/database/queriers/postgres/meal_plan_options.go
@@ -265,7 +265,7 @@ func (q *SQLQuerier) GetMealPlanOptions(ctx context.Context, mealPlanID string, 
 	}
 
 	groupBys := []string{"meal_plan_options.id", "meals.id"}
-	query, args := q.buildListQuery(ctx, "meal_plan_options", getMealPlanOptionsJoins, groupBys, nil, householdOwnershipColumn, mealPlanOptionsTableColumns, "", false, filter)
+	query, args := q.buildListQuery(ctx, "meal_plan_options", getMealPlanOptionsJoins, groupBys, nil, householdOwnershipColumn, mealPlanOptionsTableColumns, "", false, filter, true)
 
 	rows, err := q.performReadQuery(ctx, q.db, "mealPlanOptions", query, args)
 	if err != nil {

--- a/internal/database/queriers/postgres/meal_plan_options_test.go
+++ b/internal/database/queriers/postgres/meal_plan_options_test.go
@@ -345,7 +345,7 @@ func TestQuerier_GetMealPlanOptions(T *testing.T) {
 		c, db := buildTestClient(t)
 
 		groupBys := []string{"meal_plan_options.id", "meals.id"}
-		query, args := c.buildListQuery(ctx, "meal_plan_options", getMealPlanOptionsJoins, groupBys, nil, householdOwnershipColumn, mealPlanOptionsTableColumns, "", false, filter)
+		query, args := c.buildListQuery(ctx, "meal_plan_options", getMealPlanOptionsJoins, groupBys, nil, householdOwnershipColumn, mealPlanOptionsTableColumns, "", false, filter, true)
 
 		db.ExpectQuery(formatQueryForSQLMock(query)).
 			WithArgs(interfaceToDriverValue(args)...).
@@ -388,7 +388,7 @@ func TestQuerier_GetMealPlanOptions(T *testing.T) {
 		c, db := buildTestClient(t)
 
 		groupBys := []string{"meal_plan_options.id", "meals.id"}
-		query, args := c.buildListQuery(ctx, "meal_plan_options", getMealPlanOptionsJoins, groupBys, nil, householdOwnershipColumn, mealPlanOptionsTableColumns, "", false, filter)
+		query, args := c.buildListQuery(ctx, "meal_plan_options", getMealPlanOptionsJoins, groupBys, nil, householdOwnershipColumn, mealPlanOptionsTableColumns, "", false, filter, true)
 
 		db.ExpectQuery(formatQueryForSQLMock(query)).
 			WithArgs(interfaceToDriverValue(args)...).
@@ -411,7 +411,7 @@ func TestQuerier_GetMealPlanOptions(T *testing.T) {
 		c, db := buildTestClient(t)
 
 		groupBys := []string{"meal_plan_options.id", "meals.id"}
-		query, args := c.buildListQuery(ctx, "meal_plan_options", getMealPlanOptionsJoins, groupBys, nil, householdOwnershipColumn, mealPlanOptionsTableColumns, "", false, filter)
+		query, args := c.buildListQuery(ctx, "meal_plan_options", getMealPlanOptionsJoins, groupBys, nil, householdOwnershipColumn, mealPlanOptionsTableColumns, "", false, filter, true)
 
 		db.ExpectQuery(formatQueryForSQLMock(query)).
 			WithArgs(interfaceToDriverValue(args)...).
@@ -434,7 +434,7 @@ func TestQuerier_GetMealPlanOptions(T *testing.T) {
 		c, db := buildTestClient(t)
 
 		groupBys := []string{"meal_plan_options.id", "meals.id"}
-		query, args := c.buildListQuery(ctx, "meal_plan_options", getMealPlanOptionsJoins, groupBys, nil, householdOwnershipColumn, mealPlanOptionsTableColumns, "", false, filter)
+		query, args := c.buildListQuery(ctx, "meal_plan_options", getMealPlanOptionsJoins, groupBys, nil, householdOwnershipColumn, mealPlanOptionsTableColumns, "", false, filter, true)
 
 		db.ExpectQuery(formatQueryForSQLMock(query)).
 			WithArgs(interfaceToDriverValue(args)...).

--- a/internal/database/queriers/postgres/meal_plans.go
+++ b/internal/database/queriers/postgres/meal_plans.go
@@ -342,7 +342,7 @@ func (q *SQLQuerier) GetMealPlans(ctx context.Context, filter *types.QueryFilter
 		x.Page, x.Limit = filter.Page, filter.Limit
 	}
 
-	query, args := q.buildListQuery(ctx, "meal_plans", nil, nil, nil, householdOwnershipColumn, mealPlansTableColumns, "", false, filter)
+	query, args := q.buildListQuery(ctx, "meal_plans", nil, nil, nil, householdOwnershipColumn, mealPlansTableColumns, "", false, filter, true)
 
 	rows, err := q.performReadQuery(ctx, q.db, "mealPlans", query, args)
 	if err != nil {

--- a/internal/database/queriers/postgres/meal_plans_test.go
+++ b/internal/database/queriers/postgres/meal_plans_test.go
@@ -446,7 +446,7 @@ func TestQuerier_GetMealPlans(T *testing.T) {
 		ctx := context.Background()
 		c, db := buildTestClient(t)
 
-		query, args := c.buildListQuery(ctx, "meal_plans", nil, nil, nil, householdOwnershipColumn, mealPlansTableColumns, "", false, filter)
+		query, args := c.buildListQuery(ctx, "meal_plans", nil, nil, nil, householdOwnershipColumn, mealPlansTableColumns, "", false, filter, true)
 
 		db.ExpectQuery(formatQueryForSQLMock(query)).
 			WithArgs(interfaceToDriverValue(args)...).
@@ -473,7 +473,7 @@ func TestQuerier_GetMealPlans(T *testing.T) {
 		ctx := context.Background()
 		c, db := buildTestClient(t)
 
-		query, args := c.buildListQuery(ctx, "meal_plans", nil, nil, nil, householdOwnershipColumn, mealPlansTableColumns, "", false, filter)
+		query, args := c.buildListQuery(ctx, "meal_plans", nil, nil, nil, householdOwnershipColumn, mealPlansTableColumns, "", false, filter, true)
 
 		db.ExpectQuery(formatQueryForSQLMock(query)).
 			WithArgs(interfaceToDriverValue(args)...).
@@ -494,7 +494,7 @@ func TestQuerier_GetMealPlans(T *testing.T) {
 		ctx := context.Background()
 		c, db := buildTestClient(t)
 
-		query, args := c.buildListQuery(ctx, "meal_plans", nil, nil, nil, householdOwnershipColumn, mealPlansTableColumns, "", false, filter)
+		query, args := c.buildListQuery(ctx, "meal_plans", nil, nil, nil, householdOwnershipColumn, mealPlansTableColumns, "", false, filter, true)
 
 		db.ExpectQuery(formatQueryForSQLMock(query)).
 			WithArgs(interfaceToDriverValue(args)...).
@@ -515,7 +515,7 @@ func TestQuerier_GetMealPlans(T *testing.T) {
 		ctx := context.Background()
 		c, db := buildTestClient(t)
 
-		query, args := c.buildListQuery(ctx, "meal_plans", nil, nil, nil, householdOwnershipColumn, mealPlansTableColumns, "", false, filter)
+		query, args := c.buildListQuery(ctx, "meal_plans", nil, nil, nil, householdOwnershipColumn, mealPlansTableColumns, "", false, filter, true)
 
 		db.ExpectQuery(formatQueryForSQLMock(query)).
 			WithArgs(interfaceToDriverValue(args)...).

--- a/internal/database/queriers/postgres/meals.go
+++ b/internal/database/queriers/postgres/meals.go
@@ -249,7 +249,7 @@ func (q *SQLQuerier) GetMeals(ctx context.Context, filter *types.QueryFilter) (x
 		x.Page, x.Limit = filter.Page, filter.Limit
 	}
 
-	query, args := q.buildListQuery(ctx, "meals", nil, nil, nil, "", mealsTableColumns, "", false, filter)
+	query, args := q.buildListQuery(ctx, "meals", nil, nil, nil, "", mealsTableColumns, "", false, filter, true)
 
 	rows, err := q.performReadQuery(ctx, q.db, "meals", query, args)
 	if err != nil {

--- a/internal/database/queriers/postgres/meals_test.go
+++ b/internal/database/queriers/postgres/meals_test.go
@@ -212,14 +212,34 @@ func TestQuerier_GetMeal(T *testing.T) {
 			WillReturnRows(buildMockFullRowsFromMeal(exampleMeal))
 
 		for _, recipe := range exampleMeal.Recipes {
+			allIngredients := []*types.RecipeStepIngredient{}
+			allProducts := []*types.RecipeStepProduct{}
+			for _, step := range recipe.Steps {
+				allIngredients = append(allIngredients, step.Ingredients...)
+				allProducts = append(allProducts, step.Products...)
+			}
+
 			getRecipeArgs := []interface{}{
 				recipe.ID,
 				recipe.ID,
 			}
 
-			db.ExpectQuery(formatQueryForSQLMock(getCompleteRecipeByIDQuery)).
+			db.ExpectQuery(formatQueryForSQLMock(getRecipeByIDQuery)).
 				WithArgs(interfaceToDriverValue(getRecipeArgs)...).
 				WillReturnRows(buildMockFullRowsFromRecipe(recipe))
+
+			query, args := c.buildListQuery(ctx, "recipe_step_ingredients", getRecipeStepIngredientsJoins, []string{"recipe_step_ingredients.id", "valid_ingredients.id"}, nil, householdOwnershipColumn, recipeStepIngredientsTableColumns, "", false, nil, false)
+			db.ExpectQuery(formatQueryForSQLMock(query)).
+				WithArgs(interfaceToDriverValue(args)...).
+				WillReturnRows(buildMockRowsFromRecipeStepIngredients(false, 0, allIngredients...))
+
+			productsArgs := []interface{}{
+				recipe.ID,
+				recipe.ID,
+			}
+			db.ExpectQuery(formatQueryForSQLMock(getRecipeStepProductsForRecipeQuery)).
+				WithArgs(interfaceToDriverValue(productsArgs)...).
+				WillReturnRows(buildMockRowsFromRecipeStepProducts(false, 0, allProducts...))
 		}
 
 		actual, err := c.GetMeal(ctx, exampleMeal.ID)
@@ -307,7 +327,7 @@ func TestQuerier_GetMeal(T *testing.T) {
 			exampleMeal.Recipes[0].ID,
 		}
 
-		db.ExpectQuery(formatQueryForSQLMock(getCompleteRecipeByIDQuery)).
+		db.ExpectQuery(formatQueryForSQLMock(getRecipeByIDQuery)).
 			WithArgs(interfaceToDriverValue(getRecipeArgs)...).
 			WillReturnError(errors.New("blah"))
 
@@ -375,7 +395,7 @@ func TestQuerier_GetMeals(T *testing.T) {
 		ctx := context.Background()
 		c, db := buildTestClient(t)
 
-		query, args := c.buildListQuery(ctx, "meals", nil, nil, nil, householdOwnershipColumn, mealsTableColumns, "", false, filter)
+		query, args := c.buildListQuery(ctx, "meals", nil, nil, nil, householdOwnershipColumn, mealsTableColumns, "", false, filter, true)
 
 		db.ExpectQuery(formatQueryForSQLMock(query)).
 			WithArgs(interfaceToDriverValue(args)...).
@@ -402,7 +422,7 @@ func TestQuerier_GetMeals(T *testing.T) {
 		ctx := context.Background()
 		c, db := buildTestClient(t)
 
-		query, args := c.buildListQuery(ctx, "meals", nil, nil, nil, householdOwnershipColumn, mealsTableColumns, "", false, filter)
+		query, args := c.buildListQuery(ctx, "meals", nil, nil, nil, householdOwnershipColumn, mealsTableColumns, "", false, filter, true)
 
 		db.ExpectQuery(formatQueryForSQLMock(query)).
 			WithArgs(interfaceToDriverValue(args)...).
@@ -423,7 +443,7 @@ func TestQuerier_GetMeals(T *testing.T) {
 		ctx := context.Background()
 		c, db := buildTestClient(t)
 
-		query, args := c.buildListQuery(ctx, "meals", nil, nil, nil, householdOwnershipColumn, mealsTableColumns, "", false, filter)
+		query, args := c.buildListQuery(ctx, "meals", nil, nil, nil, householdOwnershipColumn, mealsTableColumns, "", false, filter, true)
 
 		db.ExpectQuery(formatQueryForSQLMock(query)).
 			WithArgs(interfaceToDriverValue(args)...).
@@ -444,7 +464,7 @@ func TestQuerier_GetMeals(T *testing.T) {
 		ctx := context.Background()
 		c, db := buildTestClient(t)
 
-		query, args := c.buildListQuery(ctx, "meals", nil, nil, nil, householdOwnershipColumn, mealsTableColumns, "", false, filter)
+		query, args := c.buildListQuery(ctx, "meals", nil, nil, nil, householdOwnershipColumn, mealsTableColumns, "", false, filter, true)
 
 		db.ExpectQuery(formatQueryForSQLMock(query)).
 			WithArgs(interfaceToDriverValue(args)...).

--- a/internal/database/queriers/postgres/meals_test.go
+++ b/internal/database/queriers/postgres/meals_test.go
@@ -193,6 +193,13 @@ func TestQuerier_GetMeal(T *testing.T) {
 
 		exampleMeal := fakes.BuildFakeMeal()
 
+		// TODO: remove me
+		for i := range exampleMeal.Recipes {
+			for j := range exampleMeal.Recipes[i].Steps {
+				exampleMeal.Recipes[i].Steps[j].Products = nil
+			}
+		}
+
 		ctx := context.Background()
 		c, db := buildTestClient(t)
 

--- a/internal/database/queriers/postgres/meals_test.go
+++ b/internal/database/queriers/postgres/meals_test.go
@@ -193,7 +193,6 @@ func TestQuerier_GetMeal(T *testing.T) {
 
 		exampleMeal := fakes.BuildFakeMeal()
 
-		// TODO: remove me
 		for i := range exampleMeal.Recipes {
 			for j := range exampleMeal.Recipes[i].Steps {
 				exampleMeal.Recipes[i].Steps[j].Products = nil

--- a/internal/database/queriers/postgres/migrate.go
+++ b/internal/database/queriers/postgres/migrate.go
@@ -75,6 +75,9 @@ var (
 	//go:embed migrations/00016_recipe_step_products.sql
 	recipeStepProductsReintroductionMigration string
 
+	//go:embed migrations/00017_remove_yields_from_recipe_steps.sql
+	recipeStepProductsRemoveYieldsMigration string
+
 	migrations = []darwin.Migration{
 		{
 			Version:     1,
@@ -155,6 +158,11 @@ var (
 			Version:     16,
 			Description: "reintroduce recipe step products table",
 			Script:      recipeStepProductsReintroductionMigration,
+		},
+		{
+			Version:     17,
+			Description: "remove yields from recipe steps table",
+			Script:      recipeStepProductsRemoveYieldsMigration,
 		},
 	}
 )

--- a/internal/database/queriers/postgres/migrations/00017_remove_yields_from_recipe_steps.sql
+++ b/internal/database/queriers/postgres/migrations/00017_remove_yields_from_recipe_steps.sql
@@ -1,0 +1,1 @@
+ALTER TABLE recipe_steps DROP COLUMN IF EXISTS "yields";

--- a/internal/database/queriers/postgres/postgres.go
+++ b/internal/database/queriers/postgres/postgres.go
@@ -79,7 +79,7 @@ func ProvideDatabaseClient(
 		db:            db,
 		config:        cfg,
 		tracer:        tracer,
-		logQueries:    false,
+		logQueries:    true,
 		timeFunc:      defaultTimeFunc,
 		connectionURL: string(cfg.ConnectionDetails),
 		logger:        logging.EnsureLogger(logger),

--- a/internal/database/queriers/postgres/queries_test.go
+++ b/internal/database/queriers/postgres/queries_test.go
@@ -75,7 +75,7 @@ func TestPostgres_buildListQuery(T *testing.T) {
 			"key": "value",
 		}
 
-		actualQuery, actualArgs := q.buildListQuery(ctx, exampleTableName, exampleJoins, nil, exampleWhere, exampleOwnershipColumn, exampleColumns, exampleUser.ID, false, filter)
+		actualQuery, actualArgs := q.buildListQuery(ctx, exampleTableName, exampleJoins, nil, exampleWhere, exampleOwnershipColumn, exampleColumns, exampleUser.ID, false, filter, true)
 
 		assertArgCountMatchesQuery(t, actualQuery, actualArgs)
 		assert.Equal(t, expectedQuery, actualQuery)
@@ -102,7 +102,7 @@ func TestPostgres_buildListQuery(T *testing.T) {
 			filter.UpdatedAfter,
 			filter.UpdatedBefore,
 		}
-		actualQuery, actualArgs := q.buildListQuery(ctx, exampleTableName, nil, nil, nil, exampleOwnershipColumn, exampleColumns, exampleUser.ID, true, filter)
+		actualQuery, actualArgs := q.buildListQuery(ctx, exampleTableName, nil, nil, nil, exampleOwnershipColumn, exampleColumns, exampleUser.ID, true, filter, true)
 
 		assertArgCountMatchesQuery(t, actualQuery, actualArgs)
 		assert.Equal(t, expectedQuery, actualQuery)
@@ -130,7 +130,7 @@ func TestPostgres_buildListQuery(T *testing.T) {
 			filter.UpdatedAfter,
 			filter.UpdatedBefore,
 		}
-		actualQuery, actualArgs := q.buildListQuery(ctx, exampleTableName, nil, nil, nil, exampleOwnershipColumn, exampleColumns, exampleUser.ID, true, filter)
+		actualQuery, actualArgs := q.buildListQuery(ctx, exampleTableName, nil, nil, nil, exampleOwnershipColumn, exampleColumns, exampleUser.ID, true, filter, true)
 
 		assertArgCountMatchesQuery(t, actualQuery, actualArgs)
 		assert.Equal(t, expectedQuery, actualQuery)

--- a/internal/database/queriers/postgres/recipe_step_ingredients_test.go
+++ b/internal/database/queriers/postgres/recipe_step_ingredients_test.go
@@ -38,6 +38,28 @@ func buildMockRowsFromRecipeStepIngredients(includeCounts bool, filteredCount ui
 			x.LastUpdatedOn,
 			x.ArchivedOn,
 			x.BelongsToRecipeStep,
+			x.Ingredient.ID,
+			x.Ingredient.Name,
+			x.Ingredient.Variant,
+			x.Ingredient.Description,
+			x.Ingredient.Warning,
+			x.Ingredient.ContainsEgg,
+			x.Ingredient.ContainsDairy,
+			x.Ingredient.ContainsPeanut,
+			x.Ingredient.ContainsTreeNut,
+			x.Ingredient.ContainsSoy,
+			x.Ingredient.ContainsWheat,
+			x.Ingredient.ContainsShellfish,
+			x.Ingredient.ContainsSesame,
+			x.Ingredient.ContainsFish,
+			x.Ingredient.ContainsGluten,
+			x.Ingredient.AnimalFlesh,
+			x.Ingredient.AnimalDerived,
+			x.Ingredient.Volumetric,
+			x.Ingredient.IconPath,
+			x.Ingredient.CreatedOn,
+			x.Ingredient.LastUpdatedOn,
+			x.Ingredient.ArchivedOn,
 		}
 
 		if includeCounts {
@@ -365,6 +387,35 @@ func TestQuerier_GetTotalRecipeStepIngredientCount(T *testing.T) {
 	})
 }
 
+func TestQuerier_getRecipeStepIngredientsForRecipe(T *testing.T) {
+	T.Parallel()
+
+	T.Run("standard", func(t *testing.T) {
+		t.Parallel()
+
+		exampleRecipeID := fakes.BuildFakeID()
+		exampleRecipeStepIngredientList := fakes.BuildFakeRecipeStepIngredientList()
+
+		for i := range exampleRecipeStepIngredientList.RecipeStepIngredients {
+			exampleRecipeStepIngredientList.RecipeStepIngredients[i].Ingredient = types.ValidIngredient{}
+		}
+
+		ctx := context.Background()
+		c, db := buildTestClient(t)
+
+		query, args := c.buildListQuery(ctx, "recipe_step_ingredients", getRecipeStepIngredientsJoins, []string{"recipe_step_ingredients.id", "valid_ingredients.id"}, nil, householdOwnershipColumn, recipeStepIngredientsTableColumns, "", false, nil, false)
+		db.ExpectQuery(formatQueryForSQLMock(query)).
+			WithArgs(interfaceToDriverValue(args)...).
+			WillReturnRows(buildMockRowsFromRecipeStepIngredients(false, 0, exampleRecipeStepIngredientList.RecipeStepIngredients...))
+
+		actual, err := c.getRecipeStepIngredientsForRecipe(ctx, exampleRecipeID)
+		assert.NoError(t, err)
+		assert.Equal(t, exampleRecipeStepIngredientList.RecipeStepIngredients, actual)
+
+		mock.AssertExpectationsForObjects(t, db)
+	})
+}
+
 func TestQuerier_GetRecipeStepIngredients(T *testing.T) {
 	T.Parallel()
 
@@ -383,8 +434,7 @@ func TestQuerier_GetRecipeStepIngredients(T *testing.T) {
 		ctx := context.Background()
 		c, db := buildTestClient(t)
 
-		query, args := c.buildListQuery(ctx, "recipe_step_ingredients", getRecipeStepIngredientsJoins, nil, nil, householdOwnershipColumn, recipeStepIngredientsTableColumns, "", false, filter)
-
+		query, args := c.buildListQuery(ctx, "recipe_step_ingredients", getRecipeStepIngredientsJoins, []string{"recipe_step_ingredients.id", "valid_ingredients.id"}, nil, householdOwnershipColumn, recipeStepIngredientsTableColumns, "", false, filter, true)
 		db.ExpectQuery(formatQueryForSQLMock(query)).
 			WithArgs(interfaceToDriverValue(args)...).
 			WillReturnRows(buildMockRowsFromRecipeStepIngredients(true, exampleRecipeStepIngredientList.FilteredCount, exampleRecipeStepIngredientList.RecipeStepIngredients...))
@@ -440,8 +490,7 @@ func TestQuerier_GetRecipeStepIngredients(T *testing.T) {
 		ctx := context.Background()
 		c, db := buildTestClient(t)
 
-		query, args := c.buildListQuery(ctx, "recipe_step_ingredients", getRecipeStepIngredientsJoins, nil, nil, householdOwnershipColumn, recipeStepIngredientsTableColumns, "", false, filter)
-
+		query, args := c.buildListQuery(ctx, "recipe_step_ingredients", getRecipeStepIngredientsJoins, []string{"recipe_step_ingredients.id", "valid_ingredients.id"}, nil, householdOwnershipColumn, recipeStepIngredientsTableColumns, "", false, filter, true)
 		db.ExpectQuery(formatQueryForSQLMock(query)).
 			WithArgs(interfaceToDriverValue(args)...).
 			WillReturnRows(buildMockRowsFromRecipeStepIngredients(true, exampleRecipeStepIngredientList.FilteredCount, exampleRecipeStepIngredientList.RecipeStepIngredients...))
@@ -463,8 +512,7 @@ func TestQuerier_GetRecipeStepIngredients(T *testing.T) {
 		ctx := context.Background()
 		c, db := buildTestClient(t)
 
-		query, args := c.buildListQuery(ctx, "recipe_step_ingredients", getRecipeStepIngredientsJoins, nil, nil, householdOwnershipColumn, recipeStepIngredientsTableColumns, "", false, filter)
-
+		query, args := c.buildListQuery(ctx, "recipe_step_ingredients", getRecipeStepIngredientsJoins, []string{"recipe_step_ingredients.id", "valid_ingredients.id"}, nil, householdOwnershipColumn, recipeStepIngredientsTableColumns, "", false, filter, true)
 		db.ExpectQuery(formatQueryForSQLMock(query)).
 			WithArgs(interfaceToDriverValue(args)...).
 			WillReturnError(errors.New("blah"))
@@ -486,8 +534,7 @@ func TestQuerier_GetRecipeStepIngredients(T *testing.T) {
 		ctx := context.Background()
 		c, db := buildTestClient(t)
 
-		query, args := c.buildListQuery(ctx, "recipe_step_ingredients", getRecipeStepIngredientsJoins, nil, nil, householdOwnershipColumn, recipeStepIngredientsTableColumns, "", false, filter)
-
+		query, args := c.buildListQuery(ctx, "recipe_step_ingredients", getRecipeStepIngredientsJoins, []string{"recipe_step_ingredients.id", "valid_ingredients.id"}, nil, householdOwnershipColumn, recipeStepIngredientsTableColumns, "", false, filter, true)
 		db.ExpectQuery(formatQueryForSQLMock(query)).
 			WithArgs(interfaceToDriverValue(args)...).
 			WillReturnRows(buildErroneousMockRow())

--- a/internal/database/queriers/postgres/recipe_step_instruments.go
+++ b/internal/database/queriers/postgres/recipe_step_instruments.go
@@ -234,7 +234,7 @@ func (q *SQLQuerier) GetRecipeStepInstruments(ctx context.Context, recipeID, rec
 		x.Page, x.Limit = filter.Page, filter.Limit
 	}
 
-	query, args := q.buildListQuery(ctx, "recipe_step_instruments", getRecipeStepInstrumentsJoins, nil, nil, householdOwnershipColumn, recipeStepInstrumentsTableColumns, "", false, filter)
+	query, args := q.buildListQuery(ctx, "recipe_step_instruments", getRecipeStepInstrumentsJoins, nil, nil, householdOwnershipColumn, recipeStepInstrumentsTableColumns, "", false, filter, true)
 
 	rows, err := q.performReadQuery(ctx, q.db, "recipeStepInstruments", query, args)
 	if err != nil {

--- a/internal/database/queriers/postgres/recipe_step_instruments_test.go
+++ b/internal/database/queriers/postgres/recipe_step_instruments_test.go
@@ -375,7 +375,7 @@ func TestQuerier_GetRecipeStepInstruments(T *testing.T) {
 		ctx := context.Background()
 		c, db := buildTestClient(t)
 
-		query, args := c.buildListQuery(ctx, "recipe_step_instruments", getRecipeStepInstrumentsJoins, nil, nil, householdOwnershipColumn, recipeStepInstrumentsTableColumns, "", false, filter)
+		query, args := c.buildListQuery(ctx, "recipe_step_instruments", getRecipeStepInstrumentsJoins, nil, nil, householdOwnershipColumn, recipeStepInstrumentsTableColumns, "", false, filter, true)
 
 		db.ExpectQuery(formatQueryForSQLMock(query)).
 			WithArgs(interfaceToDriverValue(args)...).
@@ -429,7 +429,7 @@ func TestQuerier_GetRecipeStepInstruments(T *testing.T) {
 		ctx := context.Background()
 		c, db := buildTestClient(t)
 
-		query, args := c.buildListQuery(ctx, "recipe_step_instruments", getRecipeStepInstrumentsJoins, nil, nil, householdOwnershipColumn, recipeStepInstrumentsTableColumns, "", false, filter)
+		query, args := c.buildListQuery(ctx, "recipe_step_instruments", getRecipeStepInstrumentsJoins, nil, nil, householdOwnershipColumn, recipeStepInstrumentsTableColumns, "", false, filter, true)
 
 		db.ExpectQuery(formatQueryForSQLMock(query)).
 			WithArgs(interfaceToDriverValue(args)...).
@@ -452,7 +452,7 @@ func TestQuerier_GetRecipeStepInstruments(T *testing.T) {
 		ctx := context.Background()
 		c, db := buildTestClient(t)
 
-		query, args := c.buildListQuery(ctx, "recipe_step_instruments", getRecipeStepInstrumentsJoins, nil, nil, householdOwnershipColumn, recipeStepInstrumentsTableColumns, "", false, filter)
+		query, args := c.buildListQuery(ctx, "recipe_step_instruments", getRecipeStepInstrumentsJoins, nil, nil, householdOwnershipColumn, recipeStepInstrumentsTableColumns, "", false, filter, true)
 
 		db.ExpectQuery(formatQueryForSQLMock(query)).
 			WithArgs(interfaceToDriverValue(args)...).
@@ -475,7 +475,7 @@ func TestQuerier_GetRecipeStepInstruments(T *testing.T) {
 		ctx := context.Background()
 		c, db := buildTestClient(t)
 
-		query, args := c.buildListQuery(ctx, "recipe_step_instruments", getRecipeStepInstrumentsJoins, nil, nil, householdOwnershipColumn, recipeStepInstrumentsTableColumns, "", false, filter)
+		query, args := c.buildListQuery(ctx, "recipe_step_instruments", getRecipeStepInstrumentsJoins, nil, nil, householdOwnershipColumn, recipeStepInstrumentsTableColumns, "", false, filter, true)
 
 		db.ExpectQuery(formatQueryForSQLMock(query)).
 			WithArgs(interfaceToDriverValue(args)...).

--- a/internal/database/queriers/postgres/recipe_step_products.go
+++ b/internal/database/queriers/postgres/recipe_step_products.go
@@ -143,7 +143,26 @@ func (q *SQLQuerier) RecipeStepProductExists(ctx context.Context, recipeID, reci
 	return result, nil
 }
 
-const getRecipeStepProductQuery = "SELECT recipe_step_products.id, recipe_step_products.name, recipe_step_products.recipe_step_id, recipe_step_products.created_on, recipe_step_products.last_updated_on, recipe_step_products.archived_on, recipe_step_products.belongs_to_recipe_step FROM recipe_step_products JOIN recipe_steps ON recipe_step_products.belongs_to_recipe_step=recipe_steps.id JOIN recipes ON recipe_steps.belongs_to_recipe=recipes.id WHERE recipe_step_products.archived_on IS NULL AND recipe_step_products.belongs_to_recipe_step = $1 AND recipe_step_products.id = $2 AND recipe_steps.archived_on IS NULL AND recipe_steps.belongs_to_recipe = $3 AND recipe_steps.id = $4 AND recipes.archived_on IS NULL AND recipes.id = $5"
+const getRecipeStepProductQuery = `SELECT
+	recipe_step_products.id,
+	recipe_step_products.name,
+	recipe_step_products.recipe_step_id,
+	recipe_step_products.created_on,
+	recipe_step_products.last_updated_on,
+	recipe_step_products.archived_on,
+	recipe_step_products.belongs_to_recipe_step
+FROM recipe_step_products
+JOIN recipe_steps ON recipe_step_products.belongs_to_recipe_step=recipe_steps.id
+JOIN recipes ON recipe_steps.belongs_to_recipe=recipes.id
+WHERE recipe_step_products.archived_on IS NULL
+AND recipe_step_products.belongs_to_recipe_step = $1 
+AND recipe_step_products.id = $2
+AND recipe_steps.archived_on IS NULL
+AND recipe_steps.belongs_to_recipe = $3
+AND recipe_steps.id = $4
+AND recipes.archived_on IS NULL 
+AND recipes.id = $5
+`
 
 // GetRecipeStepProduct fetches a recipe step product from the database.
 func (q *SQLQuerier) GetRecipeStepProduct(ctx context.Context, recipeID, recipeStepID, recipeStepProductID string) (*types.RecipeStepProduct, error) {
@@ -205,6 +224,55 @@ func (q *SQLQuerier) GetTotalRecipeStepProductCount(ctx context.Context) (uint64
 	return count, nil
 }
 
+const getRecipeStepProductsForRecipeQuery = `SELECT
+	recipe_step_products.id,
+	recipe_step_products.name,
+	recipe_step_products.recipe_step_id,
+	recipe_step_products.created_on,
+	recipe_step_products.last_updated_on,
+	recipe_step_products.archived_on,
+	recipe_step_products.belongs_to_recipe_step
+FROM recipe_step_products
+JOIN recipe_steps ON recipe_step_products.belongs_to_recipe_step=recipe_steps.id
+JOIN recipes ON recipe_steps.belongs_to_recipe=recipes.id
+WHERE recipe_step_products.archived_on IS NULL
+AND recipe_steps.archived_on IS NULL
+AND recipe_steps.belongs_to_recipe = $1
+AND recipes.archived_on IS NULL 
+AND recipes.id = $2
+`
+
+// getRecipeStepProductsForRecipe fetches a list of recipe step products from the database that meet a particular filter.
+func (q *SQLQuerier) getRecipeStepProductsForRecipe(ctx context.Context, recipeID string) ([]*types.RecipeStepProduct, error) {
+	ctx, span := q.tracer.StartSpan(ctx)
+	defer span.End()
+
+	logger := q.logger.Clone()
+
+	if recipeID == "" {
+		return nil, ErrInvalidIDProvided
+	}
+	logger = logger.WithValue(keys.RecipeIDKey, recipeID)
+	tracing.AttachRecipeIDToSpan(span, recipeID)
+
+	args := []interface{}{
+		recipeID,
+		recipeID,
+	}
+
+	rows, err := q.performReadQuery(ctx, q.db, "recipe step products", getRecipeStepProductsForRecipeQuery, args)
+	if err != nil {
+		return nil, observability.PrepareError(err, logger, span, "executing recipe step products list retrieval query")
+	}
+
+	recipeStepProducts, _, _, err := q.scanRecipeStepProducts(ctx, rows, false)
+	if err != nil {
+		return nil, observability.PrepareError(err, logger, span, "scanning recipe step products")
+	}
+
+	return recipeStepProducts, nil
+}
+
 // GetRecipeStepProducts fetches a list of recipe step products from the database that meet a particular filter.
 func (q *SQLQuerier) GetRecipeStepProducts(ctx context.Context, recipeID, recipeStepID string, filter *types.QueryFilter) (x *types.RecipeStepProductList, err error) {
 	ctx, span := q.tracer.StartSpan(ctx)
@@ -232,9 +300,9 @@ func (q *SQLQuerier) GetRecipeStepProducts(ctx context.Context, recipeID, recipe
 		x.Page, x.Limit = filter.Page, filter.Limit
 	}
 
-	query, args := q.buildListQuery(ctx, "recipe_step_products", getRecipeStepProductsJoins, nil, nil, householdOwnershipColumn, recipeStepProductsTableColumns, "", false, filter)
+	query, args := q.buildListQuery(ctx, "recipe_step_products", getRecipeStepProductsJoins, nil, nil, householdOwnershipColumn, recipeStepProductsTableColumns, "", false, filter, true)
 
-	rows, err := q.performReadQuery(ctx, q.db, "recipeStepProducts", query, args)
+	rows, err := q.performReadQuery(ctx, q.db, "recipe step products", query, args)
 	if err != nil {
 		return nil, observability.PrepareError(err, logger, span, "executing recipe step products list retrieval query")
 	}
@@ -324,8 +392,6 @@ func (q *SQLQuerier) createRecipeStepProduct(ctx context.Context, db database.SQ
 
 	logger := q.logger.WithValue(keys.RecipeStepProductIDKey, input.ID)
 
-	logger.WithValue("input", input).Info("input arrived at createRecipeStepProduct")
-
 	args := []interface{}{
 		input.ID,
 		input.Name,
@@ -347,7 +413,6 @@ func (q *SQLQuerier) createRecipeStepProduct(ctx context.Context, db database.SQ
 	}
 
 	tracing.AttachRecipeStepProductIDToSpan(span, x.ID)
-	logger.Info("recipe step product created")
 
 	return x, nil
 }

--- a/internal/database/queriers/postgres/recipe_step_products_test.go
+++ b/internal/database/queriers/postgres/recipe_step_products_test.go
@@ -360,6 +360,34 @@ func TestQuerier_GetTotalRecipeStepProductCount(T *testing.T) {
 	})
 }
 
+func TestQuerier_getRecipeStepProductsForRecipe(T *testing.T) {
+	T.Parallel()
+
+	T.Run("standard", func(t *testing.T) {
+		t.Parallel()
+
+		exampleRecipeID := fakes.BuildFakeID()
+		exampleRecipeStepProductList := fakes.BuildFakeRecipeStepProductList()
+
+		ctx := context.Background()
+		c, db := buildTestClient(t)
+
+		args := []interface{}{
+			exampleRecipeID,
+			exampleRecipeID,
+		}
+		db.ExpectQuery(formatQueryForSQLMock(getRecipeStepProductsForRecipeQuery)).
+			WithArgs(interfaceToDriverValue(args)...).
+			WillReturnRows(buildMockRowsFromRecipeStepProducts(false, exampleRecipeStepProductList.FilteredCount, exampleRecipeStepProductList.RecipeStepProducts...))
+
+		actual, err := c.getRecipeStepProductsForRecipe(ctx, exampleRecipeID)
+		assert.NoError(t, err)
+		assert.Equal(t, exampleRecipeStepProductList.RecipeStepProducts, actual)
+
+		mock.AssertExpectationsForObjects(t, db)
+	})
+}
+
 func TestQuerier_GetRecipeStepProducts(T *testing.T) {
 	T.Parallel()
 
@@ -374,7 +402,7 @@ func TestQuerier_GetRecipeStepProducts(T *testing.T) {
 		ctx := context.Background()
 		c, db := buildTestClient(t)
 
-		query, args := c.buildListQuery(ctx, "recipe_step_products", getRecipeStepProductsJoins, nil, nil, householdOwnershipColumn, recipeStepProductsTableColumns, "", false, filter)
+		query, args := c.buildListQuery(ctx, "recipe_step_products", getRecipeStepProductsJoins, nil, nil, householdOwnershipColumn, recipeStepProductsTableColumns, "", false, filter, true)
 
 		db.ExpectQuery(formatQueryForSQLMock(query)).
 			WithArgs(interfaceToDriverValue(args)...).
@@ -428,7 +456,7 @@ func TestQuerier_GetRecipeStepProducts(T *testing.T) {
 		ctx := context.Background()
 		c, db := buildTestClient(t)
 
-		query, args := c.buildListQuery(ctx, "recipe_step_products", getRecipeStepProductsJoins, nil, nil, householdOwnershipColumn, recipeStepProductsTableColumns, "", false, filter)
+		query, args := c.buildListQuery(ctx, "recipe_step_products", getRecipeStepProductsJoins, nil, nil, householdOwnershipColumn, recipeStepProductsTableColumns, "", false, filter, true)
 
 		db.ExpectQuery(formatQueryForSQLMock(query)).
 			WithArgs(interfaceToDriverValue(args)...).
@@ -451,7 +479,7 @@ func TestQuerier_GetRecipeStepProducts(T *testing.T) {
 		ctx := context.Background()
 		c, db := buildTestClient(t)
 
-		query, args := c.buildListQuery(ctx, "recipe_step_products", getRecipeStepProductsJoins, nil, nil, householdOwnershipColumn, recipeStepProductsTableColumns, "", false, filter)
+		query, args := c.buildListQuery(ctx, "recipe_step_products", getRecipeStepProductsJoins, nil, nil, householdOwnershipColumn, recipeStepProductsTableColumns, "", false, filter, true)
 
 		db.ExpectQuery(formatQueryForSQLMock(query)).
 			WithArgs(interfaceToDriverValue(args)...).
@@ -474,7 +502,7 @@ func TestQuerier_GetRecipeStepProducts(T *testing.T) {
 		ctx := context.Background()
 		c, db := buildTestClient(t)
 
-		query, args := c.buildListQuery(ctx, "recipe_step_products", getRecipeStepProductsJoins, nil, nil, householdOwnershipColumn, recipeStepProductsTableColumns, "", false, filter)
+		query, args := c.buildListQuery(ctx, "recipe_step_products", getRecipeStepProductsJoins, nil, nil, householdOwnershipColumn, recipeStepProductsTableColumns, "", false, filter, true)
 
 		db.ExpectQuery(formatQueryForSQLMock(query)).
 			WithArgs(interfaceToDriverValue(args)...).

--- a/internal/database/queriers/postgres/recipe_steps.go
+++ b/internal/database/queriers/postgres/recipe_steps.go
@@ -262,7 +262,7 @@ func (q *SQLQuerier) GetRecipeSteps(ctx context.Context, recipeID string, filter
 		x.Page, x.Limit = filter.Page, filter.Limit
 	}
 
-	query, args := q.buildListQuery(ctx, "recipe_steps", getRecipeStepsJoins, []string{"valid_preparations.id"}, nil, householdOwnershipColumn, recipeStepsTableColumns, "", false, filter)
+	query, args := q.buildListQuery(ctx, "recipe_steps", getRecipeStepsJoins, []string{"valid_preparations.id"}, nil, householdOwnershipColumn, recipeStepsTableColumns, "", false, filter, true)
 
 	rows, err := q.performReadQuery(ctx, q.db, "recipeSteps", query, args)
 	if err != nil {
@@ -354,8 +354,6 @@ func (q *SQLQuerier) createRecipeStep(ctx context.Context, db database.SQLQueryE
 
 	logger := q.logger.WithValue(keys.RecipeStepIDKey, input.ID)
 
-	logger.WithValue("input", input).Info("input arrived at createRecipeStep")
-
 	args := []interface{}{
 		input.ID,
 		input.Index,
@@ -408,7 +406,6 @@ func (q *SQLQuerier) createRecipeStep(ctx context.Context, db database.SQLQueryE
 	}
 
 	tracing.AttachRecipeStepIDToSpan(span, x.ID)
-	logger.Info("recipe step created")
 
 	return x, nil
 }

--- a/internal/database/queriers/postgres/recipe_steps_test.go
+++ b/internal/database/queriers/postgres/recipe_steps_test.go
@@ -41,7 +41,6 @@ func buildMockRowsFromRecipeSteps(includeCounts bool, filteredCount uint64, reci
 			x.MaxEstimatedTimeInSeconds,
 			x.TemperatureInCelsius,
 			x.Notes,
-			x.Yields,
 			x.Optional,
 			x.CreatedOn,
 			x.LastUpdatedOn,
@@ -211,6 +210,7 @@ func TestQuerier_GetRecipeStep(T *testing.T) {
 		exampleRecipeID := fakes.BuildFakeID()
 		exampleRecipeStep := fakes.BuildFakeRecipeStep()
 		exampleRecipeStep.Ingredients = nil
+		exampleRecipeStep.Products = nil
 
 		ctx := context.Background()
 		c, db := buildTestClient(t)
@@ -338,6 +338,7 @@ func TestQuerier_GetRecipeSteps(T *testing.T) {
 
 		for i := range exampleRecipeStepList.RecipeSteps {
 			exampleRecipeStepList.RecipeSteps[i].Ingredients = nil
+			exampleRecipeStepList.RecipeSteps[i].Products = nil
 		}
 
 		ctx := context.Background()
@@ -379,6 +380,7 @@ func TestQuerier_GetRecipeSteps(T *testing.T) {
 		exampleRecipeStepList.Limit = 0
 		for i := range exampleRecipeStepList.RecipeSteps {
 			exampleRecipeStepList.RecipeSteps[i].Ingredients = nil
+			exampleRecipeStepList.RecipeSteps[i].Products = nil
 		}
 
 		ctx := context.Background()
@@ -455,6 +457,7 @@ func TestQuerier_GetRecipeStepsWithIDs(T *testing.T) {
 		for i, x := range exampleRecipeStepList.RecipeSteps {
 			exampleIDs = append(exampleIDs, x.ID)
 			exampleRecipeStepList.RecipeSteps[i].Ingredients = nil
+			exampleRecipeStepList.RecipeSteps[i].Products = nil
 		}
 
 		ctx := context.Background()
@@ -565,6 +568,7 @@ func TestQuerier_CreateRecipeStep(T *testing.T) {
 		exampleRecipeStep := fakes.BuildFakeRecipeStep()
 		exampleRecipeStep.ID = "1"
 		exampleRecipeStep.Ingredients = nil
+		exampleRecipeStep.Products = nil
 		exampleRecipeStep.Preparation = types.ValidPreparation{}
 		exampleInput := fakes.BuildFakeRecipeStepDatabaseCreationInputFromRecipeStep(exampleRecipeStep)
 
@@ -580,7 +584,6 @@ func TestQuerier_CreateRecipeStep(T *testing.T) {
 			exampleInput.MaxEstimatedTimeInSeconds,
 			exampleInput.TemperatureInCelsius,
 			exampleInput.Notes,
-			exampleInput.Yields,
 			exampleInput.Optional,
 			exampleInput.BelongsToRecipe,
 		}
@@ -630,7 +633,6 @@ func TestQuerier_CreateRecipeStep(T *testing.T) {
 			exampleInput.MaxEstimatedTimeInSeconds,
 			exampleInput.TemperatureInCelsius,
 			exampleInput.Notes,
-			exampleInput.Yields,
 			exampleInput.Optional,
 			exampleInput.BelongsToRecipe,
 		}
@@ -666,6 +668,7 @@ func TestSQLQuerier_createRecipeStep(T *testing.T) {
 			exampleRecipeStep.Ingredients[i].ID = "3"
 			exampleRecipeStep.Ingredients[i].BelongsToRecipeStep = "2"
 			exampleRecipeStep.Ingredients[i].Ingredient = types.ValidIngredient{}
+			exampleRecipeStep.Products = nil
 		}
 
 		exampleInput := fakes.BuildFakeRecipeStepDatabaseCreationInputFromRecipeStep(exampleRecipeStep)
@@ -682,7 +685,6 @@ func TestSQLQuerier_createRecipeStep(T *testing.T) {
 			exampleInput.MaxEstimatedTimeInSeconds,
 			exampleInput.TemperatureInCelsius,
 			exampleInput.Notes,
-			exampleInput.Yields,
 			exampleInput.Optional,
 			exampleInput.BelongsToRecipe,
 		}
@@ -746,7 +748,6 @@ func TestSQLQuerier_createRecipeStep(T *testing.T) {
 			exampleInput.MaxEstimatedTimeInSeconds,
 			exampleInput.TemperatureInCelsius,
 			exampleInput.Notes,
-			exampleInput.Yields,
 			exampleInput.Optional,
 			exampleInput.BelongsToRecipe,
 		}
@@ -801,7 +802,6 @@ func TestQuerier_UpdateRecipeStep(T *testing.T) {
 			exampleRecipeStep.MaxEstimatedTimeInSeconds,
 			exampleRecipeStep.TemperatureInCelsius,
 			exampleRecipeStep.Notes,
-			exampleRecipeStep.Yields,
 			exampleRecipeStep.Optional,
 			exampleRecipeStep.BelongsToRecipe,
 			exampleRecipeStep.ID,
@@ -841,7 +841,6 @@ func TestQuerier_UpdateRecipeStep(T *testing.T) {
 			exampleRecipeStep.MaxEstimatedTimeInSeconds,
 			exampleRecipeStep.TemperatureInCelsius,
 			exampleRecipeStep.Notes,
-			exampleRecipeStep.Yields,
 			exampleRecipeStep.Optional,
 			exampleRecipeStep.BelongsToRecipe,
 			exampleRecipeStep.ID,

--- a/internal/database/queriers/postgres/recipe_steps_test.go
+++ b/internal/database/queriers/postgres/recipe_steps_test.go
@@ -344,7 +344,7 @@ func TestQuerier_GetRecipeSteps(T *testing.T) {
 		ctx := context.Background()
 		c, db := buildTestClient(t)
 
-		query, args := c.buildListQuery(ctx, "recipe_steps", getRecipeStepsJoins, []string{"valid_preparations.id"}, nil, householdOwnershipColumn, recipeStepsTableColumns, "", false, filter)
+		query, args := c.buildListQuery(ctx, "recipe_steps", getRecipeStepsJoins, []string{"valid_preparations.id"}, nil, householdOwnershipColumn, recipeStepsTableColumns, "", false, filter, true)
 
 		db.ExpectQuery(formatQueryForSQLMock(query)).
 			WithArgs(interfaceToDriverValue(args)...).
@@ -386,7 +386,7 @@ func TestQuerier_GetRecipeSteps(T *testing.T) {
 		ctx := context.Background()
 		c, db := buildTestClient(t)
 
-		query, args := c.buildListQuery(ctx, "recipe_steps", getRecipeStepsJoins, []string{"valid_preparations.id"}, nil, householdOwnershipColumn, recipeStepsTableColumns, "", false, filter)
+		query, args := c.buildListQuery(ctx, "recipe_steps", getRecipeStepsJoins, []string{"valid_preparations.id"}, nil, householdOwnershipColumn, recipeStepsTableColumns, "", false, filter, true)
 
 		db.ExpectQuery(formatQueryForSQLMock(query)).
 			WithArgs(interfaceToDriverValue(args)...).
@@ -408,7 +408,7 @@ func TestQuerier_GetRecipeSteps(T *testing.T) {
 		ctx := context.Background()
 		c, db := buildTestClient(t)
 
-		query, args := c.buildListQuery(ctx, "recipe_steps", getRecipeStepsJoins, []string{"valid_preparations.id"}, nil, householdOwnershipColumn, recipeStepsTableColumns, "", false, filter)
+		query, args := c.buildListQuery(ctx, "recipe_steps", getRecipeStepsJoins, []string{"valid_preparations.id"}, nil, householdOwnershipColumn, recipeStepsTableColumns, "", false, filter, true)
 
 		db.ExpectQuery(formatQueryForSQLMock(query)).
 			WithArgs(interfaceToDriverValue(args)...).
@@ -430,7 +430,7 @@ func TestQuerier_GetRecipeSteps(T *testing.T) {
 		ctx := context.Background()
 		c, db := buildTestClient(t)
 
-		query, args := c.buildListQuery(ctx, "recipe_steps", getRecipeStepsJoins, []string{"valid_preparations.id"}, nil, householdOwnershipColumn, recipeStepsTableColumns, "", false, filter)
+		query, args := c.buildListQuery(ctx, "recipe_steps", getRecipeStepsJoins, []string{"valid_preparations.id"}, nil, householdOwnershipColumn, recipeStepsTableColumns, "", false, filter, true)
 
 		db.ExpectQuery(formatQueryForSQLMock(query)).
 			WithArgs(interfaceToDriverValue(args)...).

--- a/internal/database/queriers/postgres/recipes.go
+++ b/internal/database/queriers/postgres/recipes.go
@@ -96,7 +96,6 @@ func (q *SQLQuerier) scanCompleteRecipeRow(ctx context.Context, scan database.Sc
 		&recipeStep.MaxEstimatedTimeInSeconds,
 		&recipeStep.TemperatureInCelsius,
 		&recipeStep.Notes,
-		&recipeStep.Yields,
 		&recipeStep.Optional,
 		&recipeStep.CreatedOn,
 		&recipeStep.LastUpdatedOn,
@@ -263,7 +262,6 @@ var completeRecipeColumns = []string{
 	"recipe_steps.max_estimated_time_in_seconds",
 	"recipe_steps.temperature_in_celsius",
 	"recipe_steps.notes",
-	"recipe_steps.yields",
 	"recipe_steps.optional",
 	"recipe_steps.created_on",
 	"recipe_steps.last_updated_on",
@@ -328,7 +326,6 @@ const getCompleteRecipeByIDQuery = `SELECT
 	recipe_steps.max_estimated_time_in_seconds,
 	recipe_steps.temperature_in_celsius,
 	recipe_steps.notes,
-	recipe_steps.yields,
 	recipe_steps.optional,
 	recipe_steps.created_on,
 	recipe_steps.last_updated_on,
@@ -429,7 +426,6 @@ const getCompleteRecipeByIDAndAuthorIDQuery = `SELECT
 	recipe_steps.max_estimated_time_in_seconds,
 	recipe_steps.temperature_in_celsius,
 	recipe_steps.notes,
-	recipe_steps.yields,
 	recipe_steps.optional,
 	recipe_steps.created_on,
 	recipe_steps.last_updated_on,
@@ -664,6 +660,8 @@ func (q *SQLQuerier) CreateRecipe(ctx context.Context, input *types.RecipeDataba
 	}
 
 	logger := q.logger.WithValue(keys.RecipeIDKey, input.ID)
+
+	logger.WithValue("input", input).Info("input arrived at CreateRecipe")
 
 	tx, err := q.db.BeginTx(ctx, nil)
 	if err != nil {

--- a/internal/database/queriers/postgres/recipes_test.go
+++ b/internal/database/queriers/postgres/recipes_test.go
@@ -80,7 +80,6 @@ func buildMockFullRowsFromRecipe(recipe *types.Recipe) *sqlmock.Rows {
 				&step.MaxEstimatedTimeInSeconds,
 				&step.TemperatureInCelsius,
 				&step.Notes,
-				&step.Yields,
 				&step.Optional,
 				&step.CreatedOn,
 				&step.LastUpdatedOn,
@@ -133,7 +132,6 @@ func buildInvalidMockFullRowsFromRecipe(recipe *types.Recipe) *sqlmock.Rows {
 	for _, step := range recipe.Steps {
 		for range step.Ingredients {
 			exampleRows.AddRow(
-				driver.Value(nil),
 				driver.Value(nil),
 				driver.Value(nil),
 				driver.Value(nil),
@@ -342,6 +340,9 @@ func TestQuerier_GetRecipe(T *testing.T) {
 
 				exampleRecipe.Steps[i].Ingredients = append(step.Ingredients, ingredient)
 			}
+
+			// TODO: remove me
+			exampleRecipe.Steps[i].Products = nil
 		}
 
 		ctx := context.Background()
@@ -414,6 +415,9 @@ func TestQuerier_GetRecipe(T *testing.T) {
 				fakes.BuildFakeRecipeStepIngredient(),
 				fakes.BuildFakeRecipeStepIngredient(),
 			}
+
+			// TODO: remove me
+			step.Products = nil
 		}
 
 		ctx := context.Background()
@@ -497,6 +501,9 @@ func TestQuerier_GetRecipeByUser(T *testing.T) {
 
 				exampleRecipe.Steps[i].Ingredients = append(step.Ingredients, ingredient)
 			}
+
+			// TODO: remove me
+			exampleRecipe.Steps[i].Products = nil
 		}
 
 		ctx := context.Background()
@@ -986,6 +993,9 @@ func TestQuerier_CreateRecipe(T *testing.T) {
 				exampleRecipe.Steps[i].Ingredients[j].BelongsToRecipeStep = "2"
 				exampleRecipe.Steps[i].Ingredients[j].Ingredient = types.ValidIngredient{}
 			}
+
+			// TODO: remove me
+			step.Products = nil
 		}
 
 		exampleInput := fakes.BuildFakeRecipeDatabaseCreationInputFromRecipe(exampleRecipe)
@@ -1018,7 +1028,6 @@ func TestQuerier_CreateRecipe(T *testing.T) {
 				step.MaxEstimatedTimeInSeconds,
 				step.TemperatureInCelsius,
 				step.Notes,
-				step.Yields,
 				step.Optional,
 				step.BelongsToRecipe,
 			}
@@ -1197,7 +1206,6 @@ func TestQuerier_CreateRecipe(T *testing.T) {
 			exampleInput.Steps[0].MaxEstimatedTimeInSeconds,
 			exampleInput.Steps[0].TemperatureInCelsius,
 			exampleInput.Steps[0].Notes,
-			exampleInput.Steps[0].Yields,
 			exampleInput.Steps[0].Optional,
 			exampleInput.Steps[0].BelongsToRecipe,
 		}

--- a/internal/database/queriers/postgres/recipes_test.go
+++ b/internal/database/queriers/postgres/recipes_test.go
@@ -51,139 +51,84 @@ func buildMockRowsFromRecipes(includeCounts bool, filteredCount uint64, recipes 
 	return exampleRows
 }
 
+// fullRecipesColumns are the columns for the recipes table.
+var fullRecipesColumns = []string{
+	"recipes.id",
+	"recipes.name",
+	"recipes.source",
+	"recipes.description",
+	"recipes.inspired_by_recipe_id",
+	"recipes.created_on",
+	"recipes.last_updated_on",
+	"recipes.archived_on",
+	"recipes.created_by_user",
+	"recipe_steps.id",
+	"recipe_steps.index",
+	"valid_preparations.id",
+	"valid_preparations.name",
+	"valid_preparations.description",
+	"valid_preparations.icon_path",
+	"valid_preparations.created_on",
+	"valid_preparations.last_updated_on",
+	"valid_preparations.archived_on",
+	"recipe_steps.prerequisite_step",
+	"recipe_steps.min_estimated_time_in_seconds",
+	"recipe_steps.max_estimated_time_in_seconds",
+	"recipe_steps.temperature_in_celsius",
+	"recipe_steps.notes",
+	"recipe_steps.optional",
+	"recipe_steps.created_on",
+	"recipe_steps.last_updated_on",
+	"recipe_steps.archived_on",
+	"recipe_steps.belongs_to_recipe",
+}
+
 func buildMockFullRowsFromRecipe(recipe *types.Recipe) *sqlmock.Rows {
-	exampleRows := sqlmock.NewRows(completeRecipeColumns)
+	exampleRows := sqlmock.NewRows(fullRecipesColumns)
 
 	for _, step := range recipe.Steps {
-		for _, ingredient := range step.Ingredients {
-			exampleRows.AddRow(
-				&recipe.ID,
-				&recipe.Name,
-				&recipe.Source,
-				&recipe.Description,
-				&recipe.InspiredByRecipeID,
-				&recipe.CreatedOn,
-				&recipe.LastUpdatedOn,
-				&recipe.ArchivedOn,
-				&recipe.CreatedByUser,
-				&step.ID,
-				&step.Index,
-				&step.Preparation.ID,
-				&step.Preparation.Name,
-				&step.Preparation.Description,
-				&step.Preparation.IconPath,
-				&step.Preparation.CreatedOn,
-				&step.Preparation.LastUpdatedOn,
-				&step.Preparation.ArchivedOn,
-				&step.PrerequisiteStep,
-				&step.MinEstimatedTimeInSeconds,
-				&step.MaxEstimatedTimeInSeconds,
-				&step.TemperatureInCelsius,
-				&step.Notes,
-				&step.Optional,
-				&step.CreatedOn,
-				&step.LastUpdatedOn,
-				&step.ArchivedOn,
-				&step.BelongsToRecipe,
-				&ingredient.ID,
-				&ingredient.Ingredient.ID,
-				&ingredient.Ingredient.Name,
-				&ingredient.Ingredient.Variant,
-				&ingredient.Ingredient.Description,
-				&ingredient.Ingredient.Warning,
-				&ingredient.Ingredient.ContainsEgg,
-				&ingredient.Ingredient.ContainsDairy,
-				&ingredient.Ingredient.ContainsPeanut,
-				&ingredient.Ingredient.ContainsTreeNut,
-				&ingredient.Ingredient.ContainsSoy,
-				&ingredient.Ingredient.ContainsWheat,
-				&ingredient.Ingredient.ContainsShellfish,
-				&ingredient.Ingredient.ContainsSesame,
-				&ingredient.Ingredient.ContainsFish,
-				&ingredient.Ingredient.ContainsGluten,
-				&ingredient.Ingredient.AnimalFlesh,
-				&ingredient.Ingredient.AnimalDerived,
-				&ingredient.Ingredient.Volumetric,
-				&ingredient.Ingredient.IconPath,
-				&ingredient.Ingredient.CreatedOn,
-				&ingredient.Ingredient.LastUpdatedOn,
-				&ingredient.Ingredient.ArchivedOn,
-				&ingredient.IngredientID,
-				&ingredient.QuantityType,
-				&ingredient.QuantityValue,
-				&ingredient.QuantityNotes,
-				&ingredient.ProductOfRecipeStep,
-				&ingredient.IngredientNotes,
-				&ingredient.CreatedOn,
-				&ingredient.LastUpdatedOn,
-				&ingredient.ArchivedOn,
-				&ingredient.BelongsToRecipeStep,
-			)
-		}
+		exampleRows.AddRow(
+			&recipe.ID,
+			&recipe.Name,
+			&recipe.Source,
+			&recipe.Description,
+			&recipe.InspiredByRecipeID,
+			&recipe.CreatedOn,
+			&recipe.LastUpdatedOn,
+			&recipe.ArchivedOn,
+			&recipe.CreatedByUser,
+			&step.ID,
+			&step.Index,
+			&step.Preparation.ID,
+			&step.Preparation.Name,
+			&step.Preparation.Description,
+			&step.Preparation.IconPath,
+			&step.Preparation.CreatedOn,
+			&step.Preparation.LastUpdatedOn,
+			&step.Preparation.ArchivedOn,
+			&step.PrerequisiteStep,
+			&step.MinEstimatedTimeInSeconds,
+			&step.MaxEstimatedTimeInSeconds,
+			&step.TemperatureInCelsius,
+			&step.Notes,
+			&step.Optional,
+			&step.CreatedOn,
+			&step.LastUpdatedOn,
+			&step.ArchivedOn,
+			&step.BelongsToRecipe,
+		)
 	}
 
 	return exampleRows
 }
 
 func buildInvalidMockFullRowsFromRecipe(recipe *types.Recipe) *sqlmock.Rows {
-	columns := completeRecipeColumns
+	columns := recipesTableColumns
 	exampleRows := sqlmock.NewRows(columns)
 
 	for _, step := range recipe.Steps {
 		for range step.Ingredients {
 			exampleRows.AddRow(
-				driver.Value(nil),
-				driver.Value(nil),
-				driver.Value(nil),
-				driver.Value(nil),
-				driver.Value(nil),
-				driver.Value(nil),
-				driver.Value(nil),
-				driver.Value(nil),
-				driver.Value(nil),
-				driver.Value(nil),
-				driver.Value(nil),
-				driver.Value(nil),
-				driver.Value(nil),
-				driver.Value(nil),
-				driver.Value(nil),
-				driver.Value(nil),
-				driver.Value(nil),
-				driver.Value(nil),
-				driver.Value(nil),
-				driver.Value(nil),
-				driver.Value(nil),
-				driver.Value(nil),
-				driver.Value(nil),
-				driver.Value(nil),
-				driver.Value(nil),
-				driver.Value(nil),
-				driver.Value(nil),
-				driver.Value(nil),
-				driver.Value(nil),
-				driver.Value(nil),
-				driver.Value(nil),
-				driver.Value(nil),
-				driver.Value(nil),
-				driver.Value(nil),
-				driver.Value(nil),
-				driver.Value(nil),
-				driver.Value(nil),
-				driver.Value(nil),
-				driver.Value(nil),
-				driver.Value(nil),
-				driver.Value(nil),
-				driver.Value(nil),
-				driver.Value(nil),
-				driver.Value(nil),
-				driver.Value(nil),
-				driver.Value(nil),
-				driver.Value(nil),
-				driver.Value(nil),
-				driver.Value(nil),
-				driver.Value(nil),
-				driver.Value(nil),
-				driver.Value(nil),
 				driver.Value(nil),
 				driver.Value(nil),
 				driver.Value(nil),
@@ -332,17 +277,11 @@ func TestQuerier_GetRecipe(T *testing.T) {
 			fakes.BuildFakeRecipeStep(),
 		}
 
-		for i, step := range exampleRecipe.Steps {
-			exampleRecipe.Steps[i].Ingredients = []*types.RecipeStepIngredient{}
-			for j := 0; j < 3; j++ {
-				ingredient := fakes.BuildFakeRecipeStepIngredient()
-				ingredient.IngredientID = nil
-
-				exampleRecipe.Steps[i].Ingredients = append(step.Ingredients, ingredient)
-			}
-
-			// TODO: remove me
-			exampleRecipe.Steps[i].Products = nil
+		allIngredients := []*types.RecipeStepIngredient{}
+		allProducts := []*types.RecipeStepProduct{}
+		for _, step := range exampleRecipe.Steps {
+			allIngredients = append(allIngredients, step.Ingredients...)
+			allProducts = append(allProducts, step.Products...)
 		}
 
 		ctx := context.Background()
@@ -353,9 +292,22 @@ func TestQuerier_GetRecipe(T *testing.T) {
 			exampleRecipe.ID,
 		}
 
-		db.ExpectQuery(formatQueryForSQLMock(getCompleteRecipeByIDQuery)).
+		db.ExpectQuery(formatQueryForSQLMock(getRecipeByIDQuery)).
 			WithArgs(interfaceToDriverValue(args)...).
 			WillReturnRows(buildMockFullRowsFromRecipe(exampleRecipe))
+
+		query, args := c.buildListQuery(ctx, "recipe_step_ingredients", getRecipeStepIngredientsJoins, []string{"recipe_step_ingredients.id", "valid_ingredients.id"}, nil, householdOwnershipColumn, recipeStepIngredientsTableColumns, "", false, nil, false)
+		db.ExpectQuery(formatQueryForSQLMock(query)).
+			WithArgs(interfaceToDriverValue(args)...).
+			WillReturnRows(buildMockRowsFromRecipeStepIngredients(false, 0, allIngredients...))
+
+		productsArgs := []interface{}{
+			exampleRecipe.ID,
+			exampleRecipe.ID,
+		}
+		db.ExpectQuery(formatQueryForSQLMock(getRecipeStepProductsForRecipeQuery)).
+			WithArgs(interfaceToDriverValue(productsArgs)...).
+			WillReturnRows(buildMockRowsFromRecipeStepProducts(false, 0, allProducts...))
 
 		actual, err := c.GetRecipe(ctx, exampleRecipe.ID)
 		assert.NoError(t, err)
@@ -387,7 +339,7 @@ func TestQuerier_GetRecipe(T *testing.T) {
 			exampleRecipe.ID,
 		}
 
-		db.ExpectQuery(formatQueryForSQLMock(getCompleteRecipeByIDQuery)).
+		db.ExpectQuery(formatQueryForSQLMock(getRecipeByIDQuery)).
 			WithArgs(interfaceToDriverValue(args)...).
 			WillReturnError(errors.New("blah"))
 
@@ -409,17 +361,6 @@ func TestQuerier_GetRecipe(T *testing.T) {
 			fakes.BuildFakeRecipeStep(),
 		}
 
-		for _, step := range exampleRecipe.Steps {
-			step.Ingredients = []*types.RecipeStepIngredient{
-				fakes.BuildFakeRecipeStepIngredient(),
-				fakes.BuildFakeRecipeStepIngredient(),
-				fakes.BuildFakeRecipeStepIngredient(),
-			}
-
-			// TODO: remove me
-			step.Products = nil
-		}
-
 		ctx := context.Background()
 		c, db := buildTestClient(t)
 
@@ -428,7 +369,7 @@ func TestQuerier_GetRecipe(T *testing.T) {
 			exampleRecipe.ID,
 		}
 
-		db.ExpectQuery(formatQueryForSQLMock(getCompleteRecipeByIDQuery)).
+		db.ExpectQuery(formatQueryForSQLMock(getRecipeByIDQuery)).
 			WithArgs(interfaceToDriverValue(args)...).
 			WillReturnRows(buildInvalidMockFullRowsFromRecipe(exampleRecipe))
 
@@ -466,9 +407,9 @@ func TestQuerier_GetRecipe(T *testing.T) {
 			exampleRecipe.ID,
 		}
 
-		db.ExpectQuery(formatQueryForSQLMock(getCompleteRecipeByIDQuery)).
+		db.ExpectQuery(formatQueryForSQLMock(getRecipeByIDQuery)).
 			WithArgs(interfaceToDriverValue(args)...).
-			WillReturnRows(sqlmock.NewRows([]string{"things"}))
+			WillReturnError(sql.ErrNoRows)
 
 		actual, err := c.GetRecipe(ctx, exampleRecipe.ID)
 		assert.Error(t, err)
@@ -493,17 +434,11 @@ func TestQuerier_GetRecipeByUser(T *testing.T) {
 			fakes.BuildFakeRecipeStep(),
 		}
 
-		for i, step := range exampleRecipe.Steps {
-			exampleRecipe.Steps[i].Ingredients = []*types.RecipeStepIngredient{}
-			for j := 0; j < 3; j++ {
-				ingredient := fakes.BuildFakeRecipeStepIngredient()
-				ingredient.IngredientID = nil
-
-				exampleRecipe.Steps[i].Ingredients = append(step.Ingredients, ingredient)
-			}
-
-			// TODO: remove me
-			exampleRecipe.Steps[i].Products = nil
+		allIngredients := []*types.RecipeStepIngredient{}
+		allProducts := []*types.RecipeStepProduct{}
+		for _, step := range exampleRecipe.Steps {
+			allIngredients = append(allIngredients, step.Ingredients...)
+			allProducts = append(allProducts, step.Products...)
 		}
 
 		ctx := context.Background()
@@ -515,9 +450,22 @@ func TestQuerier_GetRecipeByUser(T *testing.T) {
 			exampleRecipe.CreatedByUser,
 		}
 
-		db.ExpectQuery(formatQueryForSQLMock(getCompleteRecipeByIDAndAuthorIDQuery)).
+		db.ExpectQuery(formatQueryForSQLMock(getRecipeByIDAndAuthorIDQuery)).
 			WithArgs(interfaceToDriverValue(args)...).
 			WillReturnRows(buildMockFullRowsFromRecipe(exampleRecipe))
+
+		query, args := c.buildListQuery(ctx, "recipe_step_ingredients", getRecipeStepIngredientsJoins, []string{"recipe_step_ingredients.id", "valid_ingredients.id"}, nil, householdOwnershipColumn, recipeStepIngredientsTableColumns, "", false, nil, false)
+		db.ExpectQuery(formatQueryForSQLMock(query)).
+			WithArgs(interfaceToDriverValue(args)...).
+			WillReturnRows(buildMockRowsFromRecipeStepIngredients(false, 0, allIngredients...))
+
+		productsArgs := []interface{}{
+			exampleRecipe.ID,
+			exampleRecipe.ID,
+		}
+		db.ExpectQuery(formatQueryForSQLMock(getRecipeStepProductsForRecipeQuery)).
+			WithArgs(interfaceToDriverValue(productsArgs)...).
+			WillReturnRows(buildMockRowsFromRecipeStepProducts(false, 0, allProducts...))
 
 		actual, err := c.GetRecipeByIDAndUser(ctx, exampleRecipe.ID, exampleRecipe.CreatedByUser)
 		assert.NoError(t, err)
@@ -563,7 +511,7 @@ func TestQuerier_GetRecipeByUser(T *testing.T) {
 			exampleRecipe.CreatedByUser,
 		}
 
-		db.ExpectQuery(formatQueryForSQLMock(getCompleteRecipeByIDAndAuthorIDQuery)).
+		db.ExpectQuery(formatQueryForSQLMock(getRecipeByIDAndAuthorIDQuery)).
 			WithArgs(interfaceToDriverValue(args)...).
 			WillReturnError(errors.New("blah"))
 
@@ -602,7 +550,7 @@ func TestQuerier_GetRecipeByUser(T *testing.T) {
 			exampleRecipe.CreatedByUser,
 		}
 
-		db.ExpectQuery(formatQueryForSQLMock(getCompleteRecipeByIDAndAuthorIDQuery)).
+		db.ExpectQuery(formatQueryForSQLMock(getRecipeByIDAndAuthorIDQuery)).
 			WithArgs(interfaceToDriverValue(args)...).
 			WillReturnRows(buildInvalidMockFullRowsFromRecipe(exampleRecipe))
 
@@ -641,9 +589,9 @@ func TestQuerier_GetRecipeByUser(T *testing.T) {
 			exampleRecipe.CreatedByUser,
 		}
 
-		db.ExpectQuery(formatQueryForSQLMock(getCompleteRecipeByIDAndAuthorIDQuery)).
+		db.ExpectQuery(formatQueryForSQLMock(getRecipeByIDAndAuthorIDQuery)).
 			WithArgs(interfaceToDriverValue(args)...).
-			WillReturnRows(sqlmock.NewRows([]string{"things"}))
+			WillReturnError(sql.ErrNoRows)
 
 		actual, err := c.GetRecipeByIDAndUser(ctx, exampleRecipe.ID, exampleRecipe.CreatedByUser)
 		assert.Error(t, err)
@@ -710,7 +658,7 @@ func TestQuerier_GetRecipes(T *testing.T) {
 		ctx := context.Background()
 		c, db := buildTestClient(t)
 
-		query, args := c.buildListQuery(ctx, "recipes", nil, nil, nil, householdOwnershipColumn, recipesTableColumns, "", false, filter)
+		query, args := c.buildListQuery(ctx, "recipes", nil, nil, nil, householdOwnershipColumn, recipesTableColumns, "", false, filter, true)
 
 		db.ExpectQuery(formatQueryForSQLMock(query)).
 			WithArgs(interfaceToDriverValue(args)...).
@@ -737,7 +685,7 @@ func TestQuerier_GetRecipes(T *testing.T) {
 		ctx := context.Background()
 		c, db := buildTestClient(t)
 
-		query, args := c.buildListQuery(ctx, "recipes", nil, nil, nil, householdOwnershipColumn, recipesTableColumns, "", false, filter)
+		query, args := c.buildListQuery(ctx, "recipes", nil, nil, nil, householdOwnershipColumn, recipesTableColumns, "", false, filter, true)
 
 		db.ExpectQuery(formatQueryForSQLMock(query)).
 			WithArgs(interfaceToDriverValue(args)...).
@@ -758,7 +706,7 @@ func TestQuerier_GetRecipes(T *testing.T) {
 		ctx := context.Background()
 		c, db := buildTestClient(t)
 
-		query, args := c.buildListQuery(ctx, "recipes", nil, nil, nil, householdOwnershipColumn, recipesTableColumns, "", false, filter)
+		query, args := c.buildListQuery(ctx, "recipes", nil, nil, nil, householdOwnershipColumn, recipesTableColumns, "", false, filter, true)
 
 		db.ExpectQuery(formatQueryForSQLMock(query)).
 			WithArgs(interfaceToDriverValue(args)...).
@@ -779,7 +727,7 @@ func TestQuerier_GetRecipes(T *testing.T) {
 		ctx := context.Background()
 		c, db := buildTestClient(t)
 
-		query, args := c.buildListQuery(ctx, "recipes", nil, nil, nil, householdOwnershipColumn, recipesTableColumns, "", false, filter)
+		query, args := c.buildListQuery(ctx, "recipes", nil, nil, nil, householdOwnershipColumn, recipesTableColumns, "", false, filter, true)
 
 		db.ExpectQuery(formatQueryForSQLMock(query)).
 			WithArgs(interfaceToDriverValue(args)...).

--- a/internal/database/queriers/postgres/recipes_test.go
+++ b/internal/database/queriers/postgres/recipes_test.go
@@ -942,7 +942,6 @@ func TestQuerier_CreateRecipe(T *testing.T) {
 				exampleRecipe.Steps[i].Ingredients[j].Ingredient = types.ValidIngredient{}
 			}
 
-			// TODO: remove me
 			step.Products = nil
 		}
 

--- a/internal/database/queriers/postgres/users.go
+++ b/internal/database/queriers/postgres/users.go
@@ -441,7 +441,7 @@ func (q *SQLQuerier) GetUsers(ctx context.Context, filter *types.QueryFilter) (x
 		x.Page, x.Limit = filter.Page, filter.Limit
 	}
 
-	query, args := q.buildListQuery(ctx, "users", nil, nil, nil, "", usersTableColumns, "", false, filter)
+	query, args := q.buildListQuery(ctx, "users", nil, nil, nil, "", usersTableColumns, "", false, filter, true)
 
 	rows, err := q.performReadQuery(ctx, q.db, "users", query, args)
 	if err != nil {

--- a/internal/database/queriers/postgres/users_test.go
+++ b/internal/database/queriers/postgres/users_test.go
@@ -633,7 +633,7 @@ func TestQuerier_GetUsers(T *testing.T) {
 		ctx := context.Background()
 		c, db := buildTestClient(t)
 
-		query, args := c.buildListQuery(ctx, "users", nil, nil, nil, "", usersTableColumns, "", false, filter)
+		query, args := c.buildListQuery(ctx, "users", nil, nil, nil, "", usersTableColumns, "", false, filter, true)
 
 		db.ExpectQuery(formatQueryForSQLMock(query)).
 			WithArgs(interfaceToDriverValue(args)...).
@@ -656,7 +656,7 @@ func TestQuerier_GetUsers(T *testing.T) {
 		ctx := context.Background()
 		c, db := buildTestClient(t)
 
-		query, args := c.buildListQuery(ctx, "users", nil, nil, nil, "", usersTableColumns, "", false, filter)
+		query, args := c.buildListQuery(ctx, "users", nil, nil, nil, "", usersTableColumns, "", false, filter, true)
 
 		db.ExpectQuery(formatQueryForSQLMock(query)).
 			WithArgs(interfaceToDriverValue(args)...).
@@ -677,7 +677,7 @@ func TestQuerier_GetUsers(T *testing.T) {
 		ctx := context.Background()
 		c, db := buildTestClient(t)
 
-		query, args := c.buildListQuery(ctx, "users", nil, nil, nil, "", usersTableColumns, "", false, filter)
+		query, args := c.buildListQuery(ctx, "users", nil, nil, nil, "", usersTableColumns, "", false, filter, true)
 
 		db.ExpectQuery(formatQueryForSQLMock(query)).
 			WithArgs(interfaceToDriverValue(args)...).
@@ -698,7 +698,7 @@ func TestQuerier_GetUsers(T *testing.T) {
 		ctx := context.Background()
 		c, db := buildTestClient(t)
 
-		query, args := c.buildListQuery(ctx, "users", nil, nil, nil, "", usersTableColumns, "", false, filter)
+		query, args := c.buildListQuery(ctx, "users", nil, nil, nil, "", usersTableColumns, "", false, filter, true)
 
 		db.ExpectQuery(formatQueryForSQLMock(query)).
 			WithArgs(interfaceToDriverValue(args)...).

--- a/internal/database/queriers/postgres/valid_ingredient_preparations.go
+++ b/internal/database/queriers/postgres/valid_ingredient_preparations.go
@@ -179,7 +179,7 @@ func (q *SQLQuerier) GetValidIngredientPreparations(ctx context.Context, filter 
 		x.Page, x.Limit = filter.Page, filter.Limit
 	}
 
-	query, args := q.buildListQuery(ctx, "valid_ingredient_preparations", nil, nil, nil, householdOwnershipColumn, validIngredientPreparationsTableColumns, "", false, filter)
+	query, args := q.buildListQuery(ctx, "valid_ingredient_preparations", nil, nil, nil, householdOwnershipColumn, validIngredientPreparationsTableColumns, "", false, filter, true)
 
 	rows, err := q.performReadQuery(ctx, q.db, "validIngredientPreparations", query, args)
 	if err != nil {

--- a/internal/database/queriers/postgres/valid_ingredient_preparations_test.go
+++ b/internal/database/queriers/postgres/valid_ingredient_preparations_test.go
@@ -278,7 +278,7 @@ func TestQuerier_GetValidIngredientPreparations(T *testing.T) {
 		ctx := context.Background()
 		c, db := buildTestClient(t)
 
-		query, args := c.buildListQuery(ctx, "valid_ingredient_preparations", nil, nil, nil, householdOwnershipColumn, validIngredientPreparationsTableColumns, "", false, filter)
+		query, args := c.buildListQuery(ctx, "valid_ingredient_preparations", nil, nil, nil, householdOwnershipColumn, validIngredientPreparationsTableColumns, "", false, filter, true)
 
 		db.ExpectQuery(formatQueryForSQLMock(query)).
 			WithArgs(interfaceToDriverValue(args)...).
@@ -302,7 +302,7 @@ func TestQuerier_GetValidIngredientPreparations(T *testing.T) {
 		ctx := context.Background()
 		c, db := buildTestClient(t)
 
-		query, args := c.buildListQuery(ctx, "valid_ingredient_preparations", nil, nil, nil, householdOwnershipColumn, validIngredientPreparationsTableColumns, "", false, filter)
+		query, args := c.buildListQuery(ctx, "valid_ingredient_preparations", nil, nil, nil, householdOwnershipColumn, validIngredientPreparationsTableColumns, "", false, filter, true)
 
 		db.ExpectQuery(formatQueryForSQLMock(query)).
 			WithArgs(interfaceToDriverValue(args)...).
@@ -323,7 +323,7 @@ func TestQuerier_GetValidIngredientPreparations(T *testing.T) {
 		ctx := context.Background()
 		c, db := buildTestClient(t)
 
-		query, args := c.buildListQuery(ctx, "valid_ingredient_preparations", nil, nil, nil, householdOwnershipColumn, validIngredientPreparationsTableColumns, "", false, filter)
+		query, args := c.buildListQuery(ctx, "valid_ingredient_preparations", nil, nil, nil, householdOwnershipColumn, validIngredientPreparationsTableColumns, "", false, filter, true)
 
 		db.ExpectQuery(formatQueryForSQLMock(query)).
 			WithArgs(interfaceToDriverValue(args)...).
@@ -344,7 +344,7 @@ func TestQuerier_GetValidIngredientPreparations(T *testing.T) {
 		ctx := context.Background()
 		c, db := buildTestClient(t)
 
-		query, args := c.buildListQuery(ctx, "valid_ingredient_preparations", nil, nil, nil, householdOwnershipColumn, validIngredientPreparationsTableColumns, "", false, filter)
+		query, args := c.buildListQuery(ctx, "valid_ingredient_preparations", nil, nil, nil, householdOwnershipColumn, validIngredientPreparationsTableColumns, "", false, filter, true)
 
 		db.ExpectQuery(formatQueryForSQLMock(query)).
 			WithArgs(interfaceToDriverValue(args)...).

--- a/internal/database/queriers/postgres/valid_ingredients.go
+++ b/internal/database/queriers/postgres/valid_ingredients.go
@@ -241,7 +241,7 @@ func (q *SQLQuerier) GetValidIngredients(ctx context.Context, filter *types.Quer
 		x.Page, x.Limit = filter.Page, filter.Limit
 	}
 
-	query, args := q.buildListQuery(ctx, "valid_ingredients", nil, nil, nil, householdOwnershipColumn, validIngredientsTableColumns, "", false, filter)
+	query, args := q.buildListQuery(ctx, "valid_ingredients", nil, nil, nil, householdOwnershipColumn, validIngredientsTableColumns, "", false, filter, true)
 
 	rows, err := q.performReadQuery(ctx, q.db, "validIngredients", query, args)
 	if err != nil {

--- a/internal/database/queriers/postgres/valid_ingredients_test.go
+++ b/internal/database/queriers/postgres/valid_ingredients_test.go
@@ -375,7 +375,7 @@ func TestQuerier_GetValidIngredients(T *testing.T) {
 		ctx := context.Background()
 		c, db := buildTestClient(t)
 
-		query, args := c.buildListQuery(ctx, "valid_ingredients", nil, nil, nil, householdOwnershipColumn, validIngredientsTableColumns, "", false, filter)
+		query, args := c.buildListQuery(ctx, "valid_ingredients", nil, nil, nil, householdOwnershipColumn, validIngredientsTableColumns, "", false, filter, true)
 
 		db.ExpectQuery(formatQueryForSQLMock(query)).
 			WithArgs(interfaceToDriverValue(args)...).
@@ -399,7 +399,7 @@ func TestQuerier_GetValidIngredients(T *testing.T) {
 		ctx := context.Background()
 		c, db := buildTestClient(t)
 
-		query, args := c.buildListQuery(ctx, "valid_ingredients", nil, nil, nil, householdOwnershipColumn, validIngredientsTableColumns, "", false, filter)
+		query, args := c.buildListQuery(ctx, "valid_ingredients", nil, nil, nil, householdOwnershipColumn, validIngredientsTableColumns, "", false, filter, true)
 
 		db.ExpectQuery(formatQueryForSQLMock(query)).
 			WithArgs(interfaceToDriverValue(args)...).
@@ -420,7 +420,7 @@ func TestQuerier_GetValidIngredients(T *testing.T) {
 		ctx := context.Background()
 		c, db := buildTestClient(t)
 
-		query, args := c.buildListQuery(ctx, "valid_ingredients", nil, nil, nil, householdOwnershipColumn, validIngredientsTableColumns, "", false, filter)
+		query, args := c.buildListQuery(ctx, "valid_ingredients", nil, nil, nil, householdOwnershipColumn, validIngredientsTableColumns, "", false, filter, true)
 
 		db.ExpectQuery(formatQueryForSQLMock(query)).
 			WithArgs(interfaceToDriverValue(args)...).
@@ -441,7 +441,7 @@ func TestQuerier_GetValidIngredients(T *testing.T) {
 		ctx := context.Background()
 		c, db := buildTestClient(t)
 
-		query, args := c.buildListQuery(ctx, "valid_ingredients", nil, nil, nil, householdOwnershipColumn, validIngredientsTableColumns, "", false, filter)
+		query, args := c.buildListQuery(ctx, "valid_ingredients", nil, nil, nil, householdOwnershipColumn, validIngredientsTableColumns, "", false, filter, true)
 
 		db.ExpectQuery(formatQueryForSQLMock(query)).
 			WithArgs(interfaceToDriverValue(args)...).

--- a/internal/database/queriers/postgres/valid_instruments.go
+++ b/internal/database/queriers/postgres/valid_instruments.go
@@ -213,7 +213,7 @@ func (q *SQLQuerier) GetValidInstruments(ctx context.Context, filter *types.Quer
 		x.Page, x.Limit = filter.Page, filter.Limit
 	}
 
-	query, args := q.buildListQuery(ctx, "valid_instruments", nil, nil, nil, householdOwnershipColumn, validInstrumentsTableColumns, "", false, filter)
+	query, args := q.buildListQuery(ctx, "valid_instruments", nil, nil, nil, householdOwnershipColumn, validInstrumentsTableColumns, "", false, filter, true)
 
 	rows, err := q.performReadQuery(ctx, q.db, "validInstruments", query, args)
 	if err != nil {

--- a/internal/database/queriers/postgres/valid_instruments_test.go
+++ b/internal/database/queriers/postgres/valid_instruments_test.go
@@ -361,7 +361,7 @@ func TestQuerier_GetValidInstruments(T *testing.T) {
 		ctx := context.Background()
 		c, db := buildTestClient(t)
 
-		query, args := c.buildListQuery(ctx, "valid_instruments", nil, nil, nil, householdOwnershipColumn, validInstrumentsTableColumns, "", false, filter)
+		query, args := c.buildListQuery(ctx, "valid_instruments", nil, nil, nil, householdOwnershipColumn, validInstrumentsTableColumns, "", false, filter, true)
 
 		db.ExpectQuery(formatQueryForSQLMock(query)).
 			WithArgs(interfaceToDriverValue(args)...).
@@ -385,7 +385,7 @@ func TestQuerier_GetValidInstruments(T *testing.T) {
 		ctx := context.Background()
 		c, db := buildTestClient(t)
 
-		query, args := c.buildListQuery(ctx, "valid_instruments", nil, nil, nil, householdOwnershipColumn, validInstrumentsTableColumns, "", false, filter)
+		query, args := c.buildListQuery(ctx, "valid_instruments", nil, nil, nil, householdOwnershipColumn, validInstrumentsTableColumns, "", false, filter, true)
 
 		db.ExpectQuery(formatQueryForSQLMock(query)).
 			WithArgs(interfaceToDriverValue(args)...).
@@ -406,7 +406,7 @@ func TestQuerier_GetValidInstruments(T *testing.T) {
 		ctx := context.Background()
 		c, db := buildTestClient(t)
 
-		query, args := c.buildListQuery(ctx, "valid_instruments", nil, nil, nil, householdOwnershipColumn, validInstrumentsTableColumns, "", false, filter)
+		query, args := c.buildListQuery(ctx, "valid_instruments", nil, nil, nil, householdOwnershipColumn, validInstrumentsTableColumns, "", false, filter, true)
 
 		db.ExpectQuery(formatQueryForSQLMock(query)).
 			WithArgs(interfaceToDriverValue(args)...).
@@ -427,7 +427,7 @@ func TestQuerier_GetValidInstruments(T *testing.T) {
 		ctx := context.Background()
 		c, db := buildTestClient(t)
 
-		query, args := c.buildListQuery(ctx, "valid_instruments", nil, nil, nil, householdOwnershipColumn, validInstrumentsTableColumns, "", false, filter)
+		query, args := c.buildListQuery(ctx, "valid_instruments", nil, nil, nil, householdOwnershipColumn, validInstrumentsTableColumns, "", false, filter, true)
 
 		db.ExpectQuery(formatQueryForSQLMock(query)).
 			WithArgs(interfaceToDriverValue(args)...).

--- a/internal/database/queriers/postgres/valid_preparations.go
+++ b/internal/database/queriers/postgres/valid_preparations.go
@@ -215,7 +215,7 @@ func (q *SQLQuerier) GetValidPreparations(ctx context.Context, filter *types.Que
 		x.Page, x.Limit = filter.Page, filter.Limit
 	}
 
-	query, args := q.buildListQuery(ctx, "valid_preparations", nil, nil, nil, householdOwnershipColumn, validPreparationsTableColumns, "", false, filter)
+	query, args := q.buildListQuery(ctx, "valid_preparations", nil, nil, nil, householdOwnershipColumn, validPreparationsTableColumns, "", false, filter, true)
 
 	rows, err := q.performReadQuery(ctx, q.db, "validPreparations", query, args)
 	if err != nil {

--- a/internal/database/queriers/postgres/valid_preparations_test.go
+++ b/internal/database/queriers/postgres/valid_preparations_test.go
@@ -360,7 +360,7 @@ func TestQuerier_GetValidPreparations(T *testing.T) {
 		ctx := context.Background()
 		c, db := buildTestClient(t)
 
-		query, args := c.buildListQuery(ctx, "valid_preparations", nil, nil, nil, householdOwnershipColumn, validPreparationsTableColumns, "", false, filter)
+		query, args := c.buildListQuery(ctx, "valid_preparations", nil, nil, nil, householdOwnershipColumn, validPreparationsTableColumns, "", false, filter, true)
 
 		db.ExpectQuery(formatQueryForSQLMock(query)).
 			WithArgs(interfaceToDriverValue(args)...).
@@ -384,7 +384,7 @@ func TestQuerier_GetValidPreparations(T *testing.T) {
 		ctx := context.Background()
 		c, db := buildTestClient(t)
 
-		query, args := c.buildListQuery(ctx, "valid_preparations", nil, nil, nil, householdOwnershipColumn, validPreparationsTableColumns, "", false, filter)
+		query, args := c.buildListQuery(ctx, "valid_preparations", nil, nil, nil, householdOwnershipColumn, validPreparationsTableColumns, "", false, filter, true)
 
 		db.ExpectQuery(formatQueryForSQLMock(query)).
 			WithArgs(interfaceToDriverValue(args)...).
@@ -405,7 +405,7 @@ func TestQuerier_GetValidPreparations(T *testing.T) {
 		ctx := context.Background()
 		c, db := buildTestClient(t)
 
-		query, args := c.buildListQuery(ctx, "valid_preparations", nil, nil, nil, householdOwnershipColumn, validPreparationsTableColumns, "", false, filter)
+		query, args := c.buildListQuery(ctx, "valid_preparations", nil, nil, nil, householdOwnershipColumn, validPreparationsTableColumns, "", false, filter, true)
 
 		db.ExpectQuery(formatQueryForSQLMock(query)).
 			WithArgs(interfaceToDriverValue(args)...).
@@ -426,7 +426,7 @@ func TestQuerier_GetValidPreparations(T *testing.T) {
 		ctx := context.Background()
 		c, db := buildTestClient(t)
 
-		query, args := c.buildListQuery(ctx, "valid_preparations", nil, nil, nil, householdOwnershipColumn, validPreparationsTableColumns, "", false, filter)
+		query, args := c.buildListQuery(ctx, "valid_preparations", nil, nil, nil, householdOwnershipColumn, validPreparationsTableColumns, "", false, filter, true)
 
 		db.ExpectQuery(formatQueryForSQLMock(query)).
 			WithArgs(interfaceToDriverValue(args)...).

--- a/internal/database/queriers/postgres/webhooks.go
+++ b/internal/database/queriers/postgres/webhooks.go
@@ -236,7 +236,7 @@ func (q *SQLQuerier) GetWebhooks(ctx context.Context, householdID string, filter
 		x.Page, x.Limit = filter.Page, filter.Limit
 	}
 
-	query, args := q.buildListQuery(ctx, "webhooks", nil, nil, nil, "belongs_to_household", webhooksTableColumns, householdID, false, filter)
+	query, args := q.buildListQuery(ctx, "webhooks", nil, nil, nil, "belongs_to_household", webhooksTableColumns, householdID, false, filter, true)
 
 	rows, err := q.performReadQuery(ctx, q.db, "webhooks", query, args)
 	if err != nil {

--- a/internal/database/queriers/postgres/webhooks_test.go
+++ b/internal/database/queriers/postgres/webhooks_test.go
@@ -356,7 +356,7 @@ func TestQuerier_GetWebhooks(T *testing.T) {
 		ctx := context.Background()
 		c, db := buildTestClient(t)
 
-		query, args := c.buildListQuery(ctx, "webhooks", nil, nil, nil, "belongs_to_household", webhooksTableColumns, exampleHouseholdID, false, filter)
+		query, args := c.buildListQuery(ctx, "webhooks", nil, nil, nil, "belongs_to_household", webhooksTableColumns, exampleHouseholdID, false, filter, true)
 
 		db.ExpectQuery(formatQueryForSQLMock(query)).
 			WithArgs(interfaceToDriverValue(args)...).
@@ -384,7 +384,7 @@ func TestQuerier_GetWebhooks(T *testing.T) {
 		ctx := context.Background()
 		c, db := buildTestClient(t)
 
-		query, args := c.buildListQuery(ctx, "webhooks", nil, nil, nil, "belongs_to_household", webhooksTableColumns, exampleHouseholdID, false, filter)
+		query, args := c.buildListQuery(ctx, "webhooks", nil, nil, nil, "belongs_to_household", webhooksTableColumns, exampleHouseholdID, false, filter, true)
 
 		db.ExpectQuery(formatQueryForSQLMock(query)).
 			WithArgs(interfaceToDriverValue(args)...).
@@ -421,7 +421,7 @@ func TestQuerier_GetWebhooks(T *testing.T) {
 		ctx := context.Background()
 		c, db := buildTestClient(t)
 
-		query, args := c.buildListQuery(ctx, "webhooks", nil, nil, nil, "belongs_to_household", webhooksTableColumns, exampleHouseholdID, false, filter)
+		query, args := c.buildListQuery(ctx, "webhooks", nil, nil, nil, "belongs_to_household", webhooksTableColumns, exampleHouseholdID, false, filter, true)
 
 		db.ExpectQuery(formatQueryForSQLMock(query)).
 			WithArgs(interfaceToDriverValue(args)...).
@@ -442,7 +442,7 @@ func TestQuerier_GetWebhooks(T *testing.T) {
 		ctx := context.Background()
 		c, db := buildTestClient(t)
 
-		query, args := c.buildListQuery(ctx, "webhooks", nil, nil, nil, "belongs_to_household", webhooksTableColumns, exampleHouseholdID, false, filter)
+		query, args := c.buildListQuery(ctx, "webhooks", nil, nil, nil, "belongs_to_household", webhooksTableColumns, exampleHouseholdID, false, filter, true)
 
 		db.ExpectQuery(formatQueryForSQLMock(query)).
 			WithArgs(interfaceToDriverValue(args)...).

--- a/internal/services/recipes/http_routes.go
+++ b/internal/services/recipes/http_routes.go
@@ -58,8 +58,16 @@ func (s *service) CreateHandler(res http.ResponseWriter, req *http.Request) {
 		input.Steps[i].ID = ksuid.New().String()
 		for j := range step.Ingredients {
 			input.Steps[i].Ingredients[j].ID = ksuid.New().String()
+			input.Steps[i].Ingredients[j].BelongsToRecipeStep = input.Steps[i].ID
+		}
+
+		for j := range step.Products {
+			input.Steps[i].Products[j].ID = ksuid.New().String()
+			input.Steps[i].Products[j].BelongsToRecipeStep = input.Steps[i].ID
 		}
 	}
+
+	logger.WithValue("input", input).Info("input manipulated")
 
 	input.CreatedByUser = sessionCtxData.Requester.UserID
 	tracing.AttachRecipeIDToSpan(span, input.ID)

--- a/internal/services/recipes/http_routes.go
+++ b/internal/services/recipes/http_routes.go
@@ -67,8 +67,6 @@ func (s *service) CreateHandler(res http.ResponseWriter, req *http.Request) {
 		}
 	}
 
-	logger.WithValue("input", input).Info("input manipulated")
-
 	input.CreatedByUser = sessionCtxData.Requester.UserID
 	tracing.AttachRecipeIDToSpan(span, input.ID)
 

--- a/internal/services/recipesteps/http_routes.go
+++ b/internal/services/recipesteps/http_routes.go
@@ -58,6 +58,10 @@ func (s *service) CreateHandler(res http.ResponseWriter, req *http.Request) {
 		input.Ingredients[i].ID = ksuid.New().String()
 	}
 
+	for j := range input.Products {
+		input.Products[j].ID = ksuid.New().String()
+	}
+
 	// determine recipe ID.
 	recipeID := s.recipeIDFetcher(req)
 	tracing.AttachRecipeIDToSpan(span, recipeID)

--- a/pkg/client/httpclient/errors.go
+++ b/pkg/client/httpclient/errors.go
@@ -2,6 +2,7 @@ package httpclient
 
 import (
 	"errors"
+	"fmt"
 )
 
 var (
@@ -56,3 +57,8 @@ var (
 	// ErrArgumentIsNotPointer indicates we received a non-pointer interface argument.
 	ErrArgumentIsNotPointer = errors.New("value is not a pointer")
 )
+
+// buildInvalidIDError indicates a required ID was passed in as zero.
+func buildInvalidIDError(name string) error {
+	return fmt.Errorf("%s ID provided is empty", name)
+}

--- a/pkg/client/httpclient/recipe_step_ingredients.go
+++ b/pkg/client/httpclient/recipe_step_ingredients.go
@@ -17,19 +17,19 @@ func (c *Client) GetRecipeStepIngredient(ctx context.Context, recipeID, recipeSt
 	logger := c.logger.Clone()
 
 	if recipeID == "" {
-		return nil, ErrInvalidIDProvided
+		return nil, buildInvalidIDError("recipe")
 	}
 	logger = logger.WithValue(keys.RecipeIDKey, recipeID)
 	tracing.AttachRecipeIDToSpan(span, recipeID)
 
 	if recipeStepID == "" {
-		return nil, ErrInvalidIDProvided
+		return nil, buildInvalidIDError("recipe step")
 	}
 	logger = logger.WithValue(keys.RecipeStepIDKey, recipeStepID)
 	tracing.AttachRecipeStepIDToSpan(span, recipeStepID)
 
 	if recipeStepIngredientID == "" {
-		return nil, ErrInvalidIDProvided
+		return nil, buildInvalidIDError("recipe step ingredient")
 	}
 	logger = logger.WithValue(keys.RecipeStepIngredientIDKey, recipeStepIngredientID)
 	tracing.AttachRecipeStepIngredientIDToSpan(span, recipeStepIngredientID)
@@ -56,13 +56,13 @@ func (c *Client) GetRecipeStepIngredients(ctx context.Context, recipeID, recipeS
 	tracing.AttachQueryFilterToSpan(span, filter)
 
 	if recipeID == "" {
-		return nil, ErrInvalidIDProvided
+		return nil, buildInvalidIDError("recipe")
 	}
 	logger = logger.WithValue(keys.RecipeIDKey, recipeID)
 	tracing.AttachRecipeIDToSpan(span, recipeID)
 
 	if recipeStepID == "" {
-		return nil, ErrInvalidIDProvided
+		return nil, buildInvalidIDError("recipe step")
 	}
 	logger = logger.WithValue(keys.RecipeStepIDKey, recipeStepID)
 	tracing.AttachRecipeStepIDToSpan(span, recipeStepID)
@@ -88,7 +88,7 @@ func (c *Client) CreateRecipeStepIngredient(ctx context.Context, recipeID string
 	logger := c.logger.Clone()
 
 	if recipeID == "" {
-		return nil, ErrInvalidIDProvided
+		return nil, buildInvalidIDError("recipe")
 	}
 	logger = logger.WithValue(keys.RecipeIDKey, recipeID)
 	tracing.AttachRecipeIDToSpan(span, recipeID)

--- a/pkg/client/httpclient/recipe_step_instruments.go
+++ b/pkg/client/httpclient/recipe_step_instruments.go
@@ -17,13 +17,13 @@ func (c *Client) GetRecipeStepInstrument(ctx context.Context, recipeID, recipeSt
 	logger := c.logger.Clone()
 
 	if recipeID == "" {
-		return nil, ErrInvalidIDProvided
+		return nil, buildInvalidIDError("recipe")
 	}
 	logger = logger.WithValue(keys.RecipeIDKey, recipeID)
 	tracing.AttachRecipeIDToSpan(span, recipeID)
 
 	if recipeStepID == "" {
-		return nil, ErrInvalidIDProvided
+		return nil, buildInvalidIDError("recipe step")
 	}
 	logger = logger.WithValue(keys.RecipeStepIDKey, recipeStepID)
 	tracing.AttachRecipeStepIDToSpan(span, recipeStepID)
@@ -56,13 +56,13 @@ func (c *Client) GetRecipeStepInstruments(ctx context.Context, recipeID, recipeS
 	tracing.AttachQueryFilterToSpan(span, filter)
 
 	if recipeID == "" {
-		return nil, ErrInvalidIDProvided
+		return nil, buildInvalidIDError("recipe")
 	}
 	logger = logger.WithValue(keys.RecipeIDKey, recipeID)
 	tracing.AttachRecipeIDToSpan(span, recipeID)
 
 	if recipeStepID == "" {
-		return nil, ErrInvalidIDProvided
+		return nil, buildInvalidIDError("recipe step")
 	}
 	logger = logger.WithValue(keys.RecipeStepIDKey, recipeStepID)
 	tracing.AttachRecipeStepIDToSpan(span, recipeStepID)
@@ -88,7 +88,7 @@ func (c *Client) CreateRecipeStepInstrument(ctx context.Context, recipeID string
 	logger := c.logger.Clone()
 
 	if recipeID == "" {
-		return nil, ErrInvalidIDProvided
+		return nil, buildInvalidIDError("recipe")
 	}
 	logger = logger.WithValue(keys.RecipeIDKey, recipeID)
 	tracing.AttachRecipeIDToSpan(span, recipeID)

--- a/pkg/client/httpclient/recipe_step_products.go
+++ b/pkg/client/httpclient/recipe_step_products.go
@@ -17,13 +17,13 @@ func (c *Client) GetRecipeStepProduct(ctx context.Context, recipeID, recipeStepI
 	logger := c.logger.Clone()
 
 	if recipeID == "" {
-		return nil, ErrInvalidIDProvided
+		return nil, buildInvalidIDError("recipe")
 	}
 	logger = logger.WithValue(keys.RecipeIDKey, recipeID)
 	tracing.AttachRecipeIDToSpan(span, recipeID)
 
 	if recipeStepID == "" {
-		return nil, ErrInvalidIDProvided
+		return nil, buildInvalidIDError("recipe step")
 	}
 	logger = logger.WithValue(keys.RecipeStepIDKey, recipeStepID)
 	tracing.AttachRecipeStepIDToSpan(span, recipeStepID)
@@ -56,13 +56,13 @@ func (c *Client) GetRecipeStepProducts(ctx context.Context, recipeID, recipeStep
 	tracing.AttachQueryFilterToSpan(span, filter)
 
 	if recipeID == "" {
-		return nil, ErrInvalidIDProvided
+		return nil, buildInvalidIDError("recipe")
 	}
 	logger = logger.WithValue(keys.RecipeIDKey, recipeID)
 	tracing.AttachRecipeIDToSpan(span, recipeID)
 
 	if recipeStepID == "" {
-		return nil, ErrInvalidIDProvided
+		return nil, buildInvalidIDError("recipe step")
 	}
 	logger = logger.WithValue(keys.RecipeStepIDKey, recipeStepID)
 	tracing.AttachRecipeStepIDToSpan(span, recipeStepID)
@@ -88,7 +88,7 @@ func (c *Client) CreateRecipeStepProduct(ctx context.Context, recipeID string, i
 	logger := c.logger.Clone()
 
 	if recipeID == "" {
-		return nil, ErrInvalidIDProvided
+		return nil, buildInvalidIDError("recipe")
 	}
 	logger = logger.WithValue(keys.RecipeIDKey, recipeID)
 	tracing.AttachRecipeIDToSpan(span, recipeID)

--- a/pkg/client/httpclient/recipe_steps.go
+++ b/pkg/client/httpclient/recipe_steps.go
@@ -17,13 +17,13 @@ func (c *Client) GetRecipeStep(ctx context.Context, recipeID, recipeStepID strin
 	logger := c.logger.Clone()
 
 	if recipeID == "" {
-		return nil, ErrInvalidIDProvided
+		return nil, buildInvalidIDError("recipe")
 	}
 	logger = logger.WithValue(keys.RecipeIDKey, recipeID)
 	tracing.AttachRecipeIDToSpan(span, recipeID)
 
 	if recipeStepID == "" {
-		return nil, ErrInvalidIDProvided
+		return nil, buildInvalidIDError("recipe step")
 	}
 	logger = logger.WithValue(keys.RecipeStepIDKey, recipeStepID)
 	tracing.AttachRecipeStepIDToSpan(span, recipeStepID)
@@ -50,7 +50,7 @@ func (c *Client) GetRecipeSteps(ctx context.Context, recipeID string, filter *ty
 	tracing.AttachQueryFilterToSpan(span, filter)
 
 	if recipeID == "" {
-		return nil, ErrInvalidIDProvided
+		return nil, buildInvalidIDError("recipe")
 	}
 	logger = logger.WithValue(keys.RecipeIDKey, recipeID)
 	tracing.AttachRecipeIDToSpan(span, recipeID)

--- a/pkg/client/httpclient/recipes.go
+++ b/pkg/client/httpclient/recipes.go
@@ -17,7 +17,7 @@ func (c *Client) GetRecipe(ctx context.Context, recipeID string) (*types.Recipe,
 	logger := c.logger.Clone()
 
 	if recipeID == "" {
-		return nil, ErrInvalidIDProvided
+		return nil, buildInvalidIDError("recipe")
 	}
 	logger = logger.WithValue(keys.RecipeIDKey, recipeID)
 	tracing.AttachRecipeIDToSpan(span, recipeID)

--- a/pkg/client/httpclient/roundtripper_base.go
+++ b/pkg/client/httpclient/roundtripper_base.go
@@ -15,7 +15,7 @@ const (
 	userAgentHeader = "User-Agent"
 	userAgent       = "Prixfixe Service Client"
 
-	maxRetryCount = 5
+	maxRetryCount = 2
 	minRetryWait  = 100 * time.Millisecond
 	maxRetryWait  = time.Second
 )

--- a/pkg/types/fakes/recipe_step.go
+++ b/pkg/types/fakes/recipe_step.go
@@ -9,18 +9,24 @@ import (
 
 // BuildFakeRecipeStep builds a faked recipe step.
 func BuildFakeRecipeStep() *types.RecipeStep {
+	recipeStepID := ksuid.New().String()
+
 	var ingredients []*types.RecipeStepIngredient
 	for i := 0; i < exampleQuantity; i++ {
-		ingredients = append(ingredients, BuildFakeRecipeStepIngredient())
+		ing := BuildFakeRecipeStepIngredient()
+		ing.BelongsToRecipeStep = recipeStepID
+		ingredients = append(ingredients, ing)
 	}
 
 	var products []*types.RecipeStepProduct
 	for i := 0; i < exampleQuantity; i++ {
-		products = append(products, BuildFakeRecipeStepProduct())
+		p := BuildFakeRecipeStepProduct()
+		p.BelongsToRecipeStep = recipeStepID
+		products = append(products, p)
 	}
 
 	return &types.RecipeStep{
-		ID:                        ksuid.New().String(),
+		ID:                        recipeStepID,
 		Index:                     uint(fake.Uint32()),
 		Preparation:               *BuildFakeValidPreparation(),
 		PrerequisiteStep:          uint64(fake.Uint32()),

--- a/pkg/types/fakes/recipe_step.go
+++ b/pkg/types/fakes/recipe_step.go
@@ -14,6 +14,11 @@ func BuildFakeRecipeStep() *types.RecipeStep {
 		ingredients = append(ingredients, BuildFakeRecipeStepIngredient())
 	}
 
+	var products []*types.RecipeStepProduct
+	for i := 0; i < exampleQuantity; i++ {
+		products = append(products, BuildFakeRecipeStepProduct())
+	}
+
 	return &types.RecipeStep{
 		ID:                        ksuid.New().String(),
 		Index:                     uint(fake.Uint32()),
@@ -23,7 +28,7 @@ func BuildFakeRecipeStep() *types.RecipeStep {
 		MaxEstimatedTimeInSeconds: fake.Uint32(),
 		TemperatureInCelsius:      func(x uint16) *uint16 { return &x }(fake.Uint16()),
 		Notes:                     fake.LoremIpsumSentence(exampleQuantity),
-		Yields:                    fake.LoremIpsumSentence(exampleQuantity),
+		Products:                  products,
 		Optional:                  false,
 		CreatedOn:                 uint64(uint32(fake.Date().Unix())),
 		BelongsToRecipe:           ksuid.New().String(),
@@ -60,7 +65,7 @@ func BuildFakeRecipeStepUpdateRequestInput() *types.RecipeStepUpdateRequestInput
 		MaxEstimatedTimeInSeconds: recipeStep.MaxEstimatedTimeInSeconds,
 		TemperatureInCelsius:      recipeStep.TemperatureInCelsius,
 		Notes:                     recipeStep.Notes,
-		Yields:                    recipeStep.Yields,
+		Products:                  recipeStep.Products,
 		Optional:                  recipeStep.Optional,
 		BelongsToRecipe:           recipeStep.BelongsToRecipe,
 	}
@@ -69,7 +74,7 @@ func BuildFakeRecipeStepUpdateRequestInput() *types.RecipeStepUpdateRequestInput
 // BuildFakeRecipeStepUpdateRequestInputFromRecipeStep builds a faked RecipeStepUpdateRequestInput from a recipe step.
 func BuildFakeRecipeStepUpdateRequestInputFromRecipeStep(recipeStep *types.RecipeStep) *types.RecipeStepUpdateRequestInput {
 	return &types.RecipeStepUpdateRequestInput{
-		Yields:                    recipeStep.Yields,
+		Products:                  recipeStep.Products,
 		Optional:                  recipeStep.Optional,
 		Index:                     recipeStep.Index,
 		Preparation:               recipeStep.Preparation,
@@ -95,9 +100,14 @@ func BuildFakeRecipeStepCreationRequestInputFromRecipeStep(recipeStep *types.Rec
 		ingredients = append(ingredients, BuildFakeRecipeStepIngredientCreationRequestInputFromRecipeStepIngredient(ingredient))
 	}
 
+	products := []*types.RecipeStepProductCreationRequestInput{}
+	for _, product := range recipeStep.Products {
+		products = append(products, BuildFakeRecipeStepProductCreationRequestInputFromRecipeStepProduct(product))
+	}
+
 	return &types.RecipeStepCreationRequestInput{
 		ID:                        recipeStep.ID,
-		Yields:                    recipeStep.Yields,
+		Products:                  products,
 		Optional:                  recipeStep.Optional,
 		Index:                     recipeStep.Index,
 		PreparationID:             recipeStep.Preparation.ID,
@@ -124,11 +134,15 @@ func BuildFakeRecipeStepDatabaseCreationInputFromRecipeStep(recipeStep *types.Re
 		ingredients = append(ingredients, BuildFakeRecipeStepIngredientDatabaseCreationInputFromRecipeStepIngredient(i))
 	}
 
+	products := []*types.RecipeStepProductDatabaseCreationInput{}
+	for _, p := range recipeStep.Products {
+		products = append(products, BuildFakeRecipeStepProductDatabaseCreationInputFromRecipeStepProduct(p))
+	}
+
 	return &types.RecipeStepDatabaseCreationInput{
 		ID:                        recipeStep.ID,
 		Index:                     recipeStep.Index,
 		PreparationID:             recipeStep.Preparation.ID,
-		Yields:                    recipeStep.Yields,
 		Optional:                  recipeStep.Optional,
 		PrerequisiteStep:          recipeStep.PrerequisiteStep,
 		MinEstimatedTimeInSeconds: recipeStep.MinEstimatedTimeInSeconds,
@@ -136,6 +150,7 @@ func BuildFakeRecipeStepDatabaseCreationInputFromRecipeStep(recipeStep *types.Re
 		TemperatureInCelsius:      recipeStep.TemperatureInCelsius,
 		Notes:                     recipeStep.Notes,
 		Ingredients:               ingredients,
+		Products:                  products,
 		BelongsToRecipe:           recipeStep.BelongsToRecipe,
 	}
 }

--- a/pkg/types/recipe_step.go
+++ b/pkg/types/recipe_step.go
@@ -36,7 +36,7 @@ type (
 		TemperatureInCelsius      *uint16                 `json:"temperatureInCelsius"`
 		Notes                     string                  `json:"notes"`
 		ID                        string                  `json:"id"`
-		Yields                    string                  `json:"yields"`
+		Products                  []*RecipeStepProduct    `json:"products"`
 		BelongsToRecipe           string                  `json:"belongsToRecipe"`
 		Preparation               ValidPreparation        `json:"preparation"`
 		Ingredients               []*RecipeStepIngredient `json:"ingredients"`
@@ -59,7 +59,7 @@ type (
 	RecipeStepCreationRequestInput struct {
 		_                         struct{}
 		TemperatureInCelsius      *uint16                                     `json:"temperatureInCelsius"`
-		Yields                    string                                      `json:"yields"`
+		Products                  []*RecipeStepProductCreationRequestInput    `json:"products"`
 		Notes                     string                                      `json:"notes"`
 		PreparationID             string                                      `json:"preparationID"`
 		BelongsToRecipe           string                                      `json:"-"`
@@ -76,7 +76,7 @@ type (
 	RecipeStepDatabaseCreationInput struct {
 		_                         struct{}
 		TemperatureInCelsius      *uint16                                      `json:"temperatureInCelsius"`
-		Yields                    string                                       `json:"yields"`
+		Products                  []*RecipeStepProductDatabaseCreationInput    `json:"products"`
 		Notes                     string                                       `json:"notes"`
 		PreparationID             string                                       `json:"preparationID"`
 		BelongsToRecipe           string                                       `json:"belongsToRecipe"`
@@ -92,17 +92,17 @@ type (
 	// RecipeStepUpdateRequestInput represents what a user could set as input for updating recipe steps.
 	RecipeStepUpdateRequestInput struct {
 		_                         struct{}
-		TemperatureInCelsius      *uint16          `json:"temperatureInCelsius"`
-		Notes                     string           `json:"notes"`
-		Why                       string           `json:"why"`
-		BelongsToRecipe           string           `json:"belongsToRecipe"`
-		Yields                    string           `json:"yields"`
-		Preparation               ValidPreparation `json:"preparation"`
-		Index                     uint             `json:"index"`
-		PrerequisiteStep          uint64           `json:"prerequisiteStep"`
-		MinEstimatedTimeInSeconds uint32           `json:"minEstimatedTimeInSeconds"`
-		MaxEstimatedTimeInSeconds uint32           `json:"maxEstimatedTimeInSeconds"`
-		Optional                  bool             `json:"optional"`
+		TemperatureInCelsius      *uint16              `json:"temperatureInCelsius"`
+		Notes                     string               `json:"notes"`
+		Why                       string               `json:"why"`
+		BelongsToRecipe           string               `json:"belongsToRecipe"`
+		Products                  []*RecipeStepProduct `json:"products"`
+		Preparation               ValidPreparation     `json:"preparation"`
+		Index                     uint                 `json:"index"`
+		PrerequisiteStep          uint64               `json:"prerequisiteStep"`
+		MinEstimatedTimeInSeconds uint32               `json:"minEstimatedTimeInSeconds"`
+		MaxEstimatedTimeInSeconds uint32               `json:"maxEstimatedTimeInSeconds"`
+		Optional                  bool                 `json:"optional"`
 	}
 
 	// RecipeStepDataManager describes a structure capable of storing recipe steps permanently.
@@ -165,9 +165,7 @@ func (x *RecipeStep) Update(input *RecipeStepUpdateRequestInput) {
 		x.Notes = input.Notes
 	}
 
-	if input.Yields != "" && input.Yields != x.Yields {
-		x.Yields = input.Yields
-	}
+	// TODO: do something about products here
 
 	if input.Optional != x.Optional {
 		x.Optional = input.Optional
@@ -186,7 +184,7 @@ func (x *RecipeStepCreationRequestInput) ValidateWithContext(ctx context.Context
 		ctx,
 		x,
 		validation.Field(&x.PreparationID, validation.Required),
-		validation.Field(&x.Yields, validation.Required),
+		validation.Field(&x.Products, validation.Required),
 		validation.Field(&x.Ingredients, validation.Required),
 	)
 }
@@ -199,7 +197,7 @@ func (x *RecipeStepDatabaseCreationInput) ValidateWithContext(ctx context.Contex
 		ctx,
 		x,
 		validation.Field(&x.ID, validation.Required),
-		validation.Field(&x.Yields, validation.Required),
+		validation.Field(&x.Products, validation.Required),
 		validation.Field(&x.PreparationID, validation.Required),
 	)
 }
@@ -211,6 +209,11 @@ func RecipeStepDatabaseCreationInputFromRecipeStepCreationInput(input *RecipeSte
 		ingredients = append(ingredients, RecipeStepIngredientDatabaseCreationInputFromRecipeStepIngredientCreationInput(ingredient))
 	}
 
+	products := []*RecipeStepProductDatabaseCreationInput{}
+	for _, product := range input.Products {
+		products = append(products, RecipeStepProductDatabaseCreationInputFromRecipeStepProductCreationInput(product))
+	}
+
 	x := &RecipeStepDatabaseCreationInput{
 		Index:                     input.Index,
 		PreparationID:             input.PreparationID,
@@ -219,7 +222,7 @@ func RecipeStepDatabaseCreationInputFromRecipeStepCreationInput(input *RecipeSte
 		MaxEstimatedTimeInSeconds: input.MaxEstimatedTimeInSeconds,
 		TemperatureInCelsius:      input.TemperatureInCelsius,
 		Notes:                     input.Notes,
-		Yields:                    input.Yields,
+		Products:                  products,
 		Optional:                  input.Optional,
 		Ingredients:               ingredients,
 	}
@@ -240,7 +243,7 @@ func (x *RecipeStepUpdateRequestInput) ValidateWithContext(ctx context.Context) 
 		validation.Field(&x.MinEstimatedTimeInSeconds, validation.Required),
 		validation.Field(&x.MaxEstimatedTimeInSeconds, validation.Required),
 		validation.Field(&x.TemperatureInCelsius, validation.Required),
-		validation.Field(&x.Yields, validation.Required),
+		// validation.Field(&x.Products, validation.Required),
 		validation.Field(&x.Notes, validation.Required),
 	)
 }

--- a/pkg/types/recipe_step_test.go
+++ b/pkg/types/recipe_step_test.go
@@ -22,7 +22,12 @@ func TestRecipeStepCreationRequestInput_Validate(T *testing.T) {
 			MaxEstimatedTimeInSeconds: fake.Uint32(),
 			TemperatureInCelsius:      func(x uint16) *uint16 { return &x }(fake.Uint16()),
 			Notes:                     fake.LoremIpsumSentence(exampleQuantity),
-			Yields:                    fake.LoremIpsumSentence(exampleQuantity),
+			Products: []*RecipeStepProductCreationRequestInput{
+				{
+					Name:         fake.LoremIpsumSentence(exampleQuantity),
+					RecipeStepID: fake.LoremIpsumSentence(exampleQuantity),
+				},
+			},
 			Ingredients: []*RecipeStepIngredientCreationRequestInput{
 				{
 					IngredientID:        func(s string) *string { return &s }(fake.LoremIpsumSentence(exampleQuantity)),
@@ -62,9 +67,14 @@ func TestRecipeStepUpdateRequestInput_Validate(T *testing.T) {
 			PrerequisiteStep:          uint64(fake.Uint32()),
 			MinEstimatedTimeInSeconds: fake.Uint32(),
 			MaxEstimatedTimeInSeconds: fake.Uint32(),
-			Yields:                    fake.LoremIpsumSentence(exampleQuantity),
-			TemperatureInCelsius:      func(x uint16) *uint16 { return &x }(fake.Uint16()),
-			Notes:                     fake.LoremIpsumSentence(exampleQuantity),
+			Products: []*RecipeStepProduct{
+				{
+					Name:         fake.LoremIpsumSentence(exampleQuantity),
+					RecipeStepID: fake.LoremIpsumSentence(exampleQuantity),
+				},
+			},
+			TemperatureInCelsius: func(x uint16) *uint16 { return &x }(fake.Uint16()),
+			Notes:                fake.LoremIpsumSentence(exampleQuantity),
 		}
 
 		actual := x.ValidateWithContext(context.Background())

--- a/tests/integration/meal_plan_option_votes_test.go
+++ b/tests/integration/meal_plan_option_votes_test.go
@@ -41,7 +41,7 @@ func (s *TestSuite) TestMealPlanOptionVotes_CompleteLifecycle() {
 			ctx, span := tracing.StartCustomSpan(s.ctx, t.Name())
 			defer span.End()
 
-			createdMealPlan := createMealPlanWithNotificationChannel(ctx, t, testClients.main)
+			createdMealPlan := createMealPlanForTest(ctx, t, testClients.main)
 
 			var createdMealPlanOption *types.MealPlanOption
 			for _, opt := range createdMealPlan.Options {
@@ -101,7 +101,7 @@ func (s *TestSuite) TestMealPlanOptionVotes_Listing() {
 			ctx, span := tracing.StartCustomSpan(s.ctx, t.Name())
 			defer span.End()
 
-			createdMealPlan := createMealPlanWithNotificationChannel(ctx, t, testClients.main)
+			createdMealPlan := createMealPlanForTest(ctx, t, testClients.main)
 
 			var createdMealPlanOption *types.MealPlanOption
 			for _, opt := range createdMealPlan.Options {

--- a/tests/integration/meal_plan_options_test.go
+++ b/tests/integration/meal_plan_options_test.go
@@ -40,7 +40,7 @@ func (s *TestSuite) TestMealPlanOptions_CompleteLifecycle() {
 			ctx, span := tracing.StartCustomSpan(s.ctx, t.Name())
 			defer span.End()
 
-			createdMealPlan := createMealPlanWithNotificationChannel(ctx, t, testClients.main)
+			createdMealPlan := createMealPlanForTest(ctx, t, testClients.main)
 
 			var createdMealPlanOption *types.MealPlanOption
 			for _, opt := range createdMealPlan.Options {
@@ -81,7 +81,7 @@ func (s *TestSuite) TestMealPlanOptions_Listing() {
 			ctx, span := tracing.StartCustomSpan(s.ctx, t.Name())
 			defer span.End()
 
-			createdMealPlan := createMealPlanWithNotificationChannel(ctx, t, testClients.main)
+			createdMealPlan := createMealPlanForTest(ctx, t, testClients.main)
 
 			t.Log("creating meal plan options")
 			var expected []*types.MealPlanOption

--- a/tests/integration/meal_plans_test.go
+++ b/tests/integration/meal_plans_test.go
@@ -27,7 +27,7 @@ func checkMealPlanEquality(t *testing.T, expected, actual *types.MealPlan) {
 	assert.NotZero(t, actual.CreatedOn)
 }
 
-func createMealPlanWithNotificationChannel(ctx context.Context, t *testing.T, client *httpclient.Client) *types.MealPlan {
+func createMealPlanForTest(ctx context.Context, t *testing.T, client *httpclient.Client) *types.MealPlan {
 	t.Helper()
 
 	t.Log("creating meal plan")
@@ -488,7 +488,7 @@ func (s *TestSuite) TestMealPlans_Listing() {
 			t.Log("creating meal plans")
 			var expected []*types.MealPlan
 			for i := 0; i < 5; i++ {
-				createdMealPlan := createMealPlanWithNotificationChannel(ctx, t, testClients.main)
+				createdMealPlan := createMealPlanForTest(ctx, t, testClients.main)
 				expected = append(expected, createdMealPlan)
 			}
 

--- a/tests/integration/recipe_step_ingredients_test.go
+++ b/tests/integration/recipe_step_ingredients_test.go
@@ -52,13 +52,18 @@ func (s *TestSuite) TestRecipeStepIngredients_CompleteLifecycle() {
 				createdRecipeStepID,
 				createdRecipeStepIngredientID string
 			)
-			for _, step := range createdRecipe.Steps {
+			for i, step := range createdRecipe.Steps {
 				createdRecipeStepID = step.ID
+				t.Logf("ingredient count for step %d: %d", i+1, len(step.Ingredients))
 				for _, ingredient := range step.Ingredients {
 					createdRecipeStepIngredientID = ingredient.ID
 					break
 				}
 			}
+
+			t.Logf("step count: %d", len(createdRecipe.Steps))
+			require.NotEmpty(t, createdRecipeStepID, "created recipe step ID must not be empty")
+			require.NotEmpty(t, createdRecipeStepIngredientID, "created recipe step ingredient ID must not be empty")
 
 			t.Log("fetching changed recipe step ingredient")
 			createdRecipeStepIngredient, err := testClients.main.GetRecipeStepIngredient(ctx, createdRecipe.ID, createdRecipeStepID, createdRecipeStepIngredientID)

--- a/tests/integration/recipes_test.go
+++ b/tests/integration/recipes_test.go
@@ -79,9 +79,12 @@ func createRecipeForTest(ctx context.Context, t *testing.T, client *httpclient.C
 	t.Logf("recipe %q created", createdRecipe.ID)
 	checkRecipeEquality(t, exampleRecipe, createdRecipe)
 
+	// DEBUG (4/14/22): right now, this doesn't work, because the recipe isn't being returned with steps in it.
 	createdRecipe, err = client.GetRecipe(ctx, createdRecipe.ID)
 	requireNotNilAndNoProblems(t, createdRecipe, err)
 	checkRecipeEquality(t, exampleRecipe, createdRecipe)
+
+	require.NotEmpty(t, createdRecipe.Steps, "created recipe must have steps")
 
 	return createdValidIngredients, createdValidPreparation, createdRecipe
 }

--- a/tests/integration/recipes_test.go
+++ b/tests/integration/recipes_test.go
@@ -49,7 +49,6 @@ func createRecipeForTest(ctx context.Context, t *testing.T, client *httpclient.C
 	t.Logf("valid preparation %q created", createdValidPreparation.ID)
 
 	t.Log("creating recipe")
-
 	exampleRecipe := fakes.BuildFakeRecipe()
 	if recipe != nil {
 		exampleRecipe = recipe
@@ -63,8 +62,6 @@ func createRecipeForTest(ctx context.Context, t *testing.T, client *httpclient.C
 			exampleValidIngredientInput := fakes.BuildFakeValidIngredientCreationRequestInputFromValidIngredient(exampleValidIngredient)
 			createdValidIngredient, createdValidIngredientErr := client.CreateValidIngredient(ctx, exampleValidIngredientInput)
 			require.NoError(t, createdValidIngredientErr)
-
-			t.Logf("valid ingredient %q created", createdValidIngredient.ID)
 
 			createdValidIngredients = append(createdValidIngredients, createdValidIngredient)
 


### PR DESCRIPTION
This change:

- replaces the singular `Yield` field on a `RecipeStep` to `Products`, an array of `RecipeStepProduct`s 
- significantly refactors how recipes are fetched from the database
