### PR TITLE
refactor(config): omit zero-valued config fields, keeping deliberate off-switches visible

### DIFF
--- a/backend/deploy/environments/localdev/config_files/api_service_config.json
+++ b/backend/deploy/environments/localdev/config_files/api_service_config.json
@@ -1,5 +1,4 @@
 {
-	"httpClient": null,
 	"queues": {
 		"dataChangesTopicName": "data_changes",
 		"outboundEmailsTopicName": "outbound_emails",
@@ -14,48 +13,23 @@
 		"provider": "chi"
 	},
 	"pushNotifications": {
-		"apns": null,
-		"fcm": null,
 		"provider": "noop"
 	},
 	"encoding": {
 		"contentType": "application/json"
 	},
-	"baseURL": "",
 	"events": {
 		"consumer": {
-			"kafka": {
-				"groupId": "",
-				"brokers": null
-			},
 			"provider": "redis",
-			"sqs": {
-				"queueAddress": ""
-			},
-			"pubSub": {
-				"projectID": ""
-			},
 			"redis": {
-				"username": "",
 				"queueAddresses": [
 					"worker_queue:6379"
 				]
 			}
 		},
 		"publisher": {
-			"kafka": {
-				"groupId": "",
-				"brokers": null
-			},
 			"provider": "redis",
-			"sqs": {
-				"queueAddress": ""
-			},
-			"pubSub": {
-				"projectID": ""
-			},
 			"redis": {
-				"username": "",
 				"queueAddresses": [
 					"worker_queue:6379"
 				]
@@ -65,9 +39,7 @@
 	"observability": {
 		"profiling": {
 			"pprof": {
-				"port": 6060,
-				"enableMutexProfile": false,
-				"enableBlockProfile": false
+				"port": 6060
 			},
 			"serviceName": "api_server",
 			"provider": "pprof"
@@ -86,9 +58,7 @@
 			"otelgrpc": {
 				"metricsCollectorEndpoint": "otel_collector:4317",
 				"collectionInterval": 1000000000,
-				"insecure": true,
-				"enableRuntimeMetrics": false,
-				"enableHostMetrics": false
+				"insecure": true
 			},
 			"serviceName": "api_server",
 			"provider": "otelgrpc",
@@ -104,31 +74,14 @@
 			"spanCollectionProbability": 1
 		}
 	},
-	"grpc": {
-		"port": 0
-	},
 	"meta": {
 		"runMode": "development",
 		"debug": true
 	},
 	"email": {
-		"sendgrid": null,
-		"mailgun": null,
-		"mailjet": null,
-		"resend": null,
-		"postmark": null,
-		"ses": null,
-		"provider": "noop",
-		"circuitBreakerConfig": {
-			"name": "",
-			"circuitBreakerErrorPercentage": 0,
-			"circuitBreakerMinimumOccurrenceThreshold": 0
-		}
+		"provider": "noop"
 	},
 	"analytics": {
-		"proxySources": null,
-		"segment": null,
-		"posthog": null,
 		"provider": "noop",
 		"circuitBreaker": {
 			"name": "feature_flagger",
@@ -137,8 +90,6 @@
 		}
 	},
 	"featureFlags": {
-		"launchDarkly": null,
-		"posthog": null,
 		"provider": "noop",
 		"circuitBreakerConfig": {
 			"name": "feature_flagger",
@@ -147,27 +98,11 @@
 		}
 	},
 	"search": {
-		"algolia": null,
-		"elasticsearch": null,
 		"provider": "noop",
 		"circuitBreakerConfig": {
 			"name": "dev_text_searcher",
 			"circuitBreakerErrorPercentage": 0.5,
 			"circuitBreakerMinimumOccurrenceThreshold": 100
-		}
-	},
-	"auth": {
-		"sessionStore": {
-			"provider": ""
-		},
-		"passkey": {},
-		"tokens": {
-			"provider": "",
-			"issuer": "",
-			"audience": "",
-			"base64EncodedSigningKey": "",
-			"maxAccessTokenLifetime": 0,
-			"maxRefreshTokenLifetime": 0
 		}
 	},
 	"database": {
@@ -199,8 +134,7 @@
 		"maxOpenConns": 7,
 		"debug": true,
 		"logQueries": true,
-		"runMigrations": true,
-		"enableDatabaseMetrics": false
+		"runMigrations": true
 	},
 	"http": {
 		"appleAppSiteAssociation": {
@@ -214,53 +148,32 @@
 		"manager": {
 			"keyPrefix": "dinner_done_better.idempotency.",
 			"lock": {
-				"redis": null,
 				"postgres": {
-					"namespace": 0,
 					"connWaitTimeout": 5000000000
 				},
-				"provider": "postgres",
-				"circuitBreakerConfig": {
-					"name": "",
-					"circuitBreakerErrorPercentage": 0,
-					"circuitBreakerMinimumOccurrenceThreshold": 0
-				}
+				"provider": "postgres"
 			},
 			"cache": {
 				"redis": {
-					"username": "",
 					"namespace": "idempotency:",
 					"addresses": [
 						"worker_queue:6379"
-					],
-					"cluster": false
+					]
 				},
-				"provider": "redis",
-				"circuitBreakerConfig": {
-					"name": "",
-					"circuitBreakerErrorPercentage": 0,
-					"circuitBreakerMinimumOccurrenceThreshold": 0
-				},
-				"expiry": 0,
-				"janitorInterval": 0
+				"provider": "redis"
 			},
 			"ttl": 86400000000000,
-			"inFlightTTL": 120000000000,
-			"maxKeyLength": 0,
-			"failOpen": false
+			"inFlightTTL": 120000000000
 		},
 		"enabled": true
 	},
 	"metering": {
-		"tablePrefix": "",
 		"enforcer": {
 			"cachePrefix": "metering:",
-			"staleness": 10000000000,
-			"failOpen": false
+			"staleness": 10000000000
 		},
 		"flusher": {
 			"backoff": {
-				"provider": "",
 				"maxAttempts": 10,
 				"initialDelay": 1000000000,
 				"maxDelay": 300000000000,
@@ -273,16 +186,13 @@
 			"batchSize": 100,
 			"concurrency": 4,
 			"maxAttempts": 10,
-			"reapBatchSize": 1000,
-			"disableReap": false
+			"reapBatchSize": 1000
 		},
 		"recorder": {
-			"batchSize": 100,
-			"rejectUnknownMeters": false
+			"batchSize": 100
 		}
 	},
 	"webhooks": {
-		"tablePrefix": "",
 		"circuitBreaker": {
 			"name": "webhook_delivery",
 			"circuitBreakerErrorPercentage": 0.5,
@@ -291,7 +201,6 @@
 		"worker": {
 			"userAgent": "Dinner Done Better Webhooks/1",
 			"backoff": {
-				"provider": "",
 				"maxAttempts": 10,
 				"initialDelay": 5000000000,
 				"maxDelay": 3600000000000,
@@ -311,15 +220,12 @@
 		"httpClient": {
 			"timeout": 10000000000,
 			"maxIdleConns": 100,
-			"maxIdleConnsPerHost": 100,
-			"enableTracing": false
+			"maxIdleConnsPerHost": 100
 		}
 	},
 	"services": {
 		"payments": {
-			"revenueCat": null,
 			"capitalism": {
-				"stripe": null,
 				"provider": "noop"
 			}
 		},
@@ -328,16 +234,10 @@
 			"uploads": {
 				"storageConfig": {
 					"filesystem": {
-						"rootDirectory": "/uploads",
-						"directoryMode": "0o0"
+						"rootDirectory": "/uploads"
 					},
 					"bucketName": "avatars",
-					"provider": "filesystem",
-					"circuitBreakerConfig": {
-						"name": "",
-						"circuitBreakerErrorPercentage": 0,
-						"circuitBreakerMinimumOccurrenceThreshold": 0
-					}
+					"provider": "filesystem"
 				},
 				"debug": true
 			}
@@ -346,48 +246,25 @@
 			"uploads": {
 				"storageConfig": {
 					"filesystem": {
-						"rootDirectory": "/uploads",
-						"directoryMode": "0o0"
+						"rootDirectory": "/uploads"
 					},
 					"bucketName": "avatars",
-					"provider": "filesystem",
-					"circuitBreakerConfig": {
-						"name": "",
-						"circuitBreakerErrorPercentage": 0,
-						"circuitBreakerMinimumOccurrenceThreshold": 0
-					}
+					"provider": "filesystem"
 				},
 				"debug": true
 			}
-		},
-		"mealPlanning": {
-			"mediaUploadPrefix": "",
-			"uploads": {
-				"storageConfig": {
-					"circuitBreakerConfig": {
-						"name": "",
-						"circuitBreakerErrorPercentage": 0,
-						"circuitBreakerMinimumOccurrenceThreshold": 0
-					}
-				},
-				"debug": false
-			},
-			"useSearchService": false
 		},
 		"auth": {
 			"tokens": {
 				"provider": "paseto",
 				"issuer": "dinner-done-better",
 				"audience": "https://api.dinnerdonebetter.dev",
-				"base64EncodedSigningKey": "SEVSRUlTQTMyQ0hBUlNFQ1JFVFdISUNISVNNQURFVVA=",
-				"maxAccessTokenLifetime": 0,
-				"maxRefreshTokenLifetime": 0
+				"base64EncodedSigningKey": "SEVSRUlTQTMyQ0hBUlNFQ1JFVFdISUNISVNNQURFVVA="
 			},
 			"oauth2": {
 				"domain": "http://localhost:9000",
 				"accessTokenLifespan": 3600000000000,
-				"refreshTokenLifespan": 3600000000000,
-				"debug": false
+				"refreshTokenLifespan": 3600000000000
 			},
 			"jwtLifetime": 300000000000,
 			"debug": true,
@@ -403,62 +280,12 @@
 			"uploads": {
 				"storageConfig": {
 					"filesystem": {
-						"rootDirectory": "/tmp",
-						"directoryMode": "0o0"
+						"rootDirectory": "/tmp"
 					},
 					"bucketName": "userdata",
-					"provider": "filesystem",
-					"circuitBreakerConfig": {
-						"name": "",
-						"circuitBreakerErrorPercentage": 0,
-						"circuitBreakerMinimumOccurrenceThreshold": 0
-					}
-				},
-				"debug": false
-			},
-			"requests": {
-				"dialect": "",
-				"tablePrefix": "",
-				"auditErasure": {
-					"tablePrefix": "",
-					"retentionBasis": "",
-					"disabled": false
-				},
-				"worker": {
-					"artifactPathPrefix": "",
-					"backoff": {
-						"provider": "",
-						"maxAttempts": 0,
-						"initialDelay": 0,
-						"maxDelay": 0,
-						"multiplier": 0,
-						"useJitter": false
-					},
-					"pollInterval": 0,
-					"leaseDuration": 0,
-					"fulfillmentTimeout": 0,
-					"collectorTimeout": 0,
-					"artifactTTL": 0,
-					"maxDocumentBytes": 0,
-					"batchSize": 0,
-					"concurrency": 0,
-					"collectorConcurrency": 0
-				},
-				"service": {
-					"exportResponseWindow": 0,
-					"erasureResponseWindow": 0,
-					"confirmationWindow": 0,
-					"signedURLTTL": 0
-				},
-				"sweeper": {
-					"requestRetention": 0,
-					"batchSize": 0,
-					"disableReap": false
+					"provider": "filesystem"
 				}
 			}
-		},
-		"oauth2Clients": {
-			"creationEnabled": false
 		}
 	}
 }

--- a/backend/deploy/environments/localdev/config_files/async_message_handler_config.json
+++ b/backend/deploy/environments/localdev/config_files/async_message_handler_config.json
@@ -1,5 +1,4 @@
 {
-	"httpClient": null,
 	"queues": {
 		"dataChangesTopicName": "data_changes",
 		"outboundEmailsTopicName": "outbound_emails",
@@ -7,48 +6,20 @@
 		"mobileNotificationsTopicName": "mobile_notifications"
 	},
 	"pushNotifications": {
-		"apns": null,
-		"fcm": null,
 		"provider": "noop"
 	},
-	"encoding": {
-		"contentType": ""
-	},
-	"baseURL": "",
 	"events": {
 		"consumer": {
-			"kafka": {
-				"groupId": "",
-				"brokers": null
-			},
 			"provider": "redis",
-			"sqs": {
-				"queueAddress": ""
-			},
-			"pubSub": {
-				"projectID": ""
-			},
 			"redis": {
-				"username": "",
 				"queueAddresses": [
 					"worker_queue:6379"
 				]
 			}
 		},
 		"publisher": {
-			"kafka": {
-				"groupId": "",
-				"brokers": null
-			},
 			"provider": "redis",
-			"sqs": {
-				"queueAddress": ""
-			},
-			"pubSub": {
-				"projectID": ""
-			},
 			"redis": {
-				"username": "",
 				"queueAddresses": [
 					"worker_queue:6379"
 				]
@@ -58,9 +29,7 @@
 	"observability": {
 		"profiling": {
 			"pprof": {
-				"port": 6060,
-				"enableMutexProfile": false,
-				"enableBlockProfile": false
+				"port": 6060
 			},
 			"serviceName": "async_message_handler",
 			"provider": "pprof"
@@ -79,9 +48,7 @@
 			"otelgrpc": {
 				"metricsCollectorEndpoint": "otel_collector:4317",
 				"collectionInterval": 1000000000,
-				"insecure": true,
-				"enableRuntimeMetrics": false,
-				"enableHostMetrics": false
+				"insecure": true
 			},
 			"serviceName": "async_message_handler",
 			"provider": "otelgrpc",
@@ -98,23 +65,9 @@
 		}
 	},
 	"email": {
-		"sendgrid": null,
-		"mailgun": null,
-		"mailjet": null,
-		"resend": null,
-		"postmark": null,
-		"ses": null,
-		"provider": "noop",
-		"circuitBreakerConfig": {
-			"name": "",
-			"circuitBreakerErrorPercentage": 0,
-			"circuitBreakerMinimumOccurrenceThreshold": 0
-		}
+		"provider": "noop"
 	},
 	"analytics": {
-		"proxySources": null,
-		"segment": null,
-		"posthog": null,
 		"provider": "noop",
 		"circuitBreaker": {
 			"name": "feature_flagger",
@@ -123,8 +76,6 @@
 		}
 	},
 	"search": {
-		"algolia": null,
-		"elasticsearch": null,
 		"provider": "noop",
 		"circuitBreakerConfig": {
 			"name": "dev_text_searcher",
@@ -161,15 +112,12 @@
 		"maxOpenConns": 7,
 		"debug": true,
 		"logQueries": true,
-		"runMigrations": true,
-		"enableDatabaseMetrics": false
+		"runMigrations": true
 	},
 	"pools": {
 		"deadLetterTopicName": "dead_letter",
 		"dataChanges": {
-			"topic": "",
 			"retry": {
-				"provider": "",
 				"maxAttempts": 3,
 				"initialDelay": 100000000,
 				"maxDelay": 5000000000,
@@ -180,9 +128,7 @@
 			"handlerTimeout": 30000000000
 		},
 		"outboundEmails": {
-			"topic": "",
 			"retry": {
-				"provider": "",
 				"maxAttempts": 4,
 				"initialDelay": 100000000,
 				"maxDelay": 30000000000,
@@ -193,9 +139,7 @@
 			"handlerTimeout": 30000000000
 		},
 		"searchIndexRequests": {
-			"topic": "",
 			"retry": {
-				"provider": "",
 				"maxAttempts": 3,
 				"initialDelay": 100000000,
 				"maxDelay": 5000000000,
@@ -206,9 +150,7 @@
 			"handlerTimeout": 30000000000
 		},
 		"mobileNotifications": {
-			"topic": "",
 			"retry": {
-				"provider": "",
 				"maxAttempts": 3,
 				"initialDelay": 100000000,
 				"maxDelay": 5000000000,

--- a/backend/deploy/environments/localdev/config_files/job_db_cleaner_config.json
+++ b/backend/deploy/environments/localdev/config_files/job_db_cleaner_config.json
@@ -2,9 +2,7 @@
 	"observability": {
 		"profiling": {
 			"pprof": {
-				"port": 6060,
-				"enableMutexProfile": false,
-				"enableBlockProfile": false
+				"port": 6060
 			},
 			"serviceName": "db_cleaner",
 			"provider": "pprof"
@@ -23,9 +21,7 @@
 			"otelgrpc": {
 				"metricsCollectorEndpoint": "otel_collector:4317",
 				"collectionInterval": 1000000000,
-				"insecure": true,
-				"enableRuntimeMetrics": false,
-				"enableHostMetrics": false
+				"insecure": true
 			},
 			"serviceName": "db_cleaner",
 			"provider": "otelgrpc",
@@ -70,7 +66,6 @@
 		"maxOpenConns": 7,
 		"debug": true,
 		"logQueries": true,
-		"runMigrations": true,
-		"enableDatabaseMetrics": false
+		"runMigrations": true
 	}
 }

--- a/backend/deploy/environments/localdev/config_files/job_email_deliverability_test_config.json
+++ b/backend/deploy/environments/localdev/config_files/job_email_deliverability_test_config.json
@@ -1,13 +1,10 @@
 {
-	"httpClient": null,
 	"recipientEmailAddress": "verygoodsoftwarenotvirus@protonmail.com",
 	"serviceEnvironment": "dev",
 	"observability": {
 		"profiling": {
 			"pprof": {
-				"port": 6060,
-				"enableMutexProfile": false,
-				"enableBlockProfile": false
+				"port": 6060
 			},
 			"serviceName": "email_deliverability_test",
 			"provider": "pprof"
@@ -26,9 +23,7 @@
 			"otelgrpc": {
 				"metricsCollectorEndpoint": "otel_collector:4317",
 				"collectionInterval": 1000000000,
-				"insecure": true,
-				"enableRuntimeMetrics": false,
-				"enableHostMetrics": false
+				"insecure": true
 			},
 			"serviceName": "email_deliverability_test",
 			"provider": "otelgrpc",
@@ -45,17 +40,6 @@
 		}
 	},
 	"email": {
-		"sendgrid": null,
-		"mailgun": null,
-		"mailjet": null,
-		"resend": null,
-		"postmark": null,
-		"ses": null,
-		"provider": "noop",
-		"circuitBreakerConfig": {
-			"name": "",
-			"circuitBreakerErrorPercentage": 0,
-			"circuitBreakerMinimumOccurrenceThreshold": 0
-		}
+		"provider": "noop"
 	}
 }

--- a/backend/deploy/environments/localdev/config_files/mcp_server_config.json
+++ b/backend/deploy/environments/localdev/config_files/mcp_server_config.json
@@ -28,8 +28,7 @@
 		"maxOpenConns": 7,
 		"debug": true,
 		"logQueries": true,
-		"runMigrations": true,
-		"enableDatabaseMetrics": false
+		"runMigrations": true
 	},
 	"routing": {
 		"chiConfig": {
@@ -41,9 +40,7 @@
 	"observability": {
 		"profiling": {
 			"pprof": {
-				"port": 6060,
-				"enableMutexProfile": false,
-				"enableBlockProfile": false
+				"port": 6060
 			},
 			"serviceName": "dinner_done_better_mcp_server",
 			"provider": "pprof"
@@ -62,9 +59,7 @@
 			"otelgrpc": {
 				"metricsCollectorEndpoint": "otel_collector:4317",
 				"collectionInterval": 1000000000,
-				"insecure": true,
-				"enableRuntimeMetrics": false,
-				"enableHostMetrics": false
+				"insecure": true
 			},
 			"serviceName": "dinner_done_better_mcp_server",
 			"provider": "otelgrpc",

--- a/backend/deploy/environments/localdev/config_files/scheduler_config.json
+++ b/backend/deploy/environments/localdev/config_files/scheduler_config.json
@@ -6,43 +6,20 @@
 		"mobileNotificationsTopicName": "mobile_notifications"
 	},
 	"capitalism": {
-		"stripe": null,
 		"provider": "noop"
 	},
 	"events": {
 		"consumer": {
-			"kafka": {
-				"groupId": "",
-				"brokers": null
-			},
 			"provider": "redis",
-			"sqs": {
-				"queueAddress": ""
-			},
-			"pubSub": {
-				"projectID": ""
-			},
 			"redis": {
-				"username": "",
 				"queueAddresses": [
 					"worker_queue:6379"
 				]
 			}
 		},
 		"publisher": {
-			"kafka": {
-				"groupId": "",
-				"brokers": null
-			},
 			"provider": "redis",
-			"sqs": {
-				"queueAddress": ""
-			},
-			"pubSub": {
-				"projectID": ""
-			},
 			"redis": {
-				"username": "",
 				"queueAddresses": [
 					"worker_queue:6379"
 				]
@@ -52,9 +29,7 @@
 	"observability": {
 		"profiling": {
 			"pprof": {
-				"port": 6060,
-				"enableMutexProfile": false,
-				"enableBlockProfile": false
+				"port": 6060
 			},
 			"serviceName": "scheduler",
 			"provider": "pprof"
@@ -73,9 +48,7 @@
 			"otelgrpc": {
 				"metricsCollectorEndpoint": "otel_collector:4317",
 				"collectionInterval": 1000000000,
-				"insecure": true,
-				"enableRuntimeMetrics": false,
-				"enableHostMetrics": false
+				"insecure": true
 			},
 			"serviceName": "scheduler",
 			"provider": "otelgrpc",
@@ -92,9 +65,6 @@
 		}
 	},
 	"analytics": {
-		"proxySources": null,
-		"segment": null,
-		"posthog": null,
 		"provider": "noop",
 		"circuitBreaker": {
 			"name": "feature_flagger",
@@ -103,8 +73,6 @@
 		}
 	},
 	"search": {
-		"algolia": null,
-		"elasticsearch": null,
 		"provider": "noop",
 		"circuitBreakerConfig": {
 			"name": "dev_text_searcher",
@@ -120,21 +88,13 @@
 			"defaultTimeout": 60000000000
 		},
 		"lock": {
-			"redis": null,
 			"postgres": {
-				"namespace": 0,
 				"connWaitTimeout": 5000000000
 			},
-			"provider": "postgres",
-			"circuitBreakerConfig": {
-				"name": "",
-				"circuitBreakerErrorPercentage": 0,
-				"circuitBreakerMinimumOccurrenceThreshold": 0
-			}
+			"provider": "postgres"
 		},
 		"searchDataIndexScheduler": {
 			"schedule": "*/10 6-11 * * *",
-			"interval": 0,
 			"timeout": 300000000000,
 			"leaseTTL": 600000000000,
 			"enabled": true,
@@ -142,22 +102,17 @@
 		},
 		"mobileNotificationScheduler": {
 			"schedule": "CRON_TZ=America/Chicago 0 8-21 * * *",
-			"interval": 0,
 			"timeout": 300000000000,
 			"leaseTTL": 600000000000,
-			"enabled": true,
-			"runOnStart": false
+			"enabled": true
 		},
 		"queueTest": {
-			"schedule": "",
 			"interval": 900000000000,
 			"timeout": 60000000000,
 			"leaseTTL": 120000000000,
-			"enabled": true,
-			"runOnStart": false
+			"enabled": true
 		},
 		"dataPrivacySweep": {
-			"schedule": "",
 			"interval": 3600000000000,
 			"timeout": 300000000000,
 			"leaseTTL": 600000000000,
@@ -166,28 +121,22 @@
 		},
 		"auditRetentionSweeper": {
 			"schedule": "17 7 * * *",
-			"interval": 0,
 			"timeout": 600000000000,
 			"leaseTTL": 1200000000000,
-			"enabled": true,
-			"runOnStart": false
+			"enabled": true
 		},
 		"meteringFlusher": {
-			"schedule": "",
 			"interval": 300000000000,
 			"timeout": 120000000000,
 			"leaseTTL": 600000000000,
-			"enabled": true,
-			"runOnStart": false
+			"enabled": true
 		},
 		"mealPlanning": {
 			"mealPlanFinalizationStarter": {
-				"schedule": "",
 				"interval": 60000000000,
 				"timeout": 120000000000,
 				"leaseTTL": 300000000000,
-				"enabled": true,
-				"runOnStart": false
+				"enabled": true
 			}
 		}
 	},
@@ -228,14 +177,11 @@
 		"maxOpenConns": 7,
 		"debug": true,
 		"logQueries": true,
-		"runMigrations": true,
-		"enableDatabaseMetrics": false
+		"runMigrations": true
 	},
 	"outbox": {
-		"tablePrefix": "",
 		"claimMode": "skip_locked",
 		"backoff": {
-			"provider": "",
 			"maxAttempts": 8,
 			"initialDelay": 1000000000,
 			"maxDelay": 60000000000,
@@ -253,7 +199,6 @@
 		"lockKeyPrefix": "saga:instance:",
 		"idempotencyKeyPrefix": "saga:",
 		"backoff": {
-			"provider": "",
 			"maxAttempts": 3,
 			"initialDelay": 1000000000,
 			"maxDelay": 60000000000,
@@ -261,7 +206,6 @@
 			"useJitter": true
 		},
 		"compensationBackoff": {
-			"provider": "",
 			"maxAttempts": 10,
 			"initialDelay": 1000000000,
 			"maxDelay": 60000000000,
@@ -277,15 +221,12 @@
 		"concurrency": 4
 	},
 	"metering": {
-		"tablePrefix": "",
 		"enforcer": {
 			"cachePrefix": "metering:",
-			"staleness": 10000000000,
-			"failOpen": false
+			"staleness": 10000000000
 		},
 		"flusher": {
 			"backoff": {
-				"provider": "",
 				"maxAttempts": 10,
 				"initialDelay": 1000000000,
 				"maxDelay": 300000000000,
@@ -298,16 +239,13 @@
 			"batchSize": 100,
 			"concurrency": 4,
 			"maxAttempts": 10,
-			"reapBatchSize": 1000,
-			"disableReap": false
+			"reapBatchSize": 1000
 		},
 		"recorder": {
-			"batchSize": 100,
-			"rejectUnknownMeters": false
+			"batchSize": 100
 		}
 	},
 	"webhooks": {
-		"tablePrefix": "",
 		"circuitBreaker": {
 			"name": "webhook_delivery",
 			"circuitBreakerErrorPercentage": 0.5,
@@ -316,7 +254,6 @@
 		"worker": {
 			"userAgent": "Dinner Done Better Webhooks/1",
 			"backoff": {
-				"provider": "",
 				"maxAttempts": 10,
 				"initialDelay": 5000000000,
 				"maxDelay": 3600000000000,
@@ -336,8 +273,7 @@
 		"httpClient": {
 			"timeout": 10000000000,
 			"maxIdleConns": 100,
-			"maxIdleConnsPerHost": 100,
-			"enableTracing": false
+			"maxIdleConnsPerHost": 100
 		}
 	},
 	"dataPrivacy": {
@@ -348,57 +284,10 @@
 		"uploads": {
 			"storageConfig": {
 				"filesystem": {
-					"rootDirectory": "/tmp",
-					"directoryMode": "0o0"
+					"rootDirectory": "/tmp"
 				},
 				"bucketName": "userdata",
-				"provider": "filesystem",
-				"circuitBreakerConfig": {
-					"name": "",
-					"circuitBreakerErrorPercentage": 0,
-					"circuitBreakerMinimumOccurrenceThreshold": 0
-				}
-			},
-			"debug": false
-		},
-		"requests": {
-			"dialect": "",
-			"tablePrefix": "",
-			"auditErasure": {
-				"tablePrefix": "",
-				"retentionBasis": "",
-				"disabled": false
-			},
-			"worker": {
-				"artifactPathPrefix": "",
-				"backoff": {
-					"provider": "",
-					"maxAttempts": 0,
-					"initialDelay": 0,
-					"maxDelay": 0,
-					"multiplier": 0,
-					"useJitter": false
-				},
-				"pollInterval": 0,
-				"leaseDuration": 0,
-				"fulfillmentTimeout": 0,
-				"collectorTimeout": 0,
-				"artifactTTL": 0,
-				"maxDocumentBytes": 0,
-				"batchSize": 0,
-				"concurrency": 0,
-				"collectorConcurrency": 0
-			},
-			"service": {
-				"exportResponseWindow": 0,
-				"erasureResponseWindow": 0,
-				"confirmationWindow": 0,
-				"signedURLTTL": 0
-			},
-			"sweeper": {
-				"requestRetention": 0,
-				"batchSize": 0,
-				"disableReap": false
+				"provider": "filesystem"
 			}
 		}
 	}

--- a/backend/deploy/environments/localdev/kustomize/configs/api_service_config.json
+++ b/backend/deploy/environments/localdev/kustomize/configs/api_service_config.json
@@ -1,5 +1,4 @@
 {
-	"httpClient": null,
 	"queues": {
 		"dataChangesTopicName": "data_changes",
 		"outboundEmailsTopicName": "outbound_emails",
@@ -14,48 +13,23 @@
 		"provider": "chi"
 	},
 	"pushNotifications": {
-		"apns": null,
-		"fcm": null,
 		"provider": "noop"
 	},
 	"encoding": {
 		"contentType": "application/json"
 	},
-	"baseURL": "",
 	"events": {
 		"consumer": {
-			"kafka": {
-				"groupId": "",
-				"brokers": null
-			},
 			"provider": "redis",
-			"sqs": {
-				"queueAddress": ""
-			},
-			"pubSub": {
-				"projectID": ""
-			},
 			"redis": {
-				"username": "",
 				"queueAddresses": [
 					"worker_queue:6379"
 				]
 			}
 		},
 		"publisher": {
-			"kafka": {
-				"groupId": "",
-				"brokers": null
-			},
 			"provider": "redis",
-			"sqs": {
-				"queueAddress": ""
-			},
-			"pubSub": {
-				"projectID": ""
-			},
 			"redis": {
-				"username": "",
 				"queueAddresses": [
 					"worker_queue:6379"
 				]
@@ -65,9 +39,7 @@
 	"observability": {
 		"profiling": {
 			"pprof": {
-				"port": 6060,
-				"enableMutexProfile": false,
-				"enableBlockProfile": false
+				"port": 6060
 			},
 			"serviceName": "api_server",
 			"provider": "pprof"
@@ -86,9 +58,7 @@
 			"otelgrpc": {
 				"metricsCollectorEndpoint": "otel_collector:4317",
 				"collectionInterval": 1000000000,
-				"insecure": true,
-				"enableRuntimeMetrics": false,
-				"enableHostMetrics": false
+				"insecure": true
 			},
 			"serviceName": "api_server",
 			"provider": "otelgrpc",
@@ -104,31 +74,14 @@
 			"spanCollectionProbability": 1
 		}
 	},
-	"grpc": {
-		"port": 0
-	},
 	"meta": {
 		"runMode": "development",
 		"debug": true
 	},
 	"email": {
-		"sendgrid": null,
-		"mailgun": null,
-		"mailjet": null,
-		"resend": null,
-		"postmark": null,
-		"ses": null,
-		"provider": "noop",
-		"circuitBreakerConfig": {
-			"name": "",
-			"circuitBreakerErrorPercentage": 0,
-			"circuitBreakerMinimumOccurrenceThreshold": 0
-		}
+		"provider": "noop"
 	},
 	"analytics": {
-		"proxySources": null,
-		"segment": null,
-		"posthog": null,
 		"provider": "noop",
 		"circuitBreaker": {
 			"name": "feature_flagger",
@@ -137,8 +90,6 @@
 		}
 	},
 	"featureFlags": {
-		"launchDarkly": null,
-		"posthog": null,
 		"provider": "noop",
 		"circuitBreakerConfig": {
 			"name": "feature_flagger",
@@ -147,27 +98,11 @@
 		}
 	},
 	"search": {
-		"algolia": null,
-		"elasticsearch": null,
 		"provider": "noop",
 		"circuitBreakerConfig": {
 			"name": "dev_text_searcher",
 			"circuitBreakerErrorPercentage": 0.5,
 			"circuitBreakerMinimumOccurrenceThreshold": 100
-		}
-	},
-	"auth": {
-		"sessionStore": {
-			"provider": ""
-		},
-		"passkey": {},
-		"tokens": {
-			"provider": "",
-			"issuer": "",
-			"audience": "",
-			"base64EncodedSigningKey": "",
-			"maxAccessTokenLifetime": 0,
-			"maxRefreshTokenLifetime": 0
 		}
 	},
 	"database": {
@@ -199,8 +134,7 @@
 		"maxOpenConns": 7,
 		"debug": true,
 		"logQueries": true,
-		"runMigrations": true,
-		"enableDatabaseMetrics": false
+		"runMigrations": true
 	},
 	"http": {
 		"appleAppSiteAssociation": {
@@ -214,53 +148,32 @@
 		"manager": {
 			"keyPrefix": "dinner_done_better.idempotency.",
 			"lock": {
-				"redis": null,
 				"postgres": {
-					"namespace": 0,
 					"connWaitTimeout": 5000000000
 				},
-				"provider": "postgres",
-				"circuitBreakerConfig": {
-					"name": "",
-					"circuitBreakerErrorPercentage": 0,
-					"circuitBreakerMinimumOccurrenceThreshold": 0
-				}
+				"provider": "postgres"
 			},
 			"cache": {
 				"redis": {
-					"username": "",
 					"namespace": "idempotency:",
 					"addresses": [
 						"worker_queue:6379"
-					],
-					"cluster": false
+					]
 				},
-				"provider": "redis",
-				"circuitBreakerConfig": {
-					"name": "",
-					"circuitBreakerErrorPercentage": 0,
-					"circuitBreakerMinimumOccurrenceThreshold": 0
-				},
-				"expiry": 0,
-				"janitorInterval": 0
+				"provider": "redis"
 			},
 			"ttl": 86400000000000,
-			"inFlightTTL": 120000000000,
-			"maxKeyLength": 0,
-			"failOpen": false
+			"inFlightTTL": 120000000000
 		},
 		"enabled": true
 	},
 	"metering": {
-		"tablePrefix": "",
 		"enforcer": {
 			"cachePrefix": "metering:",
-			"staleness": 10000000000,
-			"failOpen": false
+			"staleness": 10000000000
 		},
 		"flusher": {
 			"backoff": {
-				"provider": "",
 				"maxAttempts": 10,
 				"initialDelay": 1000000000,
 				"maxDelay": 300000000000,
@@ -273,16 +186,13 @@
 			"batchSize": 100,
 			"concurrency": 4,
 			"maxAttempts": 10,
-			"reapBatchSize": 1000,
-			"disableReap": false
+			"reapBatchSize": 1000
 		},
 		"recorder": {
-			"batchSize": 100,
-			"rejectUnknownMeters": false
+			"batchSize": 100
 		}
 	},
 	"webhooks": {
-		"tablePrefix": "",
 		"circuitBreaker": {
 			"name": "webhook_delivery",
 			"circuitBreakerErrorPercentage": 0.5,
@@ -291,7 +201,6 @@
 		"worker": {
 			"userAgent": "Dinner Done Better Webhooks/1",
 			"backoff": {
-				"provider": "",
 				"maxAttempts": 10,
 				"initialDelay": 5000000000,
 				"maxDelay": 3600000000000,
@@ -311,15 +220,12 @@
 		"httpClient": {
 			"timeout": 10000000000,
 			"maxIdleConns": 100,
-			"maxIdleConnsPerHost": 100,
-			"enableTracing": false
+			"maxIdleConnsPerHost": 100
 		}
 	},
 	"services": {
 		"payments": {
-			"revenueCat": null,
 			"capitalism": {
-				"stripe": null,
 				"provider": "noop"
 			}
 		},
@@ -328,16 +234,10 @@
 			"uploads": {
 				"storageConfig": {
 					"filesystem": {
-						"rootDirectory": "/uploads",
-						"directoryMode": "0o0"
+						"rootDirectory": "/uploads"
 					},
 					"bucketName": "avatars",
-					"provider": "filesystem",
-					"circuitBreakerConfig": {
-						"name": "",
-						"circuitBreakerErrorPercentage": 0,
-						"circuitBreakerMinimumOccurrenceThreshold": 0
-					}
+					"provider": "filesystem"
 				},
 				"debug": true
 			}
@@ -346,48 +246,25 @@
 			"uploads": {
 				"storageConfig": {
 					"filesystem": {
-						"rootDirectory": "/uploads",
-						"directoryMode": "0o0"
+						"rootDirectory": "/uploads"
 					},
 					"bucketName": "avatars",
-					"provider": "filesystem",
-					"circuitBreakerConfig": {
-						"name": "",
-						"circuitBreakerErrorPercentage": 0,
-						"circuitBreakerMinimumOccurrenceThreshold": 0
-					}
+					"provider": "filesystem"
 				},
 				"debug": true
 			}
-		},
-		"mealPlanning": {
-			"mediaUploadPrefix": "",
-			"uploads": {
-				"storageConfig": {
-					"circuitBreakerConfig": {
-						"name": "",
-						"circuitBreakerErrorPercentage": 0,
-						"circuitBreakerMinimumOccurrenceThreshold": 0
-					}
-				},
-				"debug": false
-			},
-			"useSearchService": false
 		},
 		"auth": {
 			"tokens": {
 				"provider": "paseto",
 				"issuer": "dinner-done-better",
 				"audience": "https://api.dinnerdonebetter.dev",
-				"base64EncodedSigningKey": "SEVSRUlTQTMyQ0hBUlNFQ1JFVFdISUNISVNNQURFVVA=",
-				"maxAccessTokenLifetime": 0,
-				"maxRefreshTokenLifetime": 0
+				"base64EncodedSigningKey": "SEVSRUlTQTMyQ0hBUlNFQ1JFVFdISUNISVNNQURFVVA="
 			},
 			"oauth2": {
 				"domain": "http://localhost:9000",
 				"accessTokenLifespan": 3600000000000,
-				"refreshTokenLifespan": 3600000000000,
-				"debug": false
+				"refreshTokenLifespan": 3600000000000
 			},
 			"jwtLifetime": 300000000000,
 			"debug": true,
@@ -403,62 +280,12 @@
 			"uploads": {
 				"storageConfig": {
 					"filesystem": {
-						"rootDirectory": "/tmp",
-						"directoryMode": "0o0"
+						"rootDirectory": "/tmp"
 					},
 					"bucketName": "userdata",
-					"provider": "filesystem",
-					"circuitBreakerConfig": {
-						"name": "",
-						"circuitBreakerErrorPercentage": 0,
-						"circuitBreakerMinimumOccurrenceThreshold": 0
-					}
-				},
-				"debug": false
-			},
-			"requests": {
-				"dialect": "",
-				"tablePrefix": "",
-				"auditErasure": {
-					"tablePrefix": "",
-					"retentionBasis": "",
-					"disabled": false
-				},
-				"worker": {
-					"artifactPathPrefix": "",
-					"backoff": {
-						"provider": "",
-						"maxAttempts": 0,
-						"initialDelay": 0,
-						"maxDelay": 0,
-						"multiplier": 0,
-						"useJitter": false
-					},
-					"pollInterval": 0,
-					"leaseDuration": 0,
-					"fulfillmentTimeout": 0,
-					"collectorTimeout": 0,
-					"artifactTTL": 0,
-					"maxDocumentBytes": 0,
-					"batchSize": 0,
-					"concurrency": 0,
-					"collectorConcurrency": 0
-				},
-				"service": {
-					"exportResponseWindow": 0,
-					"erasureResponseWindow": 0,
-					"confirmationWindow": 0,
-					"signedURLTTL": 0
-				},
-				"sweeper": {
-					"requestRetention": 0,
-					"batchSize": 0,
-					"disableReap": false
+					"provider": "filesystem"
 				}
 			}
-		},
-		"oauth2Clients": {
-			"creationEnabled": false
 		}
 	}
 }

--- a/backend/deploy/environments/localdev/kustomize/configs/async_message_handler_config.json
+++ b/backend/deploy/environments/localdev/kustomize/configs/async_message_handler_config.json
@@ -1,5 +1,4 @@
 {
-	"httpClient": null,
 	"queues": {
 		"dataChangesTopicName": "data_changes",
 		"outboundEmailsTopicName": "outbound_emails",
@@ -7,48 +6,20 @@
 		"mobileNotificationsTopicName": "mobile_notifications"
 	},
 	"pushNotifications": {
-		"apns": null,
-		"fcm": null,
 		"provider": "noop"
 	},
-	"encoding": {
-		"contentType": ""
-	},
-	"baseURL": "",
 	"events": {
 		"consumer": {
-			"kafka": {
-				"groupId": "",
-				"brokers": null
-			},
 			"provider": "redis",
-			"sqs": {
-				"queueAddress": ""
-			},
-			"pubSub": {
-				"projectID": ""
-			},
 			"redis": {
-				"username": "",
 				"queueAddresses": [
 					"worker_queue:6379"
 				]
 			}
 		},
 		"publisher": {
-			"kafka": {
-				"groupId": "",
-				"brokers": null
-			},
 			"provider": "redis",
-			"sqs": {
-				"queueAddress": ""
-			},
-			"pubSub": {
-				"projectID": ""
-			},
 			"redis": {
-				"username": "",
 				"queueAddresses": [
 					"worker_queue:6379"
 				]
@@ -58,9 +29,7 @@
 	"observability": {
 		"profiling": {
 			"pprof": {
-				"port": 6060,
-				"enableMutexProfile": false,
-				"enableBlockProfile": false
+				"port": 6060
 			},
 			"serviceName": "async_message_handler",
 			"provider": "pprof"
@@ -79,9 +48,7 @@
 			"otelgrpc": {
 				"metricsCollectorEndpoint": "otel_collector:4317",
 				"collectionInterval": 1000000000,
-				"insecure": true,
-				"enableRuntimeMetrics": false,
-				"enableHostMetrics": false
+				"insecure": true
 			},
 			"serviceName": "async_message_handler",
 			"provider": "otelgrpc",
@@ -98,23 +65,9 @@
 		}
 	},
 	"email": {
-		"sendgrid": null,
-		"mailgun": null,
-		"mailjet": null,
-		"resend": null,
-		"postmark": null,
-		"ses": null,
-		"provider": "noop",
-		"circuitBreakerConfig": {
-			"name": "",
-			"circuitBreakerErrorPercentage": 0,
-			"circuitBreakerMinimumOccurrenceThreshold": 0
-		}
+		"provider": "noop"
 	},
 	"analytics": {
-		"proxySources": null,
-		"segment": null,
-		"posthog": null,
 		"provider": "noop",
 		"circuitBreaker": {
 			"name": "feature_flagger",
@@ -123,8 +76,6 @@
 		}
 	},
 	"search": {
-		"algolia": null,
-		"elasticsearch": null,
 		"provider": "noop",
 		"circuitBreakerConfig": {
 			"name": "dev_text_searcher",
@@ -161,15 +112,12 @@
 		"maxOpenConns": 7,
 		"debug": true,
 		"logQueries": true,
-		"runMigrations": true,
-		"enableDatabaseMetrics": false
+		"runMigrations": true
 	},
 	"pools": {
 		"deadLetterTopicName": "dead_letter",
 		"dataChanges": {
-			"topic": "",
 			"retry": {
-				"provider": "",
 				"maxAttempts": 3,
 				"initialDelay": 100000000,
 				"maxDelay": 5000000000,
@@ -180,9 +128,7 @@
 			"handlerTimeout": 30000000000
 		},
 		"outboundEmails": {
-			"topic": "",
 			"retry": {
-				"provider": "",
 				"maxAttempts": 4,
 				"initialDelay": 100000000,
 				"maxDelay": 30000000000,
@@ -193,9 +139,7 @@
 			"handlerTimeout": 30000000000
 		},
 		"searchIndexRequests": {
-			"topic": "",
 			"retry": {
-				"provider": "",
 				"maxAttempts": 3,
 				"initialDelay": 100000000,
 				"maxDelay": 5000000000,
@@ -206,9 +150,7 @@
 			"handlerTimeout": 30000000000
 		},
 		"mobileNotifications": {
-			"topic": "",
 			"retry": {
-				"provider": "",
 				"maxAttempts": 3,
 				"initialDelay": 100000000,
 				"maxDelay": 5000000000,

--- a/backend/deploy/environments/localdev/kustomize/configs/job_db_cleaner_config.json
+++ b/backend/deploy/environments/localdev/kustomize/configs/job_db_cleaner_config.json
@@ -2,9 +2,7 @@
 	"observability": {
 		"profiling": {
 			"pprof": {
-				"port": 6060,
-				"enableMutexProfile": false,
-				"enableBlockProfile": false
+				"port": 6060
 			},
 			"serviceName": "db_cleaner",
 			"provider": "pprof"
@@ -23,9 +21,7 @@
 			"otelgrpc": {
 				"metricsCollectorEndpoint": "otel_collector:4317",
 				"collectionInterval": 1000000000,
-				"insecure": true,
-				"enableRuntimeMetrics": false,
-				"enableHostMetrics": false
+				"insecure": true
 			},
 			"serviceName": "db_cleaner",
 			"provider": "otelgrpc",
@@ -70,7 +66,6 @@
 		"maxOpenConns": 7,
 		"debug": true,
 		"logQueries": true,
-		"runMigrations": true,
-		"enableDatabaseMetrics": false
+		"runMigrations": true
 	}
 }

--- a/backend/deploy/environments/localdev/kustomize/configs/job_email_deliverability_test_config.json
+++ b/backend/deploy/environments/localdev/kustomize/configs/job_email_deliverability_test_config.json
@@ -1,13 +1,10 @@
 {
-	"httpClient": null,
 	"recipientEmailAddress": "verygoodsoftwarenotvirus@protonmail.com",
 	"serviceEnvironment": "dev",
 	"observability": {
 		"profiling": {
 			"pprof": {
-				"port": 6060,
-				"enableMutexProfile": false,
-				"enableBlockProfile": false
+				"port": 6060
 			},
 			"serviceName": "email_deliverability_test",
 			"provider": "pprof"
@@ -26,9 +23,7 @@
 			"otelgrpc": {
 				"metricsCollectorEndpoint": "otel_collector:4317",
 				"collectionInterval": 1000000000,
-				"insecure": true,
-				"enableRuntimeMetrics": false,
-				"enableHostMetrics": false
+				"insecure": true
 			},
 			"serviceName": "email_deliverability_test",
 			"provider": "otelgrpc",
@@ -45,17 +40,6 @@
 		}
 	},
 	"email": {
-		"sendgrid": null,
-		"mailgun": null,
-		"mailjet": null,
-		"resend": null,
-		"postmark": null,
-		"ses": null,
-		"provider": "noop",
-		"circuitBreakerConfig": {
-			"name": "",
-			"circuitBreakerErrorPercentage": 0,
-			"circuitBreakerMinimumOccurrenceThreshold": 0
-		}
+		"provider": "noop"
 	}
 }

--- a/backend/deploy/environments/localdev/kustomize/configs/mcp_server_config.json
+++ b/backend/deploy/environments/localdev/kustomize/configs/mcp_server_config.json
@@ -28,8 +28,7 @@
 		"maxOpenConns": 7,
 		"debug": true,
 		"logQueries": true,
-		"runMigrations": true,
-		"enableDatabaseMetrics": false
+		"runMigrations": true
 	},
 	"routing": {
 		"chiConfig": {
@@ -41,9 +40,7 @@
 	"observability": {
 		"profiling": {
 			"pprof": {
-				"port": 6060,
-				"enableMutexProfile": false,
-				"enableBlockProfile": false
+				"port": 6060
 			},
 			"serviceName": "dinner_done_better_mcp_server",
 			"provider": "pprof"
@@ -62,9 +59,7 @@
 			"otelgrpc": {
 				"metricsCollectorEndpoint": "otel_collector:4317",
 				"collectionInterval": 1000000000,
-				"insecure": true,
-				"enableRuntimeMetrics": false,
-				"enableHostMetrics": false
+				"insecure": true
 			},
 			"serviceName": "dinner_done_better_mcp_server",
 			"provider": "otelgrpc",

--- a/backend/deploy/environments/localdev/kustomize/configs/scheduler_config.json
+++ b/backend/deploy/environments/localdev/kustomize/configs/scheduler_config.json
@@ -6,43 +6,20 @@
 		"mobileNotificationsTopicName": "mobile_notifications"
 	},
 	"capitalism": {
-		"stripe": null,
 		"provider": "noop"
 	},
 	"events": {
 		"consumer": {
-			"kafka": {
-				"groupId": "",
-				"brokers": null
-			},
 			"provider": "redis",
-			"sqs": {
-				"queueAddress": ""
-			},
-			"pubSub": {
-				"projectID": ""
-			},
 			"redis": {
-				"username": "",
 				"queueAddresses": [
 					"worker_queue:6379"
 				]
 			}
 		},
 		"publisher": {
-			"kafka": {
-				"groupId": "",
-				"brokers": null
-			},
 			"provider": "redis",
-			"sqs": {
-				"queueAddress": ""
-			},
-			"pubSub": {
-				"projectID": ""
-			},
 			"redis": {
-				"username": "",
 				"queueAddresses": [
 					"worker_queue:6379"
 				]
@@ -52,9 +29,7 @@
 	"observability": {
 		"profiling": {
 			"pprof": {
-				"port": 6060,
-				"enableMutexProfile": false,
-				"enableBlockProfile": false
+				"port": 6060
 			},
 			"serviceName": "scheduler",
 			"provider": "pprof"
@@ -73,9 +48,7 @@
 			"otelgrpc": {
 				"metricsCollectorEndpoint": "otel_collector:4317",
 				"collectionInterval": 1000000000,
-				"insecure": true,
-				"enableRuntimeMetrics": false,
-				"enableHostMetrics": false
+				"insecure": true
 			},
 			"serviceName": "scheduler",
 			"provider": "otelgrpc",
@@ -92,9 +65,6 @@
 		}
 	},
 	"analytics": {
-		"proxySources": null,
-		"segment": null,
-		"posthog": null,
 		"provider": "noop",
 		"circuitBreaker": {
 			"name": "feature_flagger",
@@ -103,8 +73,6 @@
 		}
 	},
 	"search": {
-		"algolia": null,
-		"elasticsearch": null,
 		"provider": "noop",
 		"circuitBreakerConfig": {
 			"name": "dev_text_searcher",
@@ -120,21 +88,13 @@
 			"defaultTimeout": 60000000000
 		},
 		"lock": {
-			"redis": null,
 			"postgres": {
-				"namespace": 0,
 				"connWaitTimeout": 5000000000
 			},
-			"provider": "postgres",
-			"circuitBreakerConfig": {
-				"name": "",
-				"circuitBreakerErrorPercentage": 0,
-				"circuitBreakerMinimumOccurrenceThreshold": 0
-			}
+			"provider": "postgres"
 		},
 		"searchDataIndexScheduler": {
 			"schedule": "*/10 6-11 * * *",
-			"interval": 0,
 			"timeout": 300000000000,
 			"leaseTTL": 600000000000,
 			"enabled": true,
@@ -142,22 +102,17 @@
 		},
 		"mobileNotificationScheduler": {
 			"schedule": "CRON_TZ=America/Chicago 0 8-21 * * *",
-			"interval": 0,
 			"timeout": 300000000000,
 			"leaseTTL": 600000000000,
-			"enabled": true,
-			"runOnStart": false
+			"enabled": true
 		},
 		"queueTest": {
-			"schedule": "",
 			"interval": 900000000000,
 			"timeout": 60000000000,
 			"leaseTTL": 120000000000,
-			"enabled": true,
-			"runOnStart": false
+			"enabled": true
 		},
 		"dataPrivacySweep": {
-			"schedule": "",
 			"interval": 3600000000000,
 			"timeout": 300000000000,
 			"leaseTTL": 600000000000,
@@ -166,28 +121,22 @@
 		},
 		"auditRetentionSweeper": {
 			"schedule": "17 7 * * *",
-			"interval": 0,
 			"timeout": 600000000000,
 			"leaseTTL": 1200000000000,
-			"enabled": true,
-			"runOnStart": false
+			"enabled": true
 		},
 		"meteringFlusher": {
-			"schedule": "",
 			"interval": 300000000000,
 			"timeout": 120000000000,
 			"leaseTTL": 600000000000,
-			"enabled": true,
-			"runOnStart": false
+			"enabled": true
 		},
 		"mealPlanning": {
 			"mealPlanFinalizationStarter": {
-				"schedule": "",
 				"interval": 60000000000,
 				"timeout": 120000000000,
 				"leaseTTL": 300000000000,
-				"enabled": true,
-				"runOnStart": false
+				"enabled": true
 			}
 		}
 	},
@@ -228,14 +177,11 @@
 		"maxOpenConns": 7,
 		"debug": true,
 		"logQueries": true,
-		"runMigrations": true,
-		"enableDatabaseMetrics": false
+		"runMigrations": true
 	},
 	"outbox": {
-		"tablePrefix": "",
 		"claimMode": "skip_locked",
 		"backoff": {
-			"provider": "",
 			"maxAttempts": 8,
 			"initialDelay": 1000000000,
 			"maxDelay": 60000000000,
@@ -253,7 +199,6 @@
 		"lockKeyPrefix": "saga:instance:",
 		"idempotencyKeyPrefix": "saga:",
 		"backoff": {
-			"provider": "",
 			"maxAttempts": 3,
 			"initialDelay": 1000000000,
 			"maxDelay": 60000000000,
@@ -261,7 +206,6 @@
 			"useJitter": true
 		},
 		"compensationBackoff": {
-			"provider": "",
 			"maxAttempts": 10,
 			"initialDelay": 1000000000,
 			"maxDelay": 60000000000,
@@ -277,15 +221,12 @@
 		"concurrency": 4
 	},
 	"metering": {
-		"tablePrefix": "",
 		"enforcer": {
 			"cachePrefix": "metering:",
-			"staleness": 10000000000,
-			"failOpen": false
+			"staleness": 10000000000
 		},
 		"flusher": {
 			"backoff": {
-				"provider": "",
 				"maxAttempts": 10,
 				"initialDelay": 1000000000,
 				"maxDelay": 300000000000,
@@ -298,16 +239,13 @@
 			"batchSize": 100,
 			"concurrency": 4,
 			"maxAttempts": 10,
-			"reapBatchSize": 1000,
-			"disableReap": false
+			"reapBatchSize": 1000
 		},
 		"recorder": {
-			"batchSize": 100,
-			"rejectUnknownMeters": false
+			"batchSize": 100
 		}
 	},
 	"webhooks": {
-		"tablePrefix": "",
 		"circuitBreaker": {
 			"name": "webhook_delivery",
 			"circuitBreakerErrorPercentage": 0.5,
@@ -316,7 +254,6 @@
 		"worker": {
 			"userAgent": "Dinner Done Better Webhooks/1",
 			"backoff": {
-				"provider": "",
 				"maxAttempts": 10,
 				"initialDelay": 5000000000,
 				"maxDelay": 3600000000000,
@@ -336,8 +273,7 @@
 		"httpClient": {
 			"timeout": 10000000000,
 			"maxIdleConns": 100,
-			"maxIdleConnsPerHost": 100,
-			"enableTracing": false
+			"maxIdleConnsPerHost": 100
 		}
 	},
 	"dataPrivacy": {
@@ -348,57 +284,10 @@
 		"uploads": {
 			"storageConfig": {
 				"filesystem": {
-					"rootDirectory": "/tmp",
-					"directoryMode": "0o0"
+					"rootDirectory": "/tmp"
 				},
 				"bucketName": "userdata",
-				"provider": "filesystem",
-				"circuitBreakerConfig": {
-					"name": "",
-					"circuitBreakerErrorPercentage": 0,
-					"circuitBreakerMinimumOccurrenceThreshold": 0
-				}
-			},
-			"debug": false
-		},
-		"requests": {
-			"dialect": "",
-			"tablePrefix": "",
-			"auditErasure": {
-				"tablePrefix": "",
-				"retentionBasis": "",
-				"disabled": false
-			},
-			"worker": {
-				"artifactPathPrefix": "",
-				"backoff": {
-					"provider": "",
-					"maxAttempts": 0,
-					"initialDelay": 0,
-					"maxDelay": 0,
-					"multiplier": 0,
-					"useJitter": false
-				},
-				"pollInterval": 0,
-				"leaseDuration": 0,
-				"fulfillmentTimeout": 0,
-				"collectorTimeout": 0,
-				"artifactTTL": 0,
-				"maxDocumentBytes": 0,
-				"batchSize": 0,
-				"concurrency": 0,
-				"collectorConcurrency": 0
-			},
-			"service": {
-				"exportResponseWindow": 0,
-				"erasureResponseWindow": 0,
-				"confirmationWindow": 0,
-				"signedURLTTL": 0
-			},
-			"sweeper": {
-				"requestRetention": 0,
-				"batchSize": 0,
-				"disableReap": false
+				"provider": "filesystem"
 			}
 		}
 	}

--- a/backend/deploy/environments/prod/kustomize/configs/api_service_config.json
+++ b/backend/deploy/environments/prod/kustomize/configs/api_service_config.json
@@ -1,5 +1,4 @@
 {
-	"httpClient": null,
 	"queues": {
 		"dataChangesTopicName": "data_changes",
 		"outboundEmailsTopicName": "outbound_emails",
@@ -8,61 +7,34 @@
 	},
 	"routing": {
 		"chiConfig": {
-			"serviceName": "api_server",
-			"enableCORSForLocalhost": false
+			"serviceName": "api_server"
 		},
 		"provider": "chi"
 	},
 	"pushNotifications": {
 		"apns": {
 			"authKeyPath": "/mnt/apns/apns-auth-key.p8",
-			"keyID": "",
 			"teamID": "K8R2Q5UWQS",
 			"bundleID": "com.dinnerdonebetter.ios",
 			"production": true
 		},
-		"fcm": {
-			"credentialsPath": ""
-		},
+		"fcm": {},
 		"provider": "apns_fcm"
 	},
 	"encoding": {
 		"contentType": "application/json"
 	},
-	"baseURL": "",
 	"events": {
 		"consumer": {
-			"kafka": {
-				"groupId": "",
-				"brokers": null
-			},
 			"provider": "pubsub",
-			"sqs": {
-				"queueAddress": ""
-			},
 			"pubSub": {
 				"projectID": "dinner-done-better-prod"
-			},
-			"redis": {
-				"username": "",
-				"queueAddresses": null
 			}
 		},
 		"publisher": {
-			"kafka": {
-				"groupId": "",
-				"brokers": null
-			},
 			"provider": "pubsub",
-			"sqs": {
-				"queueAddress": ""
-			},
 			"pubSub": {
 				"projectID": "dinner-done-better-prod"
-			},
-			"redis": {
-				"username": "",
-				"queueAddresses": null
 			}
 		}
 	},
@@ -70,10 +42,7 @@
 		"profiling": {
 			"pyroscope": {
 				"serverAddress": "https://profiles-prod-001.grafana.net",
-				"uploadRate": 15000000000,
-				"insecure": false,
-				"enableMutexProfile": false,
-				"enableBlockProfile": false
+				"uploadRate": 15000000000
 			},
 			"serviceName": "api_server",
 			"provider": "pyroscope"
@@ -114,18 +83,12 @@
 		"port": 8001
 	},
 	"meta": {
-		"runMode": "production",
-		"debug": false
+		"runMode": "production"
 	},
 	"email": {
-		"sendgrid": null,
-		"mailgun": null,
-		"mailjet": null,
 		"resend": {
 			"apiToken": "placeholder"
 		},
-		"postmark": null,
-		"ses": null,
 		"provider": "resend",
 		"circuitBreakerConfig": {
 			"name": "prod_emailer",
@@ -136,10 +99,8 @@
 	"analytics": {
 		"proxySources": {
 			"ios": {
-				"segment": null,
 				"posthog": {
-					"apiKey": "placeholder",
-					"endpoint": ""
+					"apiKey": "placeholder"
 				},
 				"provider": "posthog",
 				"circuitBreaker": {
@@ -149,10 +110,8 @@
 				}
 			},
 			"web": {
-				"segment": null,
 				"posthog": {
-					"apiKey": "placeholder",
-					"endpoint": ""
+					"apiKey": "placeholder"
 				},
 				"provider": "posthog",
 				"circuitBreaker": {
@@ -162,10 +121,8 @@
 				}
 			}
 		},
-		"segment": null,
 		"posthog": {
-			"apiKey": "placeholder",
-			"endpoint": ""
+			"apiKey": "placeholder"
 		},
 		"provider": "posthog",
 		"circuitBreaker": {
@@ -175,11 +132,8 @@
 		}
 	},
 	"featureFlags": {
-		"launchDarkly": null,
 		"posthog": {
-			"projectAPIKey": "placeholder",
-			"personalAPIKey": "",
-			"endpoint": ""
+			"projectAPIKey": "placeholder"
 		},
 		"provider": "posthog",
 		"circuitBreakerConfig": {
@@ -191,10 +145,8 @@
 	"search": {
 		"algolia": {
 			"appID": "placeholder",
-			"writeAPIKey": "placeholder",
-			"timeout": 0
+			"writeAPIKey": "placeholder"
 		},
-		"elasticsearch": null,
 		"provider": "algolia",
 		"circuitBreakerConfig": {
 			"name": "prod_text_searcher",
@@ -203,9 +155,6 @@
 		}
 	},
 	"auth": {
-		"sessionStore": {
-			"provider": ""
-		},
 		"passkey": {
 			"rpID": "dinnerdonebetter.com",
 			"rpDisplayName": "Dinner Done Better",
@@ -219,9 +168,7 @@
 			"provider": "paseto",
 			"issuer": "dinner-done-better",
 			"audience": "https://http-api.dinnerdonebetter.com",
-			"base64EncodedSigningKey": "SEVSRUlTQTMyQ0hBUlNFQ1JFVFdISUNISVNNQURFVVA=",
-			"maxAccessTokenLifetime": 0,
-			"maxRefreshTokenLifetime": 0
+			"base64EncodedSigningKey": "SEVSRUlTQTMyQ0hBUlNFQ1JFVFdISUNISVNNQURFVVA="
 		},
 		"enableUserSignup": true,
 		"minimumUsernameLength": 3,
@@ -231,33 +178,27 @@
 		"encryption": {
 			"provider": "salsa20"
 		},
-		"oauth2TokenEncryptionKey": "",
 		"provider": "postgres",
 		"readConnection": {
 			"username": "api_db_user",
 			"password": "REPLACE_AT_DEPLOY",
 			"database": "dinner-done-better",
 			"hostname": "REPLACE_AT_DEPLOY",
-			"port": 5432,
-			"disableSSL": false
+			"port": 5432
 		},
 		"writeConnection": {
 			"username": "api_db_user",
 			"password": "REPLACE_AT_DEPLOY",
 			"database": "dinner-done-better",
 			"hostname": "REPLACE_AT_DEPLOY",
-			"port": 5432,
-			"disableSSL": false
+			"port": 5432
 		},
 		"pingWaitPeriod": 1000000000,
 		"maxPingAttempts": 50,
 		"connMaxLifetime": 1800000000000,
 		"maxIdleConns": 5,
 		"maxOpenConns": 7,
-		"debug": false,
-		"logQueries": false,
-		"runMigrations": true,
-		"enableDatabaseMetrics": false
+		"runMigrations": true
 	},
 	"http": {
 		"appleAppSiteAssociation": {
@@ -268,46 +209,15 @@
 		"port": 8000
 	},
 	"idempotency": {
-		"manager": {
-			"keyPrefix": "",
-			"lock": {
-				"redis": null,
-				"postgres": null,
-				"provider": "",
-				"circuitBreakerConfig": {
-					"name": "",
-					"circuitBreakerErrorPercentage": 0,
-					"circuitBreakerMinimumOccurrenceThreshold": 0
-				}
-			},
-			"cache": {
-				"redis": null,
-				"provider": "",
-				"circuitBreakerConfig": {
-					"name": "",
-					"circuitBreakerErrorPercentage": 0,
-					"circuitBreakerMinimumOccurrenceThreshold": 0
-				},
-				"expiry": 0,
-				"janitorInterval": 0
-			},
-			"ttl": 0,
-			"inFlightTTL": 0,
-			"maxKeyLength": 0,
-			"failOpen": false
-		},
 		"enabled": false
 	},
 	"metering": {
-		"tablePrefix": "",
 		"enforcer": {
 			"cachePrefix": "metering:",
-			"staleness": 10000000000,
-			"failOpen": false
+			"staleness": 10000000000
 		},
 		"flusher": {
 			"backoff": {
-				"provider": "",
 				"maxAttempts": 10,
 				"initialDelay": 1000000000,
 				"maxDelay": 300000000000,
@@ -320,16 +230,13 @@
 			"batchSize": 100,
 			"concurrency": 4,
 			"maxAttempts": 10,
-			"reapBatchSize": 1000,
-			"disableReap": false
+			"reapBatchSize": 1000
 		},
 		"recorder": {
-			"batchSize": 100,
-			"rejectUnknownMeters": false
+			"batchSize": 100
 		}
 	},
 	"webhooks": {
-		"tablePrefix": "",
 		"circuitBreaker": {
 			"name": "webhook_delivery",
 			"circuitBreakerErrorPercentage": 0.5,
@@ -338,7 +245,6 @@
 		"worker": {
 			"userAgent": "Dinner Done Better Webhooks/1",
 			"backoff": {
-				"provider": "",
 				"maxAttempts": 10,
 				"initialDelay": 5000000000,
 				"maxDelay": 3600000000000,
@@ -358,15 +264,12 @@
 		"httpClient": {
 			"timeout": 10000000000,
 			"maxIdleConns": 100,
-			"maxIdleConnsPerHost": 100,
-			"enableTracing": false
+			"maxIdleConnsPerHost": 100
 		}
 	},
 	"services": {
 		"payments": {
-			"revenueCat": null,
 			"capitalism": {
-				"stripe": null,
 				"provider": "noop"
 			}
 		},
@@ -376,14 +279,8 @@
 				"storageConfig": {
 					"bucketPrefix": "avatars/",
 					"bucketName": "media.dinnerdonebetter.com",
-					"provider": "gcp",
-					"circuitBreakerConfig": {
-						"name": "",
-						"circuitBreakerErrorPercentage": 0,
-						"circuitBreakerMinimumOccurrenceThreshold": 0
-					}
-				},
-				"debug": false
+					"provider": "gcp"
+				}
 			}
 		},
 		"uploadedMedia": {
@@ -391,28 +288,11 @@
 				"storageConfig": {
 					"bucketPrefix": "avatars/",
 					"bucketName": "media.dinnerdonebetter.com",
-					"provider": "gcp",
-					"circuitBreakerConfig": {
-						"name": "",
-						"circuitBreakerErrorPercentage": 0,
-						"circuitBreakerMinimumOccurrenceThreshold": 0
-					}
-				},
-				"debug": false
+					"provider": "gcp"
+				}
 			}
 		},
 		"mealPlanning": {
-			"mediaUploadPrefix": "",
-			"uploads": {
-				"storageConfig": {
-					"circuitBreakerConfig": {
-						"name": "",
-						"circuitBreakerErrorPercentage": 0,
-						"circuitBreakerMinimumOccurrenceThreshold": 0
-					}
-				},
-				"debug": false
-			},
 			"useSearchService": true
 		},
 		"auth": {
@@ -420,15 +300,12 @@
 				"provider": "paseto",
 				"issuer": "dinner-done-better",
 				"audience": "https://http-api.dinnerdonebetter.com",
-				"base64EncodedSigningKey": "SEVSRUlTQTMyQ0hBUlNFQ1JFVFdISUNISVNNQURFVVA=",
-				"maxAccessTokenLifetime": 0,
-				"maxRefreshTokenLifetime": 0
+				"base64EncodedSigningKey": "SEVSRUlTQTMyQ0hBUlNFQ1JFVFdISUNISVNNQURFVVA="
 			},
 			"oauth2": {
 				"domain": "https://dinnerdonebetter.com",
 				"accessTokenLifespan": 3600000000000,
-				"refreshTokenLifespan": 3600000000000,
-				"debug": false
+				"refreshTokenLifespan": 3600000000000
 			},
 			"jwtLifetime": 300000000000,
 			"enableUserSignup": true,
@@ -439,57 +316,10 @@
 			"encryption": {
 				"provider": "salsa20"
 			},
-			"artifactEncryptionKey": "",
 			"uploads": {
 				"storageConfig": {
 					"bucketName": "userdata.dinnerdonebetter.com",
-					"provider": "gcp",
-					"circuitBreakerConfig": {
-						"name": "",
-						"circuitBreakerErrorPercentage": 0,
-						"circuitBreakerMinimumOccurrenceThreshold": 0
-					}
-				},
-				"debug": false
-			},
-			"requests": {
-				"dialect": "",
-				"tablePrefix": "",
-				"auditErasure": {
-					"tablePrefix": "",
-					"retentionBasis": "",
-					"disabled": false
-				},
-				"worker": {
-					"artifactPathPrefix": "",
-					"backoff": {
-						"provider": "",
-						"maxAttempts": 0,
-						"initialDelay": 0,
-						"maxDelay": 0,
-						"multiplier": 0,
-						"useJitter": false
-					},
-					"pollInterval": 0,
-					"leaseDuration": 0,
-					"fulfillmentTimeout": 0,
-					"collectorTimeout": 0,
-					"artifactTTL": 0,
-					"maxDocumentBytes": 0,
-					"batchSize": 0,
-					"concurrency": 0,
-					"collectorConcurrency": 0
-				},
-				"service": {
-					"exportResponseWindow": 0,
-					"erasureResponseWindow": 0,
-					"confirmationWindow": 0,
-					"signedURLTTL": 0
-				},
-				"sweeper": {
-					"requestRetention": 0,
-					"batchSize": 0,
-					"disableReap": false
+					"provider": "gcp"
 				}
 			}
 		},

--- a/backend/deploy/environments/prod/kustomize/configs/async_message_handler_config.json
+++ b/backend/deploy/environments/prod/kustomize/configs/async_message_handler_config.json
@@ -1,5 +1,4 @@
 {
-	"httpClient": null,
 	"queues": {
 		"dataChangesTopicName": "data_changes",
 		"outboundEmailsTopicName": "outbound_emails",
@@ -9,53 +8,24 @@
 	"pushNotifications": {
 		"apns": {
 			"authKeyPath": "/mnt/apns/apns-auth-key.p8",
-			"keyID": "",
 			"teamID": "K8R2Q5UWQS",
 			"bundleID": "com.dinnerdonebetter.ios",
 			"production": true
 		},
-		"fcm": {
-			"credentialsPath": ""
-		},
+		"fcm": {},
 		"provider": "apns_fcm"
 	},
-	"encoding": {
-		"contentType": ""
-	},
-	"baseURL": "",
 	"events": {
 		"consumer": {
-			"kafka": {
-				"groupId": "",
-				"brokers": null
-			},
 			"provider": "pubsub",
-			"sqs": {
-				"queueAddress": ""
-			},
 			"pubSub": {
 				"projectID": "dinner-done-better-prod"
-			},
-			"redis": {
-				"username": "",
-				"queueAddresses": null
 			}
 		},
 		"publisher": {
-			"kafka": {
-				"groupId": "",
-				"brokers": null
-			},
 			"provider": "pubsub",
-			"sqs": {
-				"queueAddress": ""
-			},
 			"pubSub": {
 				"projectID": "dinner-done-better-prod"
-			},
-			"redis": {
-				"username": "",
-				"queueAddresses": null
 			}
 		}
 	},
@@ -63,10 +33,7 @@
 		"profiling": {
 			"pyroscope": {
 				"serverAddress": "https://profiles-prod-001.grafana.net",
-				"uploadRate": 15000000000,
-				"insecure": false,
-				"enableMutexProfile": false,
-				"enableBlockProfile": false
+				"uploadRate": 15000000000
 			},
 			"serviceName": "async_message_handler",
 			"provider": "pyroscope"
@@ -104,14 +71,9 @@
 		}
 	},
 	"email": {
-		"sendgrid": null,
-		"mailgun": null,
-		"mailjet": null,
 		"resend": {
 			"apiToken": "placeholder"
 		},
-		"postmark": null,
-		"ses": null,
 		"provider": "resend",
 		"circuitBreakerConfig": {
 			"name": "prod_emailer",
@@ -122,10 +84,8 @@
 	"analytics": {
 		"proxySources": {
 			"ios": {
-				"segment": null,
 				"posthog": {
-					"apiKey": "placeholder",
-					"endpoint": ""
+					"apiKey": "placeholder"
 				},
 				"provider": "posthog",
 				"circuitBreaker": {
@@ -135,10 +95,8 @@
 				}
 			},
 			"web": {
-				"segment": null,
 				"posthog": {
-					"apiKey": "placeholder",
-					"endpoint": ""
+					"apiKey": "placeholder"
 				},
 				"provider": "posthog",
 				"circuitBreaker": {
@@ -148,10 +106,8 @@
 				}
 			}
 		},
-		"segment": null,
 		"posthog": {
-			"apiKey": "placeholder",
-			"endpoint": ""
+			"apiKey": "placeholder"
 		},
 		"provider": "posthog",
 		"circuitBreaker": {
@@ -163,10 +119,8 @@
 	"search": {
 		"algolia": {
 			"appID": "placeholder",
-			"writeAPIKey": "placeholder",
-			"timeout": 0
+			"writeAPIKey": "placeholder"
 		},
-		"elasticsearch": null,
 		"provider": "algolia",
 		"circuitBreakerConfig": {
 			"name": "prod_text_searcher",
@@ -178,40 +132,32 @@
 		"encryption": {
 			"provider": "salsa20"
 		},
-		"oauth2TokenEncryptionKey": "",
 		"provider": "postgres",
 		"readConnection": {
 			"username": "async_message_handler",
 			"password": "REPLACE_AT_DEPLOY",
 			"database": "dinner-done-better",
 			"hostname": "REPLACE_AT_DEPLOY",
-			"port": 5432,
-			"disableSSL": false
+			"port": 5432
 		},
 		"writeConnection": {
 			"username": "async_message_handler",
 			"password": "REPLACE_AT_DEPLOY",
 			"database": "dinner-done-better",
 			"hostname": "REPLACE_AT_DEPLOY",
-			"port": 5432,
-			"disableSSL": false
+			"port": 5432
 		},
 		"pingWaitPeriod": 1000000000,
 		"maxPingAttempts": 50,
 		"connMaxLifetime": 1800000000000,
 		"maxIdleConns": 5,
 		"maxOpenConns": 7,
-		"debug": false,
-		"logQueries": false,
-		"runMigrations": true,
-		"enableDatabaseMetrics": false
+		"runMigrations": true
 	},
 	"pools": {
 		"deadLetterTopicName": "dead_letter",
 		"dataChanges": {
-			"topic": "",
 			"retry": {
-				"provider": "",
 				"maxAttempts": 3,
 				"initialDelay": 100000000,
 				"maxDelay": 5000000000,
@@ -222,9 +168,7 @@
 			"handlerTimeout": 30000000000
 		},
 		"outboundEmails": {
-			"topic": "",
 			"retry": {
-				"provider": "",
 				"maxAttempts": 4,
 				"initialDelay": 100000000,
 				"maxDelay": 30000000000,
@@ -235,9 +179,7 @@
 			"handlerTimeout": 30000000000
 		},
 		"searchIndexRequests": {
-			"topic": "",
 			"retry": {
-				"provider": "",
 				"maxAttempts": 3,
 				"initialDelay": 100000000,
 				"maxDelay": 5000000000,
@@ -248,9 +190,7 @@
 			"handlerTimeout": 30000000000
 		},
 		"mobileNotifications": {
-			"topic": "",
 			"retry": {
-				"provider": "",
 				"maxAttempts": 3,
 				"initialDelay": 100000000,
 				"maxDelay": 5000000000,

--- a/backend/deploy/environments/prod/kustomize/configs/job_db_cleaner_config.json
+++ b/backend/deploy/environments/prod/kustomize/configs/job_db_cleaner_config.json
@@ -3,10 +3,7 @@
 		"profiling": {
 			"pyroscope": {
 				"serverAddress": "https://profiles-prod-001.grafana.net",
-				"uploadRate": 15000000000,
-				"insecure": false,
-				"enableMutexProfile": false,
-				"enableBlockProfile": false
+				"uploadRate": 15000000000
 			},
 			"serviceName": "db_cleaner",
 			"provider": "pyroscope"
@@ -25,9 +22,7 @@
 			"otelgrpc": {
 				"metricsCollectorEndpoint": "otel-collector-svc.prod.svc.cluster.local:4317",
 				"collectionInterval": 30000000000,
-				"insecure": true,
-				"enableRuntimeMetrics": false,
-				"enableHostMetrics": false
+				"insecure": true
 			},
 			"serviceName": "db_cleaner",
 			"provider": "otelgrpc",
@@ -47,32 +42,26 @@
 		"encryption": {
 			"provider": "salsa20"
 		},
-		"oauth2TokenEncryptionKey": "",
 		"provider": "postgres",
 		"readConnection": {
 			"username": "db_cleaner",
 			"password": "REPLACE_AT_DEPLOY",
 			"database": "dinner-done-better",
 			"hostname": "REPLACE_AT_DEPLOY",
-			"port": 5432,
-			"disableSSL": false
+			"port": 5432
 		},
 		"writeConnection": {
 			"username": "db_cleaner",
 			"password": "REPLACE_AT_DEPLOY",
 			"database": "dinner-done-better",
 			"hostname": "REPLACE_AT_DEPLOY",
-			"port": 5432,
-			"disableSSL": false
+			"port": 5432
 		},
 		"pingWaitPeriod": 1000000000,
 		"maxPingAttempts": 50,
 		"connMaxLifetime": 1800000000000,
 		"maxIdleConns": 5,
 		"maxOpenConns": 7,
-		"debug": false,
-		"logQueries": false,
-		"runMigrations": true,
-		"enableDatabaseMetrics": false
+		"runMigrations": true
 	}
 }

--- a/backend/deploy/environments/prod/kustomize/configs/job_email_deliverability_test_config.json
+++ b/backend/deploy/environments/prod/kustomize/configs/job_email_deliverability_test_config.json
@@ -1,15 +1,11 @@
 {
-	"httpClient": null,
 	"recipientEmailAddress": "verygoodsoftwarenotvirus@protonmail.com",
 	"serviceEnvironment": "prod",
 	"observability": {
 		"profiling": {
 			"pyroscope": {
 				"serverAddress": "https://profiles-prod-001.grafana.net",
-				"uploadRate": 15000000000,
-				"insecure": false,
-				"enableMutexProfile": false,
-				"enableBlockProfile": false
+				"uploadRate": 15000000000
 			},
 			"serviceName": "email_deliverability_test",
 			"provider": "pyroscope"
@@ -28,9 +24,7 @@
 			"otelgrpc": {
 				"metricsCollectorEndpoint": "otel-collector-svc.prod.svc.cluster.local:4317",
 				"collectionInterval": 30000000000,
-				"insecure": true,
-				"enableRuntimeMetrics": false,
-				"enableHostMetrics": false
+				"insecure": true
 			},
 			"serviceName": "email_deliverability_test",
 			"provider": "otelgrpc",
@@ -47,14 +41,9 @@
 		}
 	},
 	"email": {
-		"sendgrid": null,
-		"mailgun": null,
-		"mailjet": null,
 		"resend": {
 			"apiToken": "placeholder"
 		},
-		"postmark": null,
-		"ses": null,
 		"provider": "resend",
 		"circuitBreakerConfig": {
 			"name": "prod_emailer",

--- a/backend/deploy/environments/prod/kustomize/configs/mcp_server_config.json
+++ b/backend/deploy/environments/prod/kustomize/configs/mcp_server_config.json
@@ -3,33 +3,27 @@
 		"encryption": {
 			"provider": "salsa20"
 		},
-		"oauth2TokenEncryptionKey": "",
 		"provider": "postgres",
 		"readConnection": {
 			"username": "mcp_server",
 			"password": "REPLACE_AT_DEPLOY",
 			"database": "dinner-done-better",
 			"hostname": "REPLACE_AT_DEPLOY",
-			"port": 5432,
-			"disableSSL": false
+			"port": 5432
 		},
 		"writeConnection": {
 			"username": "mcp_server",
 			"password": "REPLACE_AT_DEPLOY",
 			"database": "dinner-done-better",
 			"hostname": "REPLACE_AT_DEPLOY",
-			"port": 5432,
-			"disableSSL": false
+			"port": 5432
 		},
 		"pingWaitPeriod": 1000000000,
 		"maxPingAttempts": 50,
 		"connMaxLifetime": 1800000000000,
 		"maxIdleConns": 5,
 		"maxOpenConns": 7,
-		"debug": false,
-		"logQueries": false,
-		"runMigrations": true,
-		"enableDatabaseMetrics": false
+		"runMigrations": true
 	},
 	"routing": {
 		"chiConfig": {
@@ -42,10 +36,7 @@
 		"profiling": {
 			"pyroscope": {
 				"serverAddress": "https://profiles-prod-001.grafana.net",
-				"uploadRate": 15000000000,
-				"insecure": false,
-				"enableMutexProfile": false,
-				"enableBlockProfile": false
+				"uploadRate": 15000000000
 			},
 			"serviceName": "dinner_done_better_mcp_server",
 			"provider": "pyroscope"
@@ -64,9 +55,7 @@
 			"otelgrpc": {
 				"metricsCollectorEndpoint": "otel-collector-svc.prod.svc.cluster.local:4317",
 				"collectionInterval": 30000000000,
-				"insecure": true,
-				"enableRuntimeMetrics": false,
-				"enableHostMetrics": false
+				"insecure": true
 			},
 			"serviceName": "dinner_done_better_mcp_server",
 			"provider": "otelgrpc",
@@ -83,8 +72,7 @@
 		}
 	},
 	"meta": {
-		"runMode": "production",
-		"debug": false
+		"runMode": "production"
 	},
 	"http": {
 		"startupDeadline": 60000000000,

--- a/backend/deploy/environments/prod/kustomize/configs/scheduler_config.json
+++ b/backend/deploy/environments/prod/kustomize/configs/scheduler_config.json
@@ -6,42 +6,19 @@
 		"mobileNotificationsTopicName": "mobile_notifications"
 	},
 	"capitalism": {
-		"stripe": null,
 		"provider": "noop"
 	},
 	"events": {
 		"consumer": {
-			"kafka": {
-				"groupId": "",
-				"brokers": null
-			},
 			"provider": "pubsub",
-			"sqs": {
-				"queueAddress": ""
-			},
 			"pubSub": {
 				"projectID": "dinner-done-better-prod"
-			},
-			"redis": {
-				"username": "",
-				"queueAddresses": null
 			}
 		},
 		"publisher": {
-			"kafka": {
-				"groupId": "",
-				"brokers": null
-			},
 			"provider": "pubsub",
-			"sqs": {
-				"queueAddress": ""
-			},
 			"pubSub": {
 				"projectID": "dinner-done-better-prod"
-			},
-			"redis": {
-				"username": "",
-				"queueAddresses": null
 			}
 		}
 	},
@@ -49,10 +26,7 @@
 		"profiling": {
 			"pyroscope": {
 				"serverAddress": "https://profiles-prod-001.grafana.net",
-				"uploadRate": 15000000000,
-				"insecure": false,
-				"enableMutexProfile": false,
-				"enableBlockProfile": false
+				"uploadRate": 15000000000
 			},
 			"serviceName": "scheduler",
 			"provider": "pyroscope"
@@ -92,10 +66,8 @@
 	"analytics": {
 		"proxySources": {
 			"ios": {
-				"segment": null,
 				"posthog": {
-					"apiKey": "placeholder",
-					"endpoint": ""
+					"apiKey": "placeholder"
 				},
 				"provider": "posthog",
 				"circuitBreaker": {
@@ -105,10 +77,8 @@
 				}
 			},
 			"web": {
-				"segment": null,
 				"posthog": {
-					"apiKey": "placeholder",
-					"endpoint": ""
+					"apiKey": "placeholder"
 				},
 				"provider": "posthog",
 				"circuitBreaker": {
@@ -118,10 +88,8 @@
 				}
 			}
 		},
-		"segment": null,
 		"posthog": {
-			"apiKey": "placeholder",
-			"endpoint": ""
+			"apiKey": "placeholder"
 		},
 		"provider": "posthog",
 		"circuitBreaker": {
@@ -133,10 +101,8 @@
 	"search": {
 		"algolia": {
 			"appID": "placeholder",
-			"writeAPIKey": "placeholder",
-			"timeout": 0
+			"writeAPIKey": "placeholder"
 		},
-		"elasticsearch": null,
 		"provider": "algolia",
 		"circuitBreakerConfig": {
 			"name": "prod_text_searcher",
@@ -152,21 +118,13 @@
 			"defaultTimeout": 60000000000
 		},
 		"lock": {
-			"redis": null,
 			"postgres": {
-				"namespace": 0,
 				"connWaitTimeout": 5000000000
 			},
-			"provider": "postgres",
-			"circuitBreakerConfig": {
-				"name": "",
-				"circuitBreakerErrorPercentage": 0,
-				"circuitBreakerMinimumOccurrenceThreshold": 0
-			}
+			"provider": "postgres"
 		},
 		"searchDataIndexScheduler": {
 			"schedule": "*/10 6-11 * * *",
-			"interval": 0,
 			"timeout": 300000000000,
 			"leaseTTL": 600000000000,
 			"enabled": true,
@@ -174,22 +132,17 @@
 		},
 		"mobileNotificationScheduler": {
 			"schedule": "CRON_TZ=America/Chicago 0 8-21 * * *",
-			"interval": 0,
 			"timeout": 300000000000,
 			"leaseTTL": 600000000000,
-			"enabled": true,
-			"runOnStart": false
+			"enabled": true
 		},
 		"queueTest": {
-			"schedule": "",
 			"interval": 900000000000,
 			"timeout": 60000000000,
 			"leaseTTL": 120000000000,
-			"enabled": true,
-			"runOnStart": false
+			"enabled": true
 		},
 		"dataPrivacySweep": {
-			"schedule": "",
 			"interval": 3600000000000,
 			"timeout": 300000000000,
 			"leaseTTL": 600000000000,
@@ -198,28 +151,22 @@
 		},
 		"auditRetentionSweeper": {
 			"schedule": "17 7 * * *",
-			"interval": 0,
 			"timeout": 600000000000,
 			"leaseTTL": 1200000000000,
-			"enabled": true,
-			"runOnStart": false
+			"enabled": true
 		},
 		"meteringFlusher": {
-			"schedule": "",
 			"interval": 300000000000,
 			"timeout": 120000000000,
 			"leaseTTL": 600000000000,
-			"enabled": true,
-			"runOnStart": false
+			"enabled": true
 		},
 		"mealPlanning": {
 			"mealPlanFinalizationStarter": {
-				"schedule": "",
 				"interval": 60000000000,
 				"timeout": 120000000000,
 				"leaseTTL": 300000000000,
-				"enabled": true,
-				"runOnStart": false
+				"enabled": true
 			}
 		}
 	},
@@ -235,39 +182,31 @@
 		"encryption": {
 			"provider": "salsa20"
 		},
-		"oauth2TokenEncryptionKey": "",
 		"provider": "postgres",
 		"readConnection": {
 			"username": "scheduler",
 			"password": "REPLACE_AT_DEPLOY",
 			"database": "dinner-done-better",
 			"hostname": "REPLACE_AT_DEPLOY",
-			"port": 5432,
-			"disableSSL": false
+			"port": 5432
 		},
 		"writeConnection": {
 			"username": "scheduler",
 			"password": "REPLACE_AT_DEPLOY",
 			"database": "dinner-done-better",
 			"hostname": "REPLACE_AT_DEPLOY",
-			"port": 5432,
-			"disableSSL": false
+			"port": 5432
 		},
 		"pingWaitPeriod": 1000000000,
 		"maxPingAttempts": 50,
 		"connMaxLifetime": 1800000000000,
 		"maxIdleConns": 5,
 		"maxOpenConns": 7,
-		"debug": false,
-		"logQueries": false,
-		"runMigrations": true,
-		"enableDatabaseMetrics": false
+		"runMigrations": true
 	},
 	"outbox": {
-		"tablePrefix": "",
 		"claimMode": "skip_locked",
 		"backoff": {
-			"provider": "",
 			"maxAttempts": 8,
 			"initialDelay": 1000000000,
 			"maxDelay": 60000000000,
@@ -285,7 +224,6 @@
 		"lockKeyPrefix": "saga:instance:",
 		"idempotencyKeyPrefix": "saga:",
 		"backoff": {
-			"provider": "",
 			"maxAttempts": 3,
 			"initialDelay": 1000000000,
 			"maxDelay": 60000000000,
@@ -293,7 +231,6 @@
 			"useJitter": true
 		},
 		"compensationBackoff": {
-			"provider": "",
 			"maxAttempts": 10,
 			"initialDelay": 1000000000,
 			"maxDelay": 60000000000,
@@ -309,15 +246,12 @@
 		"concurrency": 4
 	},
 	"metering": {
-		"tablePrefix": "",
 		"enforcer": {
 			"cachePrefix": "metering:",
-			"staleness": 10000000000,
-			"failOpen": false
+			"staleness": 10000000000
 		},
 		"flusher": {
 			"backoff": {
-				"provider": "",
 				"maxAttempts": 10,
 				"initialDelay": 1000000000,
 				"maxDelay": 300000000000,
@@ -330,16 +264,13 @@
 			"batchSize": 100,
 			"concurrency": 4,
 			"maxAttempts": 10,
-			"reapBatchSize": 1000,
-			"disableReap": false
+			"reapBatchSize": 1000
 		},
 		"recorder": {
-			"batchSize": 100,
-			"rejectUnknownMeters": false
+			"batchSize": 100
 		}
 	},
 	"webhooks": {
-		"tablePrefix": "",
 		"circuitBreaker": {
 			"name": "webhook_delivery",
 			"circuitBreakerErrorPercentage": 0.5,
@@ -348,7 +279,6 @@
 		"worker": {
 			"userAgent": "Dinner Done Better Webhooks/1",
 			"backoff": {
-				"provider": "",
 				"maxAttempts": 10,
 				"initialDelay": 5000000000,
 				"maxDelay": 3600000000000,
@@ -368,65 +298,17 @@
 		"httpClient": {
 			"timeout": 10000000000,
 			"maxIdleConns": 100,
-			"maxIdleConnsPerHost": 100,
-			"enableTracing": false
+			"maxIdleConnsPerHost": 100
 		}
 	},
 	"dataPrivacy": {
 		"encryption": {
 			"provider": "salsa20"
 		},
-		"artifactEncryptionKey": "",
 		"uploads": {
 			"storageConfig": {
 				"bucketName": "userdata.dinnerdonebetter.com",
-				"provider": "gcp",
-				"circuitBreakerConfig": {
-					"name": "",
-					"circuitBreakerErrorPercentage": 0,
-					"circuitBreakerMinimumOccurrenceThreshold": 0
-				}
-			},
-			"debug": false
-		},
-		"requests": {
-			"dialect": "",
-			"tablePrefix": "",
-			"auditErasure": {
-				"tablePrefix": "",
-				"retentionBasis": "",
-				"disabled": false
-			},
-			"worker": {
-				"artifactPathPrefix": "",
-				"backoff": {
-					"provider": "",
-					"maxAttempts": 0,
-					"initialDelay": 0,
-					"maxDelay": 0,
-					"multiplier": 0,
-					"useJitter": false
-				},
-				"pollInterval": 0,
-				"leaseDuration": 0,
-				"fulfillmentTimeout": 0,
-				"collectorTimeout": 0,
-				"artifactTTL": 0,
-				"maxDocumentBytes": 0,
-				"batchSize": 0,
-				"concurrency": 0,
-				"collectorConcurrency": 0
-			},
-			"service": {
-				"exportResponseWindow": 0,
-				"erasureResponseWindow": 0,
-				"confirmationWindow": 0,
-				"signedURLTTL": 0
-			},
-			"sweeper": {
-				"requestRetention": 0,
-				"batchSize": 0,
-				"disableReap": false
+				"provider": "gcp"
 			}
 		}
 	}

--- a/backend/deploy/environments/testing/config_files/async_message_handler_config.json
+++ b/backend/deploy/environments/testing/config_files/async_message_handler_config.json
@@ -1,5 +1,4 @@
 {
-	"httpClient": null,
 	"queues": {
 		"dataChangesTopicName": "data_changes",
 		"outboundEmailsTopicName": "outbound_emails",
@@ -7,48 +6,20 @@
 		"mobileNotificationsTopicName": "mobile_notifications"
 	},
 	"pushNotifications": {
-		"apns": null,
-		"fcm": null,
 		"provider": "noop"
 	},
-	"encoding": {
-		"contentType": ""
-	},
-	"baseURL": "",
 	"events": {
 		"consumer": {
-			"kafka": {
-				"groupId": "",
-				"brokers": null
-			},
 			"provider": "redis",
-			"sqs": {
-				"queueAddress": ""
-			},
-			"pubSub": {
-				"projectID": ""
-			},
 			"redis": {
-				"username": "",
 				"queueAddresses": [
 					"worker_queue:6379"
 				]
 			}
 		},
 		"publisher": {
-			"kafka": {
-				"groupId": "",
-				"brokers": null
-			},
 			"provider": "redis",
-			"sqs": {
-				"queueAddress": ""
-			},
-			"pubSub": {
-				"projectID": ""
-			},
 			"redis": {
-				"username": "",
 				"queueAddresses": [
 					"worker_queue:6379"
 				]
@@ -65,31 +36,16 @@
 			"provider": "slog"
 		},
 		"metrics": {
-			"serviceName": "async_message_handler",
-			"enabled": false
+			"serviceName": "async_message_handler"
 		},
 		"tracing": {
 			"service_name": "async_message_handler"
 		}
 	},
 	"email": {
-		"sendgrid": null,
-		"mailgun": null,
-		"mailjet": null,
-		"resend": null,
-		"postmark": null,
-		"ses": null,
-		"provider": "noop",
-		"circuitBreakerConfig": {
-			"name": "",
-			"circuitBreakerErrorPercentage": 0,
-			"circuitBreakerMinimumOccurrenceThreshold": 0
-		}
+		"provider": "noop"
 	},
 	"analytics": {
-		"proxySources": null,
-		"segment": null,
-		"posthog": null,
 		"provider": "noop",
 		"circuitBreaker": {
 			"name": "feature_flagger",
@@ -98,8 +54,6 @@
 		}
 	},
 	"search": {
-		"algolia": null,
-		"elasticsearch": null,
 		"provider": "noop",
 		"circuitBreakerConfig": {
 			"name": "feature_flagger",
@@ -136,15 +90,12 @@
 		"maxOpenConns": 7,
 		"debug": true,
 		"logQueries": true,
-		"runMigrations": true,
-		"enableDatabaseMetrics": false
+		"runMigrations": true
 	},
 	"pools": {
 		"deadLetterTopicName": "dead_letter",
 		"dataChanges": {
-			"topic": "",
 			"retry": {
-				"provider": "",
 				"maxAttempts": 3,
 				"initialDelay": 100000000,
 				"maxDelay": 5000000000,
@@ -155,9 +106,7 @@
 			"handlerTimeout": 30000000000
 		},
 		"outboundEmails": {
-			"topic": "",
 			"retry": {
-				"provider": "",
 				"maxAttempts": 4,
 				"initialDelay": 100000000,
 				"maxDelay": 30000000000,
@@ -168,9 +117,7 @@
 			"handlerTimeout": 30000000000
 		},
 		"searchIndexRequests": {
-			"topic": "",
 			"retry": {
-				"provider": "",
 				"maxAttempts": 3,
 				"initialDelay": 100000000,
 				"maxDelay": 5000000000,
@@ -181,9 +128,7 @@
 			"handlerTimeout": 30000000000
 		},
 		"mobileNotifications": {
-			"topic": "",
 			"retry": {
-				"provider": "",
 				"maxAttempts": 3,
 				"initialDelay": 100000000,
 				"maxDelay": 5000000000,

--- a/backend/deploy/environments/testing/config_files/integration-tests-config.json
+++ b/backend/deploy/environments/testing/config_files/integration-tests-config.json
@@ -1,5 +1,4 @@
 {
-	"httpClient": null,
 	"queues": {
 		"dataChangesTopicName": "data_changes",
 		"outboundEmailsTopicName": "outbound_emails",
@@ -14,48 +13,23 @@
 		"provider": "chi"
 	},
 	"pushNotifications": {
-		"apns": null,
-		"fcm": null,
 		"provider": "noop"
 	},
 	"encoding": {
 		"contentType": "application/json"
 	},
-	"baseURL": "",
 	"events": {
 		"consumer": {
-			"kafka": {
-				"groupId": "",
-				"brokers": null
-			},
 			"provider": "redis",
-			"sqs": {
-				"queueAddress": ""
-			},
-			"pubSub": {
-				"projectID": ""
-			},
 			"redis": {
-				"username": "",
 				"queueAddresses": [
 					"worker_queue:6379"
 				]
 			}
 		},
 		"publisher": {
-			"kafka": {
-				"groupId": "",
-				"brokers": null
-			},
 			"provider": "redis",
-			"sqs": {
-				"queueAddress": ""
-			},
-			"pubSub": {
-				"projectID": ""
-			},
 			"redis": {
-				"username": "",
 				"queueAddresses": [
 					"worker_queue:6379"
 				]
@@ -72,8 +46,7 @@
 			"provider": "slog"
 		},
 		"metrics": {
-			"serviceName": "api_server",
-			"enabled": false
+			"serviceName": "api_server"
 		},
 		"tracing": {
 			"service_name": "api_server"
@@ -83,27 +56,12 @@
 		"port": 8001
 	},
 	"meta": {
-		"runMode": "testing",
-		"debug": false
+		"runMode": "testing"
 	},
 	"email": {
-		"sendgrid": null,
-		"mailgun": null,
-		"mailjet": null,
-		"resend": null,
-		"postmark": null,
-		"ses": null,
-		"provider": "noop",
-		"circuitBreakerConfig": {
-			"name": "",
-			"circuitBreakerErrorPercentage": 0,
-			"circuitBreakerMinimumOccurrenceThreshold": 0
-		}
+		"provider": "noop"
 	},
 	"analytics": {
-		"proxySources": null,
-		"segment": null,
-		"posthog": null,
 		"provider": "noop",
 		"circuitBreaker": {
 			"name": "feature_flagger",
@@ -112,8 +70,6 @@
 		}
 	},
 	"featureFlags": {
-		"launchDarkly": null,
-		"posthog": null,
 		"provider": "noop",
 		"circuitBreakerConfig": {
 			"name": "feature_flagger",
@@ -122,27 +78,11 @@
 		}
 	},
 	"search": {
-		"algolia": null,
-		"elasticsearch": null,
 		"provider": "noop",
 		"circuitBreakerConfig": {
 			"name": "feature_flagger",
 			"circuitBreakerErrorPercentage": 0.5,
 			"circuitBreakerMinimumOccurrenceThreshold": 100
-		}
-	},
-	"auth": {
-		"sessionStore": {
-			"provider": ""
-		},
-		"passkey": {},
-		"tokens": {
-			"provider": "",
-			"issuer": "",
-			"audience": "",
-			"base64EncodedSigningKey": "",
-			"maxAccessTokenLifetime": 0,
-			"maxRefreshTokenLifetime": 0
 		}
 	},
 	"database": {
@@ -174,54 +114,22 @@
 		"maxOpenConns": 7,
 		"debug": true,
 		"logQueries": true,
-		"runMigrations": true,
-		"enableDatabaseMetrics": false
+		"runMigrations": true
 	},
 	"http": {
 		"startupDeadline": 60000000000,
 		"port": 8000
 	},
 	"idempotency": {
-		"manager": {
-			"keyPrefix": "",
-			"lock": {
-				"redis": null,
-				"postgres": null,
-				"provider": "",
-				"circuitBreakerConfig": {
-					"name": "",
-					"circuitBreakerErrorPercentage": 0,
-					"circuitBreakerMinimumOccurrenceThreshold": 0
-				}
-			},
-			"cache": {
-				"redis": null,
-				"provider": "",
-				"circuitBreakerConfig": {
-					"name": "",
-					"circuitBreakerErrorPercentage": 0,
-					"circuitBreakerMinimumOccurrenceThreshold": 0
-				},
-				"expiry": 0,
-				"janitorInterval": 0
-			},
-			"ttl": 0,
-			"inFlightTTL": 0,
-			"maxKeyLength": 0,
-			"failOpen": false
-		},
 		"enabled": false
 	},
 	"metering": {
-		"tablePrefix": "",
 		"enforcer": {
 			"cachePrefix": "metering:",
-			"staleness": 10000000000,
-			"failOpen": false
+			"staleness": 10000000000
 		},
 		"flusher": {
 			"backoff": {
-				"provider": "",
 				"maxAttempts": 10,
 				"initialDelay": 1000000000,
 				"maxDelay": 300000000000,
@@ -234,16 +142,13 @@
 			"batchSize": 100,
 			"concurrency": 4,
 			"maxAttempts": 10,
-			"reapBatchSize": 1000,
-			"disableReap": false
+			"reapBatchSize": 1000
 		},
 		"recorder": {
-			"batchSize": 100,
-			"rejectUnknownMeters": false
+			"batchSize": 100
 		}
 	},
 	"webhooks": {
-		"tablePrefix": "",
 		"circuitBreaker": {
 			"name": "webhook_delivery",
 			"circuitBreakerErrorPercentage": 0.5,
@@ -252,7 +157,6 @@
 		"worker": {
 			"userAgent": "Dinner Done Better Webhooks/1",
 			"backoff": {
-				"provider": "",
 				"maxAttempts": 10,
 				"initialDelay": 5000000000,
 				"maxDelay": 3600000000000,
@@ -272,75 +176,42 @@
 		"httpClient": {
 			"timeout": 10000000000,
 			"maxIdleConns": 100,
-			"maxIdleConnsPerHost": 100,
-			"enableTracing": false
+			"maxIdleConnsPerHost": 100
 		}
 	},
 	"services": {
 		"payments": {
-			"revenueCat": null,
 			"capitalism": {
-				"stripe": null,
 				"provider": "noop"
 			}
 		},
 		"users": {
-			"publicMediaURLPrefix": "",
 			"uploads": {
 				"storageConfig": {
 					"bucketName": "avatars",
-					"provider": "memory",
-					"circuitBreakerConfig": {
-						"name": "",
-						"circuitBreakerErrorPercentage": 0,
-						"circuitBreakerMinimumOccurrenceThreshold": 0
-					}
-				},
-				"debug": false
+					"provider": "memory"
+				}
 			}
 		},
 		"uploadedMedia": {
 			"uploads": {
 				"storageConfig": {
 					"bucketName": "avatars",
-					"provider": "memory",
-					"circuitBreakerConfig": {
-						"name": "",
-						"circuitBreakerErrorPercentage": 0,
-						"circuitBreakerMinimumOccurrenceThreshold": 0
-					}
-				},
-				"debug": false
+					"provider": "memory"
+				}
 			}
-		},
-		"mealPlanning": {
-			"mediaUploadPrefix": "",
-			"uploads": {
-				"storageConfig": {
-					"circuitBreakerConfig": {
-						"name": "",
-						"circuitBreakerErrorPercentage": 0,
-						"circuitBreakerMinimumOccurrenceThreshold": 0
-					}
-				},
-				"debug": false
-			},
-			"useSearchService": false
 		},
 		"auth": {
 			"tokens": {
 				"provider": "paseto",
 				"issuer": "dinner-done-better",
 				"audience": "https://api.dinnerdonebetter.dev",
-				"base64EncodedSigningKey": "SEVSRUlTQTMyQ0hBUlNFQ1JFVFdISUNISVNNQURFVVA=",
-				"maxAccessTokenLifetime": 0,
-				"maxRefreshTokenLifetime": 0
+				"base64EncodedSigningKey": "SEVSRUlTQTMyQ0hBUlNFQ1JFVFdISUNISVNNQURFVVA="
 			},
 			"oauth2": {
 				"domain": "http://localhost:9000",
 				"accessTokenLifespan": 3600000000000,
-				"refreshTokenLifespan": 3600000000000,
-				"debug": false
+				"refreshTokenLifespan": 3600000000000
 			},
 			"jwtLifetime": 300000000000,
 			"enableUserSignup": true,
@@ -355,62 +226,12 @@
 			"uploads": {
 				"storageConfig": {
 					"filesystem": {
-						"rootDirectory": "/tmp",
-						"directoryMode": "0o0"
+						"rootDirectory": "/tmp"
 					},
 					"bucketName": "userdata",
-					"provider": "filesystem",
-					"circuitBreakerConfig": {
-						"name": "",
-						"circuitBreakerErrorPercentage": 0,
-						"circuitBreakerMinimumOccurrenceThreshold": 0
-					}
-				},
-				"debug": false
-			},
-			"requests": {
-				"dialect": "",
-				"tablePrefix": "",
-				"auditErasure": {
-					"tablePrefix": "",
-					"retentionBasis": "",
-					"disabled": false
-				},
-				"worker": {
-					"artifactPathPrefix": "",
-					"backoff": {
-						"provider": "",
-						"maxAttempts": 0,
-						"initialDelay": 0,
-						"maxDelay": 0,
-						"multiplier": 0,
-						"useJitter": false
-					},
-					"pollInterval": 0,
-					"leaseDuration": 0,
-					"fulfillmentTimeout": 0,
-					"collectorTimeout": 0,
-					"artifactTTL": 0,
-					"maxDocumentBytes": 0,
-					"batchSize": 0,
-					"concurrency": 0,
-					"collectorConcurrency": 0
-				},
-				"service": {
-					"exportResponseWindow": 0,
-					"erasureResponseWindow": 0,
-					"confirmationWindow": 0,
-					"signedURLTTL": 0
-				},
-				"sweeper": {
-					"requestRetention": 0,
-					"batchSize": 0,
-					"disableReap": false
+					"provider": "filesystem"
 				}
 			}
-		},
-		"oauth2Clients": {
-			"creationEnabled": false
 		}
 	}
 }

--- a/backend/deploy/environments/testing/config_files/job_db_cleaner_config.json
+++ b/backend/deploy/environments/testing/config_files/job_db_cleaner_config.json
@@ -9,8 +9,7 @@
 			"provider": "slog"
 		},
 		"metrics": {
-			"serviceName": "db_cleaner",
-			"enabled": false
+			"serviceName": "db_cleaner"
 		},
 		"tracing": {
 			"service_name": "db_cleaner"
@@ -45,7 +44,6 @@
 		"maxOpenConns": 7,
 		"debug": true,
 		"logQueries": true,
-		"runMigrations": true,
-		"enableDatabaseMetrics": false
+		"runMigrations": true
 	}
 }

--- a/backend/deploy/environments/testing/config_files/job_email_deliverability_test_config.json
+++ b/backend/deploy/environments/testing/config_files/job_email_deliverability_test_config.json
@@ -1,5 +1,4 @@
 {
-	"httpClient": null,
 	"recipientEmailAddress": "verygoodsoftwarenotvirus@protonmail.com",
 	"serviceEnvironment": "testing",
 	"observability": {
@@ -12,25 +11,13 @@
 			"provider": "slog"
 		},
 		"metrics": {
-			"serviceName": "email_deliverability_test",
-			"enabled": false
+			"serviceName": "email_deliverability_test"
 		},
 		"tracing": {
 			"service_name": "email_deliverability_test"
 		}
 	},
 	"email": {
-		"sendgrid": null,
-		"mailgun": null,
-		"mailjet": null,
-		"resend": null,
-		"postmark": null,
-		"ses": null,
-		"provider": "noop",
-		"circuitBreakerConfig": {
-			"name": "",
-			"circuitBreakerErrorPercentage": 0,
-			"circuitBreakerMinimumOccurrenceThreshold": 0
-		}
+		"provider": "noop"
 	}
 }

--- a/backend/deploy/environments/testing/config_files/mcp_server_config.json
+++ b/backend/deploy/environments/testing/config_files/mcp_server_config.json
@@ -28,8 +28,7 @@
 		"maxOpenConns": 7,
 		"debug": true,
 		"logQueries": true,
-		"runMigrations": true,
-		"enableDatabaseMetrics": false
+		"runMigrations": true
 	},
 	"routing": {
 		"chiConfig": {
@@ -48,16 +47,14 @@
 			"provider": "slog"
 		},
 		"metrics": {
-			"serviceName": "dinner_done_better_mcp_server",
-			"enabled": false
+			"serviceName": "dinner_done_better_mcp_server"
 		},
 		"tracing": {
 			"service_name": "dinner_done_better_mcp_server"
 		}
 	},
 	"meta": {
-		"runMode": "testing",
-		"debug": false
+		"runMode": "testing"
 	},
 	"http": {
 		"startupDeadline": 60000000000,

--- a/backend/deploy/environments/testing/config_files/scheduler_config.json
+++ b/backend/deploy/environments/testing/config_files/scheduler_config.json
@@ -6,43 +6,20 @@
 		"mobileNotificationsTopicName": "mobile_notifications"
 	},
 	"capitalism": {
-		"stripe": null,
 		"provider": "noop"
 	},
 	"events": {
 		"consumer": {
-			"kafka": {
-				"groupId": "",
-				"brokers": null
-			},
 			"provider": "redis",
-			"sqs": {
-				"queueAddress": ""
-			},
-			"pubSub": {
-				"projectID": ""
-			},
 			"redis": {
-				"username": "",
 				"queueAddresses": [
 					"worker_queue:6379"
 				]
 			}
 		},
 		"publisher": {
-			"kafka": {
-				"groupId": "",
-				"brokers": null
-			},
 			"provider": "redis",
-			"sqs": {
-				"queueAddress": ""
-			},
-			"pubSub": {
-				"projectID": ""
-			},
 			"redis": {
-				"username": "",
 				"queueAddresses": [
 					"worker_queue:6379"
 				]
@@ -59,17 +36,13 @@
 			"provider": "slog"
 		},
 		"metrics": {
-			"serviceName": "scheduler",
-			"enabled": false
+			"serviceName": "scheduler"
 		},
 		"tracing": {
 			"service_name": "scheduler"
 		}
 	},
 	"analytics": {
-		"proxySources": null,
-		"segment": null,
-		"posthog": null,
 		"provider": "noop",
 		"circuitBreaker": {
 			"name": "feature_flagger",
@@ -78,8 +51,6 @@
 		}
 	},
 	"search": {
-		"algolia": null,
-		"elasticsearch": null,
 		"provider": "noop",
 		"circuitBreakerConfig": {
 			"name": "feature_flagger",
@@ -95,21 +66,13 @@
 			"defaultTimeout": 60000000000
 		},
 		"lock": {
-			"redis": null,
 			"postgres": {
-				"namespace": 0,
 				"connWaitTimeout": 5000000000
 			},
-			"provider": "postgres",
-			"circuitBreakerConfig": {
-				"name": "",
-				"circuitBreakerErrorPercentage": 0,
-				"circuitBreakerMinimumOccurrenceThreshold": 0
-			}
+			"provider": "postgres"
 		},
 		"searchDataIndexScheduler": {
 			"schedule": "*/10 6-11 * * *",
-			"interval": 0,
 			"timeout": 300000000000,
 			"leaseTTL": 600000000000,
 			"enabled": true,
@@ -117,22 +80,17 @@
 		},
 		"mobileNotificationScheduler": {
 			"schedule": "CRON_TZ=America/Chicago 0 8-21 * * *",
-			"interval": 0,
 			"timeout": 300000000000,
 			"leaseTTL": 600000000000,
-			"enabled": true,
-			"runOnStart": false
+			"enabled": true
 		},
 		"queueTest": {
-			"schedule": "",
 			"interval": 900000000000,
 			"timeout": 60000000000,
 			"leaseTTL": 120000000000,
-			"enabled": true,
-			"runOnStart": false
+			"enabled": true
 		},
 		"dataPrivacySweep": {
-			"schedule": "",
 			"interval": 3600000000000,
 			"timeout": 300000000000,
 			"leaseTTL": 600000000000,
@@ -141,28 +99,22 @@
 		},
 		"auditRetentionSweeper": {
 			"schedule": "17 7 * * *",
-			"interval": 0,
 			"timeout": 600000000000,
 			"leaseTTL": 1200000000000,
-			"enabled": true,
-			"runOnStart": false
+			"enabled": true
 		},
 		"meteringFlusher": {
-			"schedule": "",
 			"interval": 300000000000,
 			"timeout": 120000000000,
 			"leaseTTL": 600000000000,
-			"enabled": true,
-			"runOnStart": false
+			"enabled": true
 		},
 		"mealPlanning": {
 			"mealPlanFinalizationStarter": {
-				"schedule": "",
 				"interval": 60000000000,
 				"timeout": 120000000000,
 				"leaseTTL": 300000000000,
-				"enabled": true,
-				"runOnStart": false
+				"enabled": true
 			}
 		}
 	},
@@ -203,14 +155,11 @@
 		"maxOpenConns": 7,
 		"debug": true,
 		"logQueries": true,
-		"runMigrations": true,
-		"enableDatabaseMetrics": false
+		"runMigrations": true
 	},
 	"outbox": {
-		"tablePrefix": "",
 		"claimMode": "skip_locked",
 		"backoff": {
-			"provider": "",
 			"maxAttempts": 8,
 			"initialDelay": 1000000000,
 			"maxDelay": 60000000000,
@@ -228,7 +177,6 @@
 		"lockKeyPrefix": "saga:instance:",
 		"idempotencyKeyPrefix": "saga:",
 		"backoff": {
-			"provider": "",
 			"maxAttempts": 3,
 			"initialDelay": 1000000000,
 			"maxDelay": 60000000000,
@@ -236,7 +184,6 @@
 			"useJitter": true
 		},
 		"compensationBackoff": {
-			"provider": "",
 			"maxAttempts": 10,
 			"initialDelay": 1000000000,
 			"maxDelay": 60000000000,
@@ -252,15 +199,12 @@
 		"concurrency": 4
 	},
 	"metering": {
-		"tablePrefix": "",
 		"enforcer": {
 			"cachePrefix": "metering:",
-			"staleness": 10000000000,
-			"failOpen": false
+			"staleness": 10000000000
 		},
 		"flusher": {
 			"backoff": {
-				"provider": "",
 				"maxAttempts": 10,
 				"initialDelay": 1000000000,
 				"maxDelay": 300000000000,
@@ -273,16 +217,13 @@
 			"batchSize": 100,
 			"concurrency": 4,
 			"maxAttempts": 10,
-			"reapBatchSize": 1000,
-			"disableReap": false
+			"reapBatchSize": 1000
 		},
 		"recorder": {
-			"batchSize": 100,
-			"rejectUnknownMeters": false
+			"batchSize": 100
 		}
 	},
 	"webhooks": {
-		"tablePrefix": "",
 		"circuitBreaker": {
 			"name": "webhook_delivery",
 			"circuitBreakerErrorPercentage": 0.5,
@@ -291,7 +232,6 @@
 		"worker": {
 			"userAgent": "Dinner Done Better Webhooks/1",
 			"backoff": {
-				"provider": "",
 				"maxAttempts": 10,
 				"initialDelay": 5000000000,
 				"maxDelay": 3600000000000,
@@ -311,8 +251,7 @@
 		"httpClient": {
 			"timeout": 10000000000,
 			"maxIdleConns": 100,
-			"maxIdleConnsPerHost": 100,
-			"enableTracing": false
+			"maxIdleConnsPerHost": 100
 		}
 	},
 	"dataPrivacy": {
@@ -323,57 +262,10 @@
 		"uploads": {
 			"storageConfig": {
 				"filesystem": {
-					"rootDirectory": "/tmp",
-					"directoryMode": "0o0"
+					"rootDirectory": "/tmp"
 				},
 				"bucketName": "userdata",
-				"provider": "filesystem",
-				"circuitBreakerConfig": {
-					"name": "",
-					"circuitBreakerErrorPercentage": 0,
-					"circuitBreakerMinimumOccurrenceThreshold": 0
-				}
-			},
-			"debug": false
-		},
-		"requests": {
-			"dialect": "",
-			"tablePrefix": "",
-			"auditErasure": {
-				"tablePrefix": "",
-				"retentionBasis": "",
-				"disabled": false
-			},
-			"worker": {
-				"artifactPathPrefix": "",
-				"backoff": {
-					"provider": "",
-					"maxAttempts": 0,
-					"initialDelay": 0,
-					"maxDelay": 0,
-					"multiplier": 0,
-					"useJitter": false
-				},
-				"pollInterval": 0,
-				"leaseDuration": 0,
-				"fulfillmentTimeout": 0,
-				"collectorTimeout": 0,
-				"artifactTTL": 0,
-				"maxDocumentBytes": 0,
-				"batchSize": 0,
-				"concurrency": 0,
-				"collectorConcurrency": 0
-			},
-			"service": {
-				"exportResponseWindow": 0,
-				"erasureResponseWindow": 0,
-				"confirmationWindow": 0,
-				"signedURLTTL": 0
-			},
-			"sweeper": {
-				"requestRetention": 0,
-				"batchSize": 0,
-				"disableReap": false
+				"provider": "filesystem"
 			}
 		}
 	}

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/matcornic/hermes/v2 v2.1.0
 	github.com/modelcontextprotocol/go-sdk v1.6.1
 	github.com/pquerna/otp v1.5.0
-	github.com/primandproper/platform-go/v9 v9.0.0
+	github.com/primandproper/platform-go/v9 v9.1.0
 	github.com/samber/do/v2 v2.0.0
 	github.com/shopspring/decimal v1.4.0
 	github.com/spf13/cobra v1.10.2

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -793,8 +793,8 @@ github.com/prashantv/gostub v1.1.0 h1:BTyx3RfQjRHnUWaGF9oQos79AlQ5k8WNktv7VGvVH4
 github.com/prashantv/gostub v1.1.0/go.mod h1:A5zLQHz7ieHGG7is6LLXLz7I8+3LZzsrV0P1IAHhP5U=
 github.com/pressly/goose/v3 v3.27.3 h1:pIglVHjw99r4e/hDHHwbl9vfOsDMqUokfkXo6+n/RxA=
 github.com/pressly/goose/v3 v3.27.3/go.mod h1:Dag+xpV6o20HR2LFY1j0q6MDwc3f7vPUFDA77R+0yGY=
-github.com/primandproper/platform-go/v9 v9.0.0 h1:QyekOyQwWFCHgtNQZbbGvMmfJ3fsdvJ3u0sCSQcJ93w=
-github.com/primandproper/platform-go/v9 v9.0.0/go.mod h1:ciDoLCy69jFNwKCQLIKP+7yqbXF2oqGCFumYcJUVCwY=
+github.com/primandproper/platform-go/v9 v9.1.0 h1:I5BTiJPFObp3u24uMnKku3rGmgwvk1/AoUS6W61ePLk=
+github.com/primandproper/platform-go/v9 v9.1.0/go.mod h1:ciDoLCy69jFNwKCQLIKP+7yqbXF2oqGCFumYcJUVCwY=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/pusher/pusher-http-go/v5 v5.1.1 h1:ZLUGdLA8yXMvByafIkS47nvuXOHrYmlh4bsQvuZnYVQ=
 github.com/pusher/pusher-http-go/v5 v5.1.1/go.mod h1:Ibji4SGoUDtOy7CVRhCiEpgy+n5Xv6hSL/QqYOhmWW8=

--- a/backend/internal/authentication/config/config.go
+++ b/backend/internal/authentication/config/config.go
@@ -22,8 +22,8 @@ type (
 	TokensConfig struct {
 		tokenscfg.Config
 
-		MaxAccessTokenLifetime  time.Duration `env:"MAX_ACCESS_TOKEN_LIFETIME"  json:"maxAccessTokenLifetime"`
-		MaxRefreshTokenLifetime time.Duration `env:"MAX_REFRESH_TOKEN_LIFETIME" json:"maxRefreshTokenLifetime"`
+		MaxAccessTokenLifetime  time.Duration `env:"MAX_ACCESS_TOKEN_LIFETIME"  json:"maxAccessTokenLifetime,omitempty"`
+		MaxRefreshTokenLifetime time.Duration `env:"MAX_REFRESH_TOKEN_LIFETIME" json:"maxRefreshTokenLifetime,omitempty"`
 	}
 
 	// PasskeyConfig holds WebAuthn Relying Party configuration for passkey registration and authentication.
@@ -37,9 +37,9 @@ type (
 	// Config is our configuration.
 	Config struct {
 		_                     struct{}           `json:"-"`
-		SessionStore          webauthncfg.Config `envPrefix:"SESSION_STORE_"    json:"sessionStore"`
-		Passkey               PasskeyConfig      `envPrefix:"PASSKEY_"          json:"passkey"`
-		Tokens                TokensConfig       `envPrefix:"TOKENS_"           json:"tokens"`
+		SessionStore          webauthncfg.Config `envPrefix:"SESSION_STORE_"    json:"sessionStore,omitzero"`
+		Passkey               PasskeyConfig      `envPrefix:"PASSKEY_"          json:"passkey,omitzero"`
+		Tokens                TokensConfig       `envPrefix:"TOKENS_"           json:"tokens,omitzero"`
 		Debug                 bool               `env:"DEBUG"                   json:"debug,omitempty"`
 		EnableUserSignup      bool               `env:"ENABLE_USER_SIGNUP"      json:"enableUserSignup,omitempty"`
 		MinimumUsernameLength uint8              `env:"MINIMUM_USERNAME_LENGTH" json:"minimumUsernameLength,omitempty"`

--- a/backend/internal/authentication/webauthn/config/config.go
+++ b/backend/internal/authentication/webauthn/config/config.go
@@ -24,7 +24,7 @@ const (
 type (
 	// Config is the configuration for the WebAuthn session store.
 	Config struct {
-		Provider string `env:"PROVIDER" json:"provider"`
+		Provider string `env:"PROVIDER" json:"provider,omitempty"`
 	}
 )
 

--- a/backend/internal/config/configs.go
+++ b/backend/internal/config/configs.go
@@ -74,42 +74,46 @@ type (
 	// APIServiceConfig configures an instance of the service. It is composed of all the other setting structs.
 	APIServiceConfig struct {
 		_                 struct{}                `json:"-"`
-		HTTPClient        *httpclientcfg.Config   `envPrefix:"HTTP_CLIENT_"        json:"httpClient"`
-		Queues            queuescfg.Config        `envPrefix:"QUEUES_"             json:"queues"`
-		Routing           routingcfg.Config       `envPrefix:"ROUTING_"            json:"routing"`
-		PushNotifications notificationscfg.Config `envPrefix:"PUSH_NOTIFICATIONS_" json:"pushNotifications"`
-		Encoding          encoding.Config         `envPrefix:"ENCODING_"           json:"encoding"`
-		BaseURL           string                  `env:"BASE_URL"                  json:"baseURL"`
-		Events            msgconfig.Config        `envPrefix:"EVENTS_"             json:"events"`
-		Observability     observability.Config    `envPrefix:"OBSERVABILITY_"      json:"observability"`
-		GRPCServer        grpc.Config             `envPrefix:"GRPC_"               json:"grpc"`
-		Meta              MetaSettings            `envPrefix:"META_"               json:"meta"`
-		Email             emailcfg.Config         `envPrefix:"EMAIL_"              json:"email"`
-		Analytics         analyticscfg.Config     `envPrefix:"ANALYTICS_"          json:"analytics"`
-		FeatureFlags      featureflagscfg.Config  `envPrefix:"FEATURE_FLAGS_"      json:"featureFlags"`
-		TextSearch        textsearchcfg.Config    `envPrefix:"SEARCH_"             json:"search"`
-		Auth              authcfg.Config          `envPrefix:"AUTH_"               json:"auth"`
-		Database          dbcfg.Config            `envPrefix:"DATABASE_"           json:"database"`
-		HTTPServer        http.Config             `envPrefix:"HTTP_"               json:"http"`
+		HTTPClient        *httpclientcfg.Config   `envPrefix:"HTTP_CLIENT_"        json:"httpClient,omitempty"`
+		Queues            queuescfg.Config        `envPrefix:"QUEUES_"             json:"queues,omitzero"`
+		Routing           routingcfg.Config       `envPrefix:"ROUTING_"            json:"routing,omitzero"`
+		PushNotifications notificationscfg.Config `envPrefix:"PUSH_NOTIFICATIONS_" json:"pushNotifications,omitzero"`
+		Encoding          encoding.Config         `envPrefix:"ENCODING_"           json:"encoding,omitzero"`
+		BaseURL           string                  `env:"BASE_URL"                  json:"baseURL,omitempty"`
+		Events            msgconfig.Config        `envPrefix:"EVENTS_"             json:"events,omitzero"`
+		Observability     observability.Config    `envPrefix:"OBSERVABILITY_"      json:"observability,omitzero"`
+		GRPCServer        grpc.Config             `envPrefix:"GRPC_"               json:"grpc,omitzero"`
+		Meta              MetaSettings            `envPrefix:"META_"               json:"meta,omitzero"`
+		Email             emailcfg.Config         `envPrefix:"EMAIL_"              json:"email,omitzero"`
+		Analytics         analyticscfg.Config     `envPrefix:"ANALYTICS_"          json:"analytics,omitzero"`
+		FeatureFlags      featureflagscfg.Config  `envPrefix:"FEATURE_FLAGS_"      json:"featureFlags,omitzero"`
+		TextSearch        textsearchcfg.Config    `envPrefix:"SEARCH_"             json:"search,omitzero"`
+		Auth              authcfg.Config          `envPrefix:"AUTH_"               json:"auth,omitzero"`
+		Database          dbcfg.Config            `envPrefix:"DATABASE_"           json:"database,omitzero"`
+		HTTPServer        http.Config             `envPrefix:"HTTP_"               json:"http,omitzero"`
 
 		// Idempotency guards the mutations where running the work twice costs real money.
 		// A client that never sees a response and retries is indistinguishable from a
 		// deliberate second purchase unless it supplies a key, so this is opt-in per call:
 		// a request without the idempotency-key metadata passes through untouched.
+		// Not omitzero, and Enabled is not omitempty: a deployment with the interceptor
+		// off is exactly the zero value, so omitting it would erase the distinction
+		// between "deliberately off" and "nobody configured this" — the silent failure
+		// the Enabled comment above exists to prevent.
 		Idempotency IdempotencyConfig `envPrefix:"IDEMPOTENCY_" json:"idempotency"`
 
 		// Metering counts what an account consumes. The API server holds only the ingest
 		// half of it — the flusher that posts usage to a billing provider runs in the
 		// scheduler — but both read this same struct, so the tables one writes are by
 		// construction the tables the other flushes.
-		Metering meteringcfg.Config `envPrefix:"METERING_" json:"metering"`
+		Metering meteringcfg.Config `envPrefix:"METERING_" json:"metering,omitzero"`
 
 		// Webhooks configures the outbound webhook tables this service writes into. Only the
 		// write side lives here: dispatch rows are written inside the transactions that
 		// caused them, and the worker that delivers them runs in the scheduler.
-		Webhooks webhookscfg.Config `envPrefix:"WEBHOOKS_" json:"webhooks"`
+		Webhooks webhookscfg.Config `envPrefix:"WEBHOOKS_" json:"webhooks,omitzero"`
 
-		Services ServicesConfig `envPrefix:"SERVICE_" json:"services"`
+		Services ServicesConfig `envPrefix:"SERVICE_" json:"services,omitzero"`
 
 		validateServices bool
 	}
@@ -119,7 +123,7 @@ type (
 	IdempotencyConfig struct {
 		_ struct{} `json:"-"`
 
-		Manager idempotencycfg.Config `envPrefix:"MANAGER_" json:"manager"`
+		Manager idempotencycfg.Config `envPrefix:"MANAGER_" json:"manager,omitzero"`
 
 		// Enabled installs the interceptor.
 		//
@@ -138,27 +142,27 @@ type (
 	DBCleanerConfig struct {
 		_ struct{} `json:"-"`
 
-		Observability observability.Config `envPrefix:"OBSERVABILITY_" json:"observability"`
+		Observability observability.Config `envPrefix:"OBSERVABILITY_" json:"observability,omitzero"`
 
-		Database dbcfg.Config `envPrefix:"DATABASE_" json:"database"`
+		Database dbcfg.Config `envPrefix:"DATABASE_" json:"database,omitzero"`
 	}
 
 	// AsyncMessageHandlerConfig configures an instance of the search data index scheduler job.
 	AsyncMessageHandlerConfig struct {
 		_          struct{}              `json:"-"`
-		HTTPClient *httpclientcfg.Config `envPrefix:"HTTP_CLIENT_" json:"httpClient"`
-		Queues     queuescfg.Config      `envPrefix:"QUEUES_"      json:"queues"`
+		HTTPClient *httpclientcfg.Config `envPrefix:"HTTP_CLIENT_" json:"httpClient,omitempty"`
+		Queues     queuescfg.Config      `envPrefix:"QUEUES_"      json:"queues,omitzero"`
 
-		PushNotifications notificationscfg.Config `envPrefix:"PUSH_NOTIFICATIONS_" json:"pushNotifications"`
-		Encoding          encoding.Config         `envPrefix:"ENCODING_"           json:"encoding"`
-		BaseURL           string                  `env:"BASE_URL"                  json:"baseURL"`
-		Events            msgconfig.Config        `envPrefix:"EVENTS_"             json:"events"`
-		Observability     observability.Config    `envPrefix:"OBSERVABILITY_"      json:"observability"`
-		Email             emailcfg.Config         `envPrefix:"EMAIL_"              json:"email"`
-		Analytics         analyticscfg.Config     `envPrefix:"ANALYTICS_"          json:"analytics"`
-		Search            textsearchcfg.Config    `envPrefix:"SEARCH_"             json:"search"`
-		Database          dbcfg.Config            `envPrefix:"DATABASE_"           json:"database"`
-		Pools             WorkerPoolsConfig       `envPrefix:"POOLS_"              json:"pools"`
+		PushNotifications notificationscfg.Config `envPrefix:"PUSH_NOTIFICATIONS_" json:"pushNotifications,omitzero"`
+		Encoding          encoding.Config         `envPrefix:"ENCODING_"           json:"encoding,omitzero"`
+		BaseURL           string                  `env:"BASE_URL"                  json:"baseURL,omitempty"`
+		Events            msgconfig.Config        `envPrefix:"EVENTS_"             json:"events,omitzero"`
+		Observability     observability.Config    `envPrefix:"OBSERVABILITY_"      json:"observability,omitzero"`
+		Email             emailcfg.Config         `envPrefix:"EMAIL_"              json:"email,omitzero"`
+		Analytics         analyticscfg.Config     `envPrefix:"ANALYTICS_"          json:"analytics,omitzero"`
+		Search            textsearchcfg.Config    `envPrefix:"SEARCH_"             json:"search,omitzero"`
+		Database          dbcfg.Config            `envPrefix:"DATABASE_"           json:"database,omitzero"`
+		Pools             WorkerPoolsConfig       `envPrefix:"POOLS_"              json:"pools,omitzero"`
 	}
 
 	// WorkerPoolsConfig configures the jobs.Pool draining each queue topic. Topics are not
@@ -170,32 +174,32 @@ type (
 		// DeadLetterTopicName is where a message goes once it has exhausted its attempts.
 		// Without it jobs.Pool has no terminal destination and silently drops exhausted
 		// messages, so it is required rather than defaulted.
-		DeadLetterTopicName string `env:"DEAD_LETTER_TOPIC_NAME" json:"deadLetterTopicName"`
+		DeadLetterTopicName string `env:"DEAD_LETTER_TOPIC_NAME" json:"deadLetterTopicName,omitempty"`
 
-		DataChanges         jobs.PoolConfig `envPrefix:"DATA_CHANGES_"          json:"dataChanges"`
-		OutboundEmails      jobs.PoolConfig `envPrefix:"OUTBOUND_EMAILS_"       json:"outboundEmails"`
-		SearchIndexRequests jobs.PoolConfig `envPrefix:"SEARCH_INDEX_REQUESTS_" json:"searchIndexRequests"`
-		MobileNotifications jobs.PoolConfig `envPrefix:"MOBILE_NOTIFICATIONS_"  json:"mobileNotifications"`
+		DataChanges         jobs.PoolConfig `envPrefix:"DATA_CHANGES_"          json:"dataChanges,omitzero"`
+		OutboundEmails      jobs.PoolConfig `envPrefix:"OUTBOUND_EMAILS_"       json:"outboundEmails,omitzero"`
+		SearchIndexRequests jobs.PoolConfig `envPrefix:"SEARCH_INDEX_REQUESTS_" json:"searchIndexRequests,omitzero"`
+		MobileNotifications jobs.PoolConfig `envPrefix:"MOBILE_NOTIFICATIONS_"  json:"mobileNotifications,omitzero"`
 	}
 
 	// EmailDeliverabilityTestConfig configures the email deliverability test cron job.
 	EmailDeliverabilityTestConfig struct {
 		_                     struct{}              `json:"-"`
-		HTTPClient            *httpclientcfg.Config `envPrefix:"HTTP_CLIENT_"      json:"httpClient"`
-		RecipientEmailAddress string                `env:"RECIPIENT_EMAIL_ADDRESS" json:"recipientEmailAddress"`
-		ServiceEnvironment    string                `env:"SERVICE_ENVIRONMENT"     json:"serviceEnvironment"`
-		Observability         observability.Config  `envPrefix:"OBSERVABILITY_"    json:"observability"`
-		Email                 emailcfg.Config       `envPrefix:"EMAIL_"            json:"email"`
+		HTTPClient            *httpclientcfg.Config `envPrefix:"HTTP_CLIENT_"      json:"httpClient,omitempty"`
+		RecipientEmailAddress string                `env:"RECIPIENT_EMAIL_ADDRESS" json:"recipientEmailAddress,omitempty"`
+		ServiceEnvironment    string                `env:"SERVICE_ENVIRONMENT"     json:"serviceEnvironment,omitempty"`
+		Observability         observability.Config  `envPrefix:"OBSERVABILITY_"    json:"observability,omitzero"`
+		Email                 emailcfg.Config       `envPrefix:"EMAIL_"            json:"email,omitzero"`
 	}
 
 	// MCPServiceConfig configures an instance of the service. It is composed of all the other setting structs.
 	MCPServiceConfig struct {
 		_             struct{}             `json:"-"`
-		Database      dbcfg.Config         `envPrefix:"DATABASE_"      json:"database"`
-		Routing       routingcfg.Config    `envPrefix:"ROUTING_"       json:"routing"`
-		Observability observability.Config `envPrefix:"OBSERVABILITY_" json:"observability"`
-		Meta          MetaSettings         `envPrefix:"META_"          json:"meta"`
-		HTTPServer    http.Config          `envPrefix:"HTTP_"          json:"http"`
+		Database      dbcfg.Config         `envPrefix:"DATABASE_"      json:"database,omitzero"`
+		Routing       routingcfg.Config    `envPrefix:"ROUTING_"       json:"routing,omitzero"`
+		Observability observability.Config `envPrefix:"OBSERVABILITY_" json:"observability,omitzero"`
+		Meta          MetaSettings         `envPrefix:"META_"          json:"meta,omitzero"`
+		HTTPServer    http.Config          `envPrefix:"HTTP_"          json:"http,omitzero"`
 	}
 )
 

--- a/backend/internal/config/mealplanning_configs.go
+++ b/backend/internal/config/mealplanning_configs.go
@@ -22,7 +22,7 @@ type (
 		// list. It only claims plans and writes a saga instance for each; the saga worker does
 		// the pipeline, so this interval is the delay before a plan enters the pipeline rather
 		// than the delay before it comes out the other end.
-		MealPlanFinalizationStarter ScheduledJobConfig `envPrefix:"MEAL_PLAN_FINALIZATION_STARTER_" json:"mealPlanFinalizationStarter"`
+		MealPlanFinalizationStarter ScheduledJobConfig `envPrefix:"MEAL_PLAN_FINALIZATION_STARTER_" json:"mealPlanFinalizationStarter,omitzero"`
 	}
 )
 

--- a/backend/internal/config/meta.go
+++ b/backend/internal/config/meta.go
@@ -8,8 +8,8 @@ import (
 
 // MetaSettings is primarily used for development.
 type MetaSettings struct {
-	RunMode runMode `env:"RUN_MODE" json:"runMode"`
-	Debug   bool    `env:"DEBUG"    json:"debug"`
+	RunMode runMode `env:"RUN_MODE" json:"runMode,omitempty"`
+	Debug   bool    `env:"DEBUG"    json:"debug,omitempty"`
 }
 
 var _ validation.ValidatableWithContext = (*MetaSettings)(nil)

--- a/backend/internal/config/scheduler.go
+++ b/backend/internal/config/scheduler.go
@@ -38,45 +38,45 @@ type (
 	SchedulerConfig struct {
 		_ struct{} `json:"-"`
 
-		Queues queuescfg.Config `envPrefix:"QUEUES_" json:"queues"`
+		Queues queuescfg.Config `envPrefix:"QUEUES_" json:"queues,omitzero"`
 
 		// Capitalism is where the flusher's usage reporter comes from. It lives in this
 		// process rather than the API server's because usage reporting happens on a
 		// scheduler tick, and a request path has no business holding the credentials for
 		// it. A provider of "noop" is a supported deployment and the current one: usage
 		// accumulates durably and nothing reaches a billing provider.
-		Capitalism    capitalismcfg.Config `envPrefix:"CAPITALISM_"    json:"capitalism"`
-		Events        msgconfig.Config     `envPrefix:"EVENTS_"        json:"events"`
-		Observability observability.Config `envPrefix:"OBSERVABILITY_" json:"observability"`
-		Analytics     analyticscfg.Config  `envPrefix:"ANALYTICS_"     json:"analytics"`
-		Search        textsearchcfg.Config `envPrefix:"SEARCH_"        json:"search"`
+		Capitalism    capitalismcfg.Config `envPrefix:"CAPITALISM_"    json:"capitalism,omitzero"`
+		Events        msgconfig.Config     `envPrefix:"EVENTS_"        json:"events,omitzero"`
+		Observability observability.Config `envPrefix:"OBSERVABILITY_" json:"observability,omitzero"`
+		Analytics     analyticscfg.Config  `envPrefix:"ANALYTICS_"     json:"analytics,omitzero"`
+		Search        textsearchcfg.Config `envPrefix:"SEARCH_"        json:"search,omitzero"`
 
-		Jobs ScheduledJobsConfig `envPrefix:"JOBS_" json:"jobs"`
+		Jobs ScheduledJobsConfig `envPrefix:"JOBS_" json:"jobs,omitzero"`
 
 		// Audit carries the retention window for the audit log. It lives here for the
 		// same reason the outbox does — the sweeper is a background loop over the
 		// database — and it runs in exactly one process, unlike the Recorder, which runs
 		// wherever a mutation does.
-		Audit    audit.SweeperConfig `envPrefix:"AUDIT_"    json:"audit"`
-		Database dbcfg.Config        `envPrefix:"DATABASE_" json:"database"`
+		Audit    audit.SweeperConfig `envPrefix:"AUDIT_"    json:"audit,omitzero"`
+		Database dbcfg.Config        `envPrefix:"DATABASE_" json:"database,omitzero"`
 
 		// Outbox moves events written inside a caller's transaction onto the broker. It
 		// lives here because it is a background loop, which is what this process is for,
 		// and because it needs exactly what this process already has: the database and a
 		// publisher provider.
-		Outbox outbox.RelayConfig `envPrefix:"OUTBOX_" json:"outbox"`
+		Outbox outbox.RelayConfig `envPrefix:"OUTBOX_" json:"outbox,omitzero"`
 
 		// Sagas advances every durable saga instance this build knows how to run. It is the
 		// other half of the scheduled jobs that start them: a job writes an instance, this
 		// loop steps it through, and it polls in seconds rather than minutes because the
 		// poll interval is the floor on how long a step's delay costs.
-		Sagas saga.WorkerConfig `envPrefix:"SAGAS_" json:"sagas"`
+		Sagas saga.WorkerConfig `envPrefix:"SAGAS_" json:"sagas,omitzero"`
 
 		// Metering is the same struct the API server carries, because the flusher has to
 		// read the tables the API server's recorder wrote. Only the flusher half is used
 		// here; the recorder and enforcer knobs are carried anyway so the table prefix
 		// cannot drift between the process that counts and the process that bills.
-		Metering meteringcfg.Config `envPrefix:"METERING_" json:"metering"`
+		Metering meteringcfg.Config `envPrefix:"METERING_" json:"metering,omitzero"`
 
 		// Webhooks configures the outbound webhook delivery worker, which lives here for
 		// the same reasons the outbox relay does: it is a polling loop that must not be
@@ -84,7 +84,7 @@ type (
 		//
 		// Its own tick also reaps delivered dispatches and their attempts past the
 		// retention window, so retention needs no separate scheduled job.
-		Webhooks webhookscfg.Config `envPrefix:"WEBHOOKS_" json:"webhooks"`
+		Webhooks webhookscfg.Config `envPrefix:"WEBHOOKS_" json:"webhooks,omitzero"`
 
 		// DataPrivacy configures the fulfillment worker and the expiry sweep, both of
 		// which run here: the request table, the artifact bucket, and the cipher. It is
@@ -95,7 +95,7 @@ type (
 		// The async message handler no longer carries it. It stopped touching artifacts
 		// when aggregation moved off the queue, and a process holding an encryption key it
 		// has no use for is exposure with nothing on the other side of it.
-		DataPrivacy dataprivacycfg.Config `envPrefix:"DATA_PRIVACY_" json:"dataPrivacy"`
+		DataPrivacy dataprivacycfg.Config `envPrefix:"DATA_PRIVACY_" json:"dataPrivacy,omitzero"`
 	}
 
 	// ScheduledJobsConfig carries the scheduler's own knobs, the lock backend that serializes
@@ -103,22 +103,22 @@ type (
 	ScheduledJobsConfig struct {
 		_ struct{} `json:"-"`
 
-		Scheduler jobs.SchedulerConfig `envPrefix:"SCHEDULER_" json:"scheduler"`
+		Scheduler jobs.SchedulerConfig `envPrefix:"SCHEDULER_" json:"scheduler,omitzero"`
 
 		// Lock decides which replica runs a given tick. The noop locker acquires
 		// unconditionally, which means every replica runs every job — right for a
 		// single-replica deployment, wrong the moment it scales.
-		Lock distributedlockcfg.Config `envPrefix:"LOCK_" json:"lock"`
+		Lock distributedlockcfg.Config `envPrefix:"LOCK_" json:"lock,omitzero"`
 
-		SearchDataIndexScheduler    ScheduledJobConfig `envPrefix:"SEARCH_DATA_INDEX_SCHEDULER_"   json:"searchDataIndexScheduler"`
-		MobileNotificationScheduler ScheduledJobConfig `envPrefix:"MOBILE_NOTIFICATION_SCHEDULER_" json:"mobileNotificationScheduler"`
-		QueueTest                   ScheduledJobConfig `envPrefix:"QUEUE_TEST_"                    json:"queueTest"`
+		SearchDataIndexScheduler    ScheduledJobConfig `envPrefix:"SEARCH_DATA_INDEX_SCHEDULER_"   json:"searchDataIndexScheduler,omitzero"`
+		MobileNotificationScheduler ScheduledJobConfig `envPrefix:"MOBILE_NOTIFICATION_SCHEDULER_" json:"mobileNotificationScheduler,omitzero"`
+		QueueTest                   ScheduledJobConfig `envPrefix:"QUEUE_TEST_"                    json:"queueTest,omitzero"`
 
 		// DataPrivacySweep expires export artifacts, lapses unconfirmed erasures, and
 		// samples the overdue gauge. Disabling it does not pause expiry so much as
 		// abandon it: every artifact ever written — each one everything the system knows
 		// about one person — stays in the bucket and nothing else will ever delete it.
-		DataPrivacySweep ScheduledJobConfig `envPrefix:"DATA_PRIVACY_SWEEP_" json:"dataPrivacySweep"`
+		DataPrivacySweep ScheduledJobConfig `envPrefix:"DATA_PRIVACY_SWEEP_" json:"dataPrivacySweep,omitzero"`
 
 		// AuditRetentionSweeper prunes audit entries past the retention window in
 		// SchedulerConfig.Audit. Disabling it does not pause retention so much as
@@ -129,16 +129,16 @@ type (
 		// Sweeper is safe to run concurrently — it prunes a prefix of a chain inside a
 		// transaction — but every replica sweeping every hour is the same work done
 		// several times for one result, and it is work that deletes.
-		AuditRetentionSweeper ScheduledJobConfig `envPrefix:"AUDIT_RETENTION_SWEEPER_" json:"auditRetentionSweeper"`
+		AuditRetentionSweeper ScheduledJobConfig `envPrefix:"AUDIT_RETENTION_SWEEPER_" json:"auditRetentionSweeper,omitzero"`
 		// MeteringFlusher posts accumulated usage to the billing provider and reaps the
 		// usage event ledger past its retention. Disabling it stops neither the counting
 		// nor the totals it feeds — the recorder is in the API server — but the event
 		// ledger then grows without bound.
-		MeteringFlusher ScheduledJobConfig `envPrefix:"METERING_FLUSHER_" json:"meteringFlusher"`
+		MeteringFlusher ScheduledJobConfig `envPrefix:"METERING_FLUSHER_" json:"meteringFlusher,omitzero"`
 
 		// Domain: mealplanning — swapping the domain replaces this field and the type it
 		// names, and touches nothing else in this struct.
-		MealPlanning MealPlanningScheduledJobsConfig `envPrefix:"MEAL_PLANNING_" json:"mealPlanning"`
+		MealPlanning MealPlanningScheduledJobsConfig `envPrefix:"MEAL_PLANNING_" json:"mealPlanning,omitzero"`
 	}
 
 	// ScheduledJobConfig is one job's schedule. Exactly one of Schedule and Interval is set:
@@ -157,19 +157,19 @@ type (
 		//
 		// There is no catch-up. A fire time that passes while the process is down, or while
 		// the previous run is still going, is skipped rather than queued.
-		Schedule string `env:"SCHEDULE" json:"schedule"`
+		Schedule string `env:"SCHEDULE" json:"schedule,omitempty"`
 
 		// Interval is how often the job fires. Ticks are not queued: a job that overruns its
 		// interval fires again as soon as it finishes rather than accumulating a backlog.
-		Interval time.Duration `env:"INTERVAL" json:"interval"`
+		Interval time.Duration `env:"INTERVAL" json:"interval,omitempty"`
 
 		// Timeout bounds one execution.
-		Timeout time.Duration `env:"TIMEOUT" json:"timeout"`
+		Timeout time.Duration `env:"TIMEOUT" json:"timeout,omitempty"`
 
 		// LeaseTTL is how long the lock is held. It is not renewed while the job runs, so it
 		// must comfortably exceed the job's worst-case duration — past it, a second replica
 		// may start the same job.
-		LeaseTTL time.Duration `env:"LEASE_TTL" json:"leaseTTL"`
+		LeaseTTL time.Duration `env:"LEASE_TTL" json:"leaseTTL,omitempty"`
 
 		// Enabled registers the job. A disabled job is not registered at all rather than
 		// registered and skipped, so it costs nothing and reports nothing.
@@ -177,7 +177,7 @@ type (
 
 		// RunOnStart fires the job once at startup instead of waiting a full interval or for
 		// the schedule's next fire time.
-		RunOnStart bool `env:"RUN_ON_START" json:"runOnStart"`
+		RunOnStart bool `env:"RUN_ON_START" json:"runOnStart,omitempty"`
 	}
 )
 

--- a/backend/internal/config/services_config.go
+++ b/backend/internal/config/services_config.go
@@ -20,13 +20,13 @@ type (
 	ServicesConfig struct {
 		_ struct{} `json:"-"`
 
-		Payments      paymentscfg.Config      `envPrefix:"PAYMENTS_"       json:"payments"`
-		Users         identitycfg.Config      `envPrefix:"USERS_"          json:"users"`
-		UploadedMedia uploadedmediacfg.Config `envPrefix:"UPLOADED_MEDIA_" json:"uploadedMedia"`
-		MealPlanning  mealplanningcfg.Config  `envPrefix:"MEAL_PLANNING_"  json:"mealPlanning"`
-		Auth          authentication.Config   `envPrefix:"AUTH_"           json:"auth"`
-		DataPrivacy   dataprivacycfg.Config   `envPrefix:"DATA_PRIVACY_"   json:"dataPrivacy"`
-		OAuth2Clients oauthcfg.Config         `envPrefix:"OAUTH2_CLIENTS_" json:"oauth2Clients"`
+		Payments      paymentscfg.Config      `envPrefix:"PAYMENTS_"       json:"payments,omitzero"`
+		Users         identitycfg.Config      `envPrefix:"USERS_"          json:"users,omitzero"`
+		UploadedMedia uploadedmediacfg.Config `envPrefix:"UPLOADED_MEDIA_" json:"uploadedMedia,omitzero"`
+		MealPlanning  mealplanningcfg.Config  `envPrefix:"MEAL_PLANNING_"  json:"mealPlanning,omitzero"`
+		Auth          authentication.Config   `envPrefix:"AUTH_"           json:"auth,omitzero"`
+		DataPrivacy   dataprivacycfg.Config   `envPrefix:"DATA_PRIVACY_"   json:"dataPrivacy,omitzero"`
+		OAuth2Clients oauthcfg.Config         `envPrefix:"OAUTH2_CLIENTS_" json:"oauth2Clients,omitzero"`
 	}
 )
 

--- a/backend/internal/database/config/config.go
+++ b/backend/internal/database/config/config.go
@@ -16,9 +16,9 @@ import (
 // Config is the database configuration.
 type Config struct {
 	// Encryption selects the cipher used for at-rest encryption of OAuth2 tokens.
-	Encryption encryptioncfg.Config `envPrefix:"ENCRYPTION_" json:"encryption"`
+	Encryption encryptioncfg.Config `envPrefix:"ENCRYPTION_" json:"encryption,omitzero"`
 
 	// OAuth2TokenEncryptionKey is the key OAuth2 client tokens are encrypted with.
-	OAuth2TokenEncryptionKey string `env:"OAUTH2_TOKEN_ENCRYPTION_KEY" json:"oauth2TokenEncryptionKey"`
+	OAuth2TokenEncryptionKey string `env:"OAUTH2_TOKEN_ENCRYPTION_KEY" json:"oauth2TokenEncryptionKey,omitempty"`
 	databasecfg.Config
 }

--- a/backend/internal/queues/config/config.go
+++ b/backend/internal/queues/config/config.go
@@ -18,10 +18,10 @@ type (
 	Config struct {
 		_ struct{} `json:"-" yaml:"-"`
 
-		DataChangesTopicName         string `env:"DATA_CHANGES_TOPIC_NAME"          json:"dataChangesTopicName"         yaml:"dataChangesTopicName"`
-		OutboundEmailsTopicName      string `env:"OUTBOUND_EMAILS_TOPIC_NAME"       json:"outboundEmailsTopicName"      yaml:"outboundEmailsTopicName"`
-		SearchIndexRequestsTopicName string `env:"SEARCH_INDEX_REQUESTS_TOPIC_NAME" json:"searchIndexRequestsTopicName" yaml:"searchIndexRequestsTopicName"`
-		MobileNotificationsTopicName string `env:"MOBILE_NOTIFICATIONS_TOPIC_NAME"  json:"mobileNotificationsTopicName" yaml:"mobileNotificationsTopicName"`
+		DataChangesTopicName         string `env:"DATA_CHANGES_TOPIC_NAME"          json:"dataChangesTopicName,omitempty"         yaml:"dataChangesTopicName,omitempty"`
+		OutboundEmailsTopicName      string `env:"OUTBOUND_EMAILS_TOPIC_NAME"       json:"outboundEmailsTopicName,omitempty"      yaml:"outboundEmailsTopicName,omitempty"`
+		SearchIndexRequestsTopicName string `env:"SEARCH_INDEX_REQUESTS_TOPIC_NAME" json:"searchIndexRequestsTopicName,omitempty" yaml:"searchIndexRequestsTopicName,omitempty"`
+		MobileNotificationsTopicName string `env:"MOBILE_NOTIFICATIONS_TOPIC_NAME"  json:"mobileNotificationsTopicName,omitempty" yaml:"mobileNotificationsTopicName,omitempty"`
 	}
 )
 

--- a/backend/internal/services/auth/handlers/authentication/config.go
+++ b/backend/internal/services/auth/handlers/authentication/config.go
@@ -14,9 +14,9 @@ type (
 	Config struct {
 		_ struct{} `json:"-"`
 
-		Tokens                authcfg.TokensConfig `envPrefix:"TOKENS_"           json:"tokens"`
-		OAuth2                OAuth2Config         `envPrefix:"OAUTH2"            json:"oauth2"`
-		TokenLifetime         time.Duration        `env:"JWT_LIFETIME"            json:"jwtLifetime"`
+		Tokens                authcfg.TokensConfig `envPrefix:"TOKENS_"           json:"tokens,omitzero"`
+		OAuth2                OAuth2Config         `envPrefix:"OAUTH2"            json:"oauth2,omitzero"`
+		TokenLifetime         time.Duration        `env:"JWT_LIFETIME"            json:"jwtLifetime,omitempty"`
 		Debug                 bool                 `env:"DEBUG"                   json:"debug,omitempty"`
 		EnableUserSignup      bool                 `env:"ENABLE_USER_SIGNUP"      json:"enableUserSignup,omitempty"`
 		MinimumUsernameLength uint8                `env:"MINIMUM_USERNAME_LENGTH" json:"minimumUsernameLength,omitempty"`
@@ -39,10 +39,10 @@ func (cfg *Config) ValidateWithContext(ctx context.Context) error {
 type OAuth2Config struct {
 	_ struct{} `json:"-"`
 
-	Domain               string        `env:"DOMAIN"                 json:"domain"`
-	AccessTokenLifespan  time.Duration `env:"ACCESS_TOKEN_LIFESPAN"  json:"accessTokenLifespan"`
-	RefreshTokenLifespan time.Duration `env:"REFRESH_TOKEN_LIFESPAN" json:"refreshTokenLifespan"`
-	Debug                bool          `env:"DEBUG"                  json:"debug"`
+	Domain               string        `env:"DOMAIN"                 json:"domain,omitempty"`
+	AccessTokenLifespan  time.Duration `env:"ACCESS_TOKEN_LIFESPAN"  json:"accessTokenLifespan,omitempty"`
+	RefreshTokenLifespan time.Duration `env:"REFRESH_TOKEN_LIFESPAN" json:"refreshTokenLifespan,omitempty"`
+	Debug                bool          `env:"DEBUG"                  json:"debug,omitempty"`
 }
 
 var _ validation.ValidatableWithContext = (*OAuth2Config)(nil)

--- a/backend/internal/services/dataprivacy/config/config.go
+++ b/backend/internal/services/dataprivacy/config/config.go
@@ -41,7 +41,7 @@ type Config struct {
 	// Encryption selects the cipher used for at-rest encryption of disclosure artifacts. A
 	// disclosure artifact is everything the system knows about one person in a single object,
 	// so it is never written in the clear.
-	Encryption encryptioncfg.Config `envPrefix:"ENCRYPTION_" json:"encryption"`
+	Encryption encryptioncfg.Config `envPrefix:"ENCRYPTION_" json:"encryption,omitzero"`
 
 	// ArtifactEncryptionKey is the key disclosure artifacts are encrypted with. Rotating it
 	// makes every artifact written under the old key unreadable — which for objects that expire
@@ -51,9 +51,9 @@ type Config struct {
 	// config for a real environment carries a blank secret and takes the value from the
 	// environment. An empty key is caught where it matters instead, when the machinery is
 	// constructed at startup.
-	ArtifactEncryptionKey string `env:"ARTIFACT_ENCRYPTION_KEY" json:"artifactEncryptionKey"`
+	ArtifactEncryptionKey string `env:"ARTIFACT_ENCRYPTION_KEY" json:"artifactEncryptionKey,omitempty"`
 
-	Uploads uploadscfg.Config `envPrefix:"UPLOADS_" json:"uploads"`
+	Uploads uploadscfg.Config `envPrefix:"UPLOADS_" json:"uploads,omitzero"`
 
 	// Requests carries the platform's own knobs: the response windows a deadline is
 	// stamped from, the confirmation window, the artifact TTL, and the fulfillment
@@ -63,7 +63,7 @@ type Config struct {
 	// see prepare in do.go. Neither has a second legal value, and a deployment that
 	// set one differently would not be configuring anything, it would be pointing the
 	// Store at a table that does not exist.
-	Requests platformdataprivacycfg.Config `envPrefix:"REQUESTS_" json:"requests"`
+	Requests platformdataprivacycfg.Config `envPrefix:"REQUESTS_" json:"requests,omitzero"`
 }
 
 var _ validation.ValidatableWithContext = (*Config)(nil)

--- a/backend/internal/services/identity/config/config.go
+++ b/backend/internal/services/identity/config/config.go
@@ -12,8 +12,8 @@ import (
 type Config struct {
 	_ struct{} `json:"-"`
 
-	PublicMediaURLPrefix string            `env:"PUBLIC_MEDIA_URL_PREFIX" json:"publicMediaURLPrefix"`
-	Uploads              uploadscfg.Config `envPrefix:"UPLOADS_"          json:"uploads"`
+	PublicMediaURLPrefix string            `env:"PUBLIC_MEDIA_URL_PREFIX" json:"publicMediaURLPrefix,omitempty"`
+	Uploads              uploadscfg.Config `envPrefix:"UPLOADS_"          json:"uploads,omitzero"`
 }
 
 var _ validation.ValidatableWithContext = (*Config)(nil)

--- a/backend/internal/services/mealplanning/config/config.go
+++ b/backend/internal/services/mealplanning/config/config.go
@@ -12,9 +12,9 @@ import (
 type Config struct {
 	_ struct{} `json:"-"`
 
-	PublicMediaURLPrefix string            `env:"PUBLIC_MEDIA_URL_PREFIX" json:"mediaUploadPrefix"`
-	Uploads              uploadscfg.Config `envPrefix:"UPLOADS_"          json:"uploads"`
-	UseSearchService     bool              `env:"USE_SEARCH_SERVICE"      json:"useSearchService"`
+	PublicMediaURLPrefix string            `env:"PUBLIC_MEDIA_URL_PREFIX" json:"mediaUploadPrefix,omitempty"`
+	Uploads              uploadscfg.Config `envPrefix:"UPLOADS_"          json:"uploads,omitzero"`
+	UseSearchService     bool              `env:"USE_SEARCH_SERVICE"      json:"useSearchService,omitempty"`
 }
 
 var _ validation.ValidatableWithContext = (*Config)(nil)

--- a/backend/internal/services/payments/config/config.go
+++ b/backend/internal/services/payments/config/config.go
@@ -11,12 +11,12 @@ import (
 // RevenueCat stays ours: mobile in-app purchases aren't something capitalism models, and
 // its webhooks are a different shape entirely.
 type Config struct {
-	RevenueCat *RevenueCatConfig    `env:"init"              envPrefix:"REVENUECAT_" json:"revenueCat"`
-	Capitalism capitalismcfg.Config `envPrefix:"CAPITALISM_" json:"capitalism"`
+	RevenueCat *RevenueCatConfig    `env:"init"              envPrefix:"REVENUECAT_"    json:"revenueCat,omitempty"`
+	Capitalism capitalismcfg.Config `envPrefix:"CAPITALISM_" json:"capitalism,omitzero"`
 }
 
 // RevenueCatConfig holds RevenueCat-specific configuration.
 type RevenueCatConfig struct {
-	APIKey            string `env:"API_KEY"             json:"apiKey"`
-	WebhookAuthHeader string `env:"WEBHOOK_AUTH_HEADER" json:"webhookAuthHeader"`
+	APIKey            string `env:"API_KEY"             json:"apiKey,omitempty"`
+	WebhookAuthHeader string `env:"WEBHOOK_AUTH_HEADER" json:"webhookAuthHeader,omitempty"`
 }

--- a/backend/internal/services/uploadedmedia/config/config.go
+++ b/backend/internal/services/uploadedmedia/config/config.go
@@ -12,7 +12,7 @@ import (
 type Config struct {
 	_ struct{} `json:"-"`
 
-	Uploads uploadscfg.Config `envPrefix:"UPLOADS_" json:"uploads"`
+	Uploads uploadscfg.Config `envPrefix:"UPLOADS_" json:"uploads,omitzero"`
 }
 
 var _ validation.ValidatableWithContext = (*Config)(nil)


### PR DESCRIPTION
Closes #1246.

Adopts platform-go **v9.1.0** (primandproper/platform-go#72) and finishes the sweep across the config structs this repo owns.

## Result

| file | before | after |
|---|---|---|
| `prod/kustomize/configs/api_service_config.json` | 499 | 329 |
| `localdev/config_files/api_service_config.json` | 463 | 290 |

1474 lines out of the generated configs overall. The `events` block is the clearest case — four fully-populated provider blocks collapse to the one `provider` actually names.

## Why struct fields use `omitzero`

`encoding/json`'s `omitempty` covers false, 0, nil pointers, and empty strings/slices/maps — a struct is none of those, so `json:"kafka,omitempty"` on a sub-config renders it in full regardless of the tag. That's why the dead provider blocks survived tags that looked correct. Struct-typed fields get `omitzero` (Go 1.24+); everything else gets `omitempty`.

## Deliberate off-switches, left visible

Three fields keep rendering their zero value — for these a `false` is a decision, and a config that stops showing it can't be told apart from one nobody thought about:

- **`APIServiceConfig.Idempotency` + `IdempotencyConfig.Enabled`.** The `Enabled` doc comment already says the failure mode of getting this wrong is silent, and it's off in prod on purpose. The **parent** field is excluded too — an off deployment is exactly the zero struct, so `omitzero` there silently erased the leaf carve-out by omitting the whole block. Caught that in review of the generated output; prod renders `"enabled": false` again.
- **`ScheduledJobConfig.Enabled`.** A disabled job isn't registered at all, so which jobs are deliberately off is the scheduler config's most load-bearing fact.
- **`oauth.Config.OAuth2ClientCreationDisabled`** — see below.

## Found along the way: the oauth flag is inverted

```go
OAuth2ClientCreationDisabled bool `env:"CREATION_DISABLED" json:"creationEnabled"`
```

The field says `Disabled`, the JSON key says `creationEnabled`. Prod currently renders `"creationEnabled": true`, which actually **disables** OAuth2 client creation. Anyone reading that config concludes the opposite of what's configured.

Left it out of the sweep rather than making an already-misleading key intermittently absent. Not fixed here — renaming the key is a config-breaking change that deserves its own PR. Worth filing.

## Not regenerated, deliberately

`internal/config/envvars/env_vars.go` and `.env.example`. Their generator walks the filesystem for platform-go structs and finds nothing now that vendoring is dropped, so `make env_vars` truncates `env_vars.go` by 1055 lines and guts `.env.example`. Neither needs regenerating anyway — the generator keys off `env`/`envPrefix` tags and this change touches only `json`/`yaml`.

## Scope

`internal/domain` is untouched. Those are API response bodies, not configuration — an early pass caught them via `ValidPrepTaskConfig` matching the `*Config` root pattern, and dropping `"containsEgg": false` from a `ValidIngredient` would break any client decoding into a non-optional `Bool`. Reverted; the 15 changed Go files are all under config packages.

## Verification

- `go build ./...` clean, `go test ./internal/...` clean.
- Config round-trips: `internal/config` tests pass against the shrunken files.
- Tag alignment (`format_go_tag_alignment.sh`) and `gofmt` both converge.
