### PR TITLE
test: resolve testifylint float-compare, re-enable the checker

### DIFF
--- a/backend/.golangci.yml
+++ b/backend/.golangci.yml
@@ -130,13 +130,6 @@ linters:
         - cancelling
     nakedret:
       max-func-lines: 4
-    testifylint:
-      disable:
-        # 62 sites compare float32 quantities with Equal. Some are round-trip
-        # checks where exact equality is correct; others follow real arithmetic
-        # (recipe scaling, unit conversion) and want a tolerance. Picking the
-        # right epsilon is per-site work, not a mechanical fix. Tracked separately.
-        - float-compare
     unparam:
       check-exported: false
     unused:

--- a/backend/internal/domain/mealplanning/grocerylistpreparation/list_creator_test.go
+++ b/backend/internal/domain/mealplanning/grocerylistpreparation/list_creator_test.go
@@ -13,6 +13,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// quantityEpsilon is the relative tolerance for asserting on generated grocery list
+// quantities. Those quantities are aggregated across recipes and scaled by portion
+// count before being rounded to a tenth, so the arithmetic can land a few ULPs off an
+// exactly-representable expectation. Because the final value is quantized to a tenth,
+// any genuinely wrong quantity differs by at least 0.1 — several orders of magnitude
+// more than this epsilon — so a tolerance this tight still catches real regressions
+// while ignoring float32 drift (~1.2e-7 relative).
+const quantityEpsilon = 1e-6
+
 func Test_groceryListCreator_GenerateGroceryListInputs(T *testing.T) {
 	T.Parallel()
 
@@ -545,8 +554,8 @@ func Test_groceryListCreator_GenerateGroceryListInputs(T *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, actual, 1)
 		// effectiveScale = 2.0 * 0.5 = 1.0, so 100 * 1.0 = 100
-		assert.Equal(t, float32(100), actual[0].MinQuantityNeeded)
-		assert.Equal(t, float32(100), *actual[0].MaxQuantityNeeded)
+		assert.InEpsilon(t, float32(100), actual[0].MinQuantityNeeded, quantityEpsilon)
+		assert.InEpsilon(t, float32(100), *actual[0].MaxQuantityNeeded, quantityEpsilon)
 	})
 
 	T.Run("with option groups", func(t *testing.T) {
@@ -656,7 +665,7 @@ func Test_groceryListCreator_GenerateGroceryListInputs(T *testing.T) {
 		assert.Equal(t, uint16(0), *spaghettiItem.IngredientIndex)
 		assert.NotNil(t, spaghettiItem.OptionIndex)
 		assert.Equal(t, uint16(0), *spaghettiItem.OptionIndex)
-		assert.Equal(t, float32(100), spaghettiItem.MinQuantityNeeded)
+		assert.InEpsilon(t, float32(100), spaghettiItem.MinQuantityNeeded, quantityEpsilon)
 
 		// Verify angelHair is NOT present (was not selected, and optionIndex=1 is not the default)
 		_, ok = actualMap[angelHair.ID]
@@ -671,7 +680,7 @@ func Test_groceryListCreator_GenerateGroceryListInputs(T *testing.T) {
 		assert.Equal(t, recipeID, *onionItem.RecipeID)
 		assert.NotNil(t, onionItem.RecipeStepID)
 		assert.Equal(t, stepID, *onionItem.RecipeStepID)
-		assert.Equal(t, float32(50), onionItem.MinQuantityNeeded)
+		assert.InEpsilon(t, float32(50), onionItem.MinQuantityNeeded, quantityEpsilon)
 	})
 
 	T.Run("with option groups and aggregation", func(t *testing.T) {
@@ -809,7 +818,7 @@ func Test_groceryListCreator_GenerateGroceryListInputs(T *testing.T) {
 		// Verify spaghetti (option group item - default selection)
 		spaghettiItem, ok := actualMap[spaghetti.ID]
 		assert.True(t, ok, "spaghetti item should exist (default optionIndex=0)")
-		assert.Equal(t, float32(100), spaghettiItem.MinQuantityNeeded)
+		assert.InEpsilon(t, float32(100), spaghettiItem.MinQuantityNeeded, quantityEpsilon)
 		assert.NotNil(t, spaghettiItem.BelongsToMealPlanOption)
 		assert.Equal(t, option1ID, *spaghettiItem.BelongsToMealPlanOption)
 
@@ -820,7 +829,7 @@ func Test_groceryListCreator_GenerateGroceryListInputs(T *testing.T) {
 		// Verify onion (non-option item, should be aggregated)
 		onionItem, ok := actualMap[onion.ID]
 		assert.True(t, ok)
-		assert.Equal(t, float32(100), onionItem.MinQuantityNeeded, "onion should be aggregated (50 + 50)")
+		assert.InEpsilon(t, float32(100), onionItem.MinQuantityNeeded, quantityEpsilon, "onion should be aggregated (50 + 50)")
 		// Consolidated across two options/recipes/steps, so attribution is cleared rather than
 		// misattributed to the first contributor.
 		assert.Nil(t, onionItem.BelongsToMealPlanOption)
@@ -946,7 +955,7 @@ func Test_groceryListCreator_GenerateGroceryListInputs(T *testing.T) {
 		assert.Equal(t, uint16(0), *angelHairItem.IngredientIndex)
 		assert.NotNil(t, angelHairItem.OptionIndex)
 		assert.Equal(t, uint16(1), *angelHairItem.OptionIndex)
-		assert.Equal(t, float32(100), angelHairItem.MinQuantityNeeded)
+		assert.InEpsilon(t, float32(100), angelHairItem.MinQuantityNeeded, quantityEpsilon)
 
 		// Verify onion (non-option item)
 		onionItem, ok := actualMap[onion.ID]
@@ -957,7 +966,7 @@ func Test_groceryListCreator_GenerateGroceryListInputs(T *testing.T) {
 		assert.Equal(t, recipeID, *onionItem.RecipeID)
 		assert.NotNil(t, onionItem.RecipeStepID)
 		assert.Equal(t, stepID, *onionItem.RecipeStepID)
-		assert.Equal(t, float32(50), onionItem.MinQuantityNeeded)
+		assert.InEpsilon(t, float32(50), onionItem.MinQuantityNeeded, quantityEpsilon)
 	})
 
 	T.Run("with associated recipes", func(t *testing.T) {
@@ -1075,7 +1084,7 @@ func Test_groceryListCreator_GenerateGroceryListInputs(T *testing.T) {
 		assert.Equal(t, mainRecipeID, *chickenItem.RecipeID)
 		assert.NotNil(t, chickenItem.RecipeStepID)
 		assert.Equal(t, mainStepID, *chickenItem.RecipeStepID)
-		assert.Equal(t, float32(500), chickenItem.MinQuantityNeeded)
+		assert.InEpsilon(t, float32(500), chickenItem.MinQuantityNeeded, quantityEpsilon)
 
 		// Verify oliveOil (from associated recipe)
 		oliveOilItem, ok := actualMap[oliveOil.ID]
@@ -1084,7 +1093,7 @@ func Test_groceryListCreator_GenerateGroceryListInputs(T *testing.T) {
 		assert.Equal(t, associatedRecipeID, *oliveOilItem.RecipeID)
 		assert.NotNil(t, oliveOilItem.RecipeStepID)
 		assert.Equal(t, associatedStepID, *oliveOilItem.RecipeStepID)
-		assert.Equal(t, float32(100), oliveOilItem.MinQuantityNeeded)
+		assert.InEpsilon(t, float32(100), oliveOilItem.MinQuantityNeeded, quantityEpsilon)
 
 		// Verify lemon (from associated recipe)
 		lemonItem, ok := actualMap[lemon.ID]
@@ -1093,7 +1102,7 @@ func Test_groceryListCreator_GenerateGroceryListInputs(T *testing.T) {
 		assert.Equal(t, associatedRecipeID, *lemonItem.RecipeID)
 		assert.NotNil(t, lemonItem.RecipeStepID)
 		assert.Equal(t, associatedStepID, *lemonItem.RecipeStepID)
-		assert.Equal(t, float32(50), lemonItem.MinQuantityNeeded)
+		assert.InEpsilon(t, float32(50), lemonItem.MinQuantityNeeded, quantityEpsilon)
 	})
 
 	T.Run("with associated recipes and scaling", func(t *testing.T) {
@@ -1196,12 +1205,12 @@ func Test_groceryListCreator_GenerateGroceryListInputs(T *testing.T) {
 		// Verify chicken (from main recipe) - should be scaled: 500 * 1.5 * 2.0 = 1500
 		chickenItem, ok := actualMap[chicken.ID]
 		assert.True(t, ok, "chicken item should exist")
-		assert.Equal(t, float32(1500), chickenItem.MinQuantityNeeded)
+		assert.InEpsilon(t, float32(1500), chickenItem.MinQuantityNeeded, quantityEpsilon)
 
 		// Verify oliveOil (from associated recipe) - should also be scaled: 100 * 1.5 * 2.0 = 300
 		oliveOilItem, ok := actualMap[oliveOil.ID]
 		assert.True(t, ok, "oliveOil item should exist from associated recipe")
-		assert.Equal(t, float32(300), oliveOilItem.MinQuantityNeeded)
+		assert.InEpsilon(t, float32(300), oliveOilItem.MinQuantityNeeded, quantityEpsilon)
 	})
 
 	T.Run("with associated recipes and aggregation", func(t *testing.T) {
@@ -1312,12 +1321,12 @@ func Test_groceryListCreator_GenerateGroceryListInputs(T *testing.T) {
 		// Verify chicken
 		chickenItem, ok := actualMap[chicken.ID]
 		assert.True(t, ok, "chicken item should exist")
-		assert.Equal(t, float32(500), chickenItem.MinQuantityNeeded)
+		assert.InEpsilon(t, float32(500), chickenItem.MinQuantityNeeded, quantityEpsilon)
 
 		// Verify salt (should be aggregated: 10 + 5 = 15)
 		saltItem, ok := actualMap[salt.ID]
 		assert.True(t, ok, "salt item should exist and be aggregated")
-		assert.Equal(t, float32(15), saltItem.MinQuantityNeeded, "salt should be aggregated from main recipe (10) and associated recipe (5)")
+		assert.InEpsilon(t, float32(15), saltItem.MinQuantityNeeded, quantityEpsilon, "salt should be aggregated from main recipe (10) and associated recipe (5)")
 		// Same option contributed both amounts, so option attribution survives, but the recipe/step
 		// attribution is cleared because the contributions came from different recipes/steps.
 		assert.NotNil(t, saltItem.BelongsToMealPlanOption)
@@ -1406,15 +1415,15 @@ func Test_groceryListCreator_GenerateGroceryListInputs(T *testing.T) {
 		// 3.01 * 1.34 = 4.0334 -> should round to 4.0
 		carrotItem, ok := actualMap[carrot.ID]
 		assert.True(t, ok, "carrot item should exist")
-		assert.Equal(t, float32(4.0), carrotItem.MinQuantityNeeded, "carrot quantity should be rounded to nearest tenth")
+		assert.InEpsilon(t, float32(4.0), carrotItem.MinQuantityNeeded, quantityEpsilon, "carrot quantity should be rounded to nearest tenth")
 		assert.NotNil(t, carrotItem.MaxQuantityNeeded)
-		assert.Equal(t, float32(4.0), *carrotItem.MaxQuantityNeeded)
+		assert.InEpsilon(t, float32(4.0), *carrotItem.MaxQuantityNeeded, quantityEpsilon)
 
 		// 1.5 * 1.34 = 2.01 -> should round to 2.0
 		thymeItem, ok := actualMap[thyme.ID]
 		assert.True(t, ok, "thyme item should exist")
-		assert.Equal(t, float32(2.0), thymeItem.MinQuantityNeeded, "thyme quantity should be rounded to nearest tenth")
+		assert.InEpsilon(t, float32(2.0), thymeItem.MinQuantityNeeded, quantityEpsilon, "thyme quantity should be rounded to nearest tenth")
 		assert.NotNil(t, thymeItem.MaxQuantityNeeded)
-		assert.Equal(t, float32(2.0), *thymeItem.MaxQuantityNeeded)
+		assert.InEpsilon(t, float32(2.0), *thymeItem.MaxQuantityNeeded, quantityEpsilon)
 	})
 }

--- a/backend/internal/domain/mealplanning/recipe_step_ingredient_test.go
+++ b/backend/internal/domain/mealplanning/recipe_step_ingredient_test.go
@@ -35,7 +35,7 @@ func TestRecipeStepIngredient_Update(T *testing.T) {
 			ScaleFactor: new(float32(0.5)),
 		}
 		x.Update(input)
-		assert.Equal(t, float32(0.5), x.ScaleFactor)
+		assert.Equal(t, float32(0.5), x.ScaleFactor) //nolint:testifylint // verbatim assignment; exact equality is the assertion
 	})
 }
 

--- a/backend/internal/domain/mealplanning/recipe_step_instrument_test.go
+++ b/backend/internal/domain/mealplanning/recipe_step_instrument_test.go
@@ -37,7 +37,7 @@ func TestRecipeStepInstrument_Update(T *testing.T) {
 			ScaleFactor: new(float32(0.5)),
 		}
 		x.Update(input)
-		assert.Equal(t, float32(0.5), x.ScaleFactor)
+		assert.Equal(t, float32(0.5), x.ScaleFactor) //nolint:testifylint // verbatim assignment; exact equality is the assertion
 	})
 }
 

--- a/backend/internal/domain/mealplanning/recipe_step_vessel_test.go
+++ b/backend/internal/domain/mealplanning/recipe_step_vessel_test.go
@@ -39,7 +39,7 @@ func TestRecipeStepVessel_Update(T *testing.T) {
 			ScaleFactor: new(float32(0.5)),
 		}
 		x.Update(input)
-		assert.Equal(t, float32(0.5), x.ScaleFactor)
+		assert.Equal(t, float32(0.5), x.ScaleFactor) //nolint:testifylint // verbatim assignment; exact equality is the assertion
 	})
 }
 

--- a/backend/internal/domain/mealplanning/valid_measurement_unit_conversion_test.go
+++ b/backend/internal/domain/mealplanning/valid_measurement_unit_conversion_test.go
@@ -8,6 +8,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// conversionEpsilon is the relative tolerance for asserting on converted measurement
+// quantities. A conversion is a float32 multiply or divide by an arbitrary modifier
+// followed by a rounding pass, so the result can land a few ULPs off an expectation
+// that happens to be exactly representable today. This is looser than the tolerance
+// the grocery list tests use, because a conversion divides by a modifier that is
+// itself inexact, whereas aggregation only adds and scales. It is still far tighter
+// than the rounding granularity of any of these conversions, so a wrong modifier or
+// a wrong direction still fails.
+const conversionEpsilon = 1e-5
+
 func TestValidMeasurementUnitConversion_Update(T *testing.T) {
 	T.Parallel()
 
@@ -146,7 +156,7 @@ func TestValidMeasurementUnitConversion_ConvertFromToTo(T *testing.T) {
 		result := x.ConvertFromToTo(2.0, 0)
 		expected := float32(473.0)
 
-		assert.Equal(t, expected, result)
+		assert.InEpsilon(t, expected, result, conversionEpsilon)
 	})
 
 	T.Run("conversion with high precision", func(t *testing.T) {
@@ -173,7 +183,7 @@ func TestValidMeasurementUnitConversion_ConvertFromToTo(T *testing.T) {
 		result := x.ConvertFromToTo(10.0)
 		expected := float32(10.0)
 
-		assert.Equal(t, expected, result)
+		assert.InEpsilon(t, expected, result, conversionEpsilon)
 	})
 
 	T.Run("conversion with zero value", func(t *testing.T) {
@@ -186,7 +196,7 @@ func TestValidMeasurementUnitConversion_ConvertFromToTo(T *testing.T) {
 		result := x.ConvertFromToTo(0.0)
 		expected := float32(0.0)
 
-		assert.Equal(t, expected, result)
+		assert.InDelta(t, expected, result, conversionEpsilon)
 	})
 
 	T.Run("conversion with fractional modifier", func(t *testing.T) {
@@ -199,7 +209,7 @@ func TestValidMeasurementUnitConversion_ConvertFromToTo(T *testing.T) {
 		result := x.ConvertFromToTo(4.0)
 		expected := float32(2.0)
 
-		assert.Equal(t, expected, result)
+		assert.InEpsilon(t, expected, result, conversionEpsilon)
 	})
 
 	T.Run("conversion with large values", func(t *testing.T) {
@@ -212,7 +222,7 @@ func TestValidMeasurementUnitConversion_ConvertFromToTo(T *testing.T) {
 		result := x.ConvertFromToTo(5.0)
 		expected := float32(5000.0)
 
-		assert.Equal(t, expected, result)
+		assert.InEpsilon(t, expected, result, conversionEpsilon)
 	})
 }
 
@@ -258,7 +268,7 @@ func TestValidMeasurementUnitConversion_ConvertToToFrom(T *testing.T) {
 		result := x.ConvertToToFrom(500.0, 0)
 		expected := float32(2.0)
 
-		assert.Equal(t, expected, result)
+		assert.InEpsilon(t, expected, result, conversionEpsilon)
 	})
 
 	T.Run("conversion with high precision", func(t *testing.T) {
@@ -285,7 +295,7 @@ func TestValidMeasurementUnitConversion_ConvertToToFrom(T *testing.T) {
 		result := x.ConvertToToFrom(10.0)
 		expected := float32(10.0)
 
-		assert.Equal(t, expected, result)
+		assert.InEpsilon(t, expected, result, conversionEpsilon)
 	})
 
 	T.Run("conversion with zero value", func(t *testing.T) {
@@ -298,7 +308,7 @@ func TestValidMeasurementUnitConversion_ConvertToToFrom(T *testing.T) {
 		result := x.ConvertToToFrom(0.0)
 		expected := float32(0.0)
 
-		assert.Equal(t, expected, result)
+		assert.InDelta(t, expected, result, conversionEpsilon)
 	})
 
 	T.Run("conversion with fractional modifier", func(t *testing.T) {
@@ -311,7 +321,7 @@ func TestValidMeasurementUnitConversion_ConvertToToFrom(T *testing.T) {
 		result := x.ConvertToToFrom(2.0)
 		expected := float32(4.0)
 
-		assert.Equal(t, expected, result)
+		assert.InEpsilon(t, expected, result, conversionEpsilon)
 	})
 
 	T.Run("conversion with large values", func(t *testing.T) {
@@ -324,7 +334,7 @@ func TestValidMeasurementUnitConversion_ConvertToToFrom(T *testing.T) {
 		result := x.ConvertToToFrom(5000.0)
 		expected := float32(5.0)
 
-		assert.Equal(t, expected, result)
+		assert.InEpsilon(t, expected, result, conversionEpsilon)
 	})
 }
 
@@ -399,6 +409,6 @@ func TestValidMeasurementUnitConversion_RoundTripConversion(T *testing.T) {
 		converted := x.ConvertFromToTo(original, 0)
 		roundTrip := x.ConvertToToFrom(converted, 0)
 
-		assert.Equal(t, original, roundTrip)
+		assert.InEpsilon(t, original, roundTrip, conversionEpsilon)
 	})
 }

--- a/backend/internal/repositories/postgres/mealplanning/meal_plans_test.go
+++ b/backend/internal/repositories/postgres/mealplanning/meal_plans_test.go
@@ -115,7 +115,7 @@ func createMealPlanForTest(t *testing.T, ctx context.Context, exampleMealPlan *t
 			require.Equal(t, exampleMealPlan.Events[i].Options[j].ID, mealPlan.Events[i].Options[j].ID)
 			require.Equal(t, exampleMealPlan.Events[i].Options[j].Votes, mealPlan.Events[i].Options[j].Votes)
 			require.Equal(t, exampleMealPlan.Events[i].Options[j].Meal, mealPlan.Events[i].Options[j].Meal)
-			require.Equal(t, exampleMealPlan.Events[i].Options[j].MealScale, mealPlan.Events[i].Options[j].MealScale)
+			require.Equal(t, exampleMealPlan.Events[i].Options[j].MealScale, mealPlan.Events[i].Options[j].MealScale) //nolint:testifylint // round-trip value; exact equality is the assertion
 			require.Equal(t, exampleMealPlan.Events[i].Options[j].Chosen, mealPlan.Events[i].Options[j].Chosen)
 			require.Equal(t, exampleMealPlan.Events[i].Options[j].TieBroken, mealPlan.Events[i].Options[j].TieBroken)
 		}

--- a/backend/testing/integration/apiserver/mealplanning_meal_plan_grocery_list_items_test.go
+++ b/backend/testing/integration/apiserver/mealplanning_meal_plan_grocery_list_items_test.go
@@ -27,7 +27,7 @@ func checkMealPlanGroceryListItemEquality(t *testing.T, expected, actual *mealpl
 	assert.Equal(t, expected.MeasurementUnit.ID, actual.MeasurementUnit.ID, "expected MeasurementUnitID for meal plan grocery list item %s to be %v, but it was %v", expected.ID, expected.MeasurementUnit.ID, actual.MeasurementUnit.ID)
 	assert.Equal(t, expected.BelongsToMealPlan, actual.BelongsToMealPlan, "expected BelongsToMealPlan for meal plan grocery list item %s to be %v, but it was %v", expected.ID, expected.BelongsToMealPlan, actual.BelongsToMealPlan)
 	assert.Equal(t, expected.Ingredient.ID, actual.Ingredient.ID, "expected ValidIngredientID for meal plan grocery list item %s to be %v, but it was %v", expected.ID, expected.Ingredient.ID, actual.Ingredient.ID)
-	assert.Equal(t, expected.MinQuantityNeeded, actual.MinQuantityNeeded, "expected MinQuantityNeeded for meal plan grocery list item %s to be %v, but it was %v", expected.ID, expected.MinQuantityNeeded, actual.MinQuantityNeeded)
+	assert.Equal(t, expected.MinQuantityNeeded, actual.MinQuantityNeeded, "expected MinQuantityNeeded for meal plan grocery list item %s to be %v, but it was %v", expected.ID, expected.MinQuantityNeeded, actual.MinQuantityNeeded) //nolint:testifylint // round-trip value; exact equality is the assertion
 	assert.Equal(t, expected.MaxQuantityNeeded, actual.MaxQuantityNeeded, "expected MaxQuantityNeeded for meal plan grocery list item %s to be %v, but it was %v", expected.ID, expected.MaxQuantityNeeded, actual.MaxQuantityNeeded)
 
 	assert.NotZero(t, actual.CreatedAt)

--- a/backend/testing/integration/apiserver/mealplanning_meals_test.go
+++ b/backend/testing/integration/apiserver/mealplanning_meals_test.go
@@ -27,7 +27,7 @@ func checkMealEquality(t *testing.T, expected, actual *types.Meal) {
 
 	assert.Equal(t, expected.Name, actual.Name, "expected Name for meal %s to be %v, but it was %v", expected.ID, expected.Name, actual.Name)
 	assert.Equal(t, expected.Description, actual.Description, "expected Description for meal %s to be %v, but it was %v", expected.ID, expected.Description, actual.Description)
-	assert.Equal(t, expected.MinEstimatedPortions, actual.MinEstimatedPortions, "expected MinEstimatedPortions for meal %s to be %v, but it was %v", expected.ID, expected.MinEstimatedPortions, actual.MinEstimatedPortions)
+	assert.Equal(t, expected.MinEstimatedPortions, actual.MinEstimatedPortions, "expected MinEstimatedPortions for meal %s to be %v, but it was %v", expected.ID, expected.MinEstimatedPortions, actual.MinEstimatedPortions) //nolint:testifylint // round-trip value; exact equality is the assertion
 	assert.Equal(t, expected.MaxEstimatedPortions, actual.MaxEstimatedPortions, "expected MaxEstimatedPortions for meal %s to be %v, but it was %v", expected.ID, expected.MaxEstimatedPortions, actual.MaxEstimatedPortions)
 	assert.Equal(t, expected.EligibleForMealPlans, actual.EligibleForMealPlans, "expected EligibleForMealPlans for meal %s to be %v, but it was %v", expected.ID, expected.EligibleForMealPlans, actual.EligibleForMealPlans)
 

--- a/backend/testing/integration/apiserver/mealplanning_recipe_ratings_test.go
+++ b/backend/testing/integration/apiserver/mealplanning_recipe_ratings_test.go
@@ -42,11 +42,11 @@ func checkRecipeRatingEquality(t *testing.T, expected, actual *types.RecipeRatin
 	assert.NotEmpty(t, actual.ID)
 	assert.Equal(t, expected.Notes, actual.Notes, "expected Notes for recipe rating %s to be %v, but it was %v", expected.ID, expected.Notes, actual.Notes)
 	assert.Equal(t, expected.BelongsToRecipe, actual.BelongsToRecipe, "expected RecipeID for recipe rating %s to be %v, but it was %v", expected.ID, expected.BelongsToRecipe, actual.BelongsToRecipe)
-	assert.Equal(t, expected.Taste, actual.Taste, "expected Taste for recipe rating %s to be %v, but it was %v", expected.ID, expected.Taste, actual.Taste)
-	assert.Equal(t, expected.Instructions, actual.Instructions, "expected Instructions for recipe rating %s to be %v, but it was %v", expected.ID, expected.Instructions, actual.Instructions)
-	assert.Equal(t, expected.Overall, actual.Overall, "expected Overall for recipe rating %s to be %v, but it was %v", expected.ID, expected.Overall, actual.Overall)
-	assert.Equal(t, expected.Cleanup, actual.Cleanup, "expected Cleanup for recipe rating %s to be %v, but it was %v", expected.ID, expected.Cleanup, actual.Cleanup)
-	assert.Equal(t, expected.Difficulty, actual.Difficulty, "expected Difficulty for recipe rating %s to be %v, but it was %v", expected.ID, expected.Difficulty, actual.Difficulty)
+	assert.Equal(t, expected.Taste, actual.Taste, "expected Taste for recipe rating %s to be %v, but it was %v", expected.ID, expected.Taste, actual.Taste)                                    //nolint:testifylint // round-trip value; exact equality is the assertion
+	assert.Equal(t, expected.Instructions, actual.Instructions, "expected Instructions for recipe rating %s to be %v, but it was %v", expected.ID, expected.Instructions, actual.Instructions) //nolint:testifylint // round-trip value; exact equality is the assertion
+	assert.Equal(t, expected.Overall, actual.Overall, "expected Overall for recipe rating %s to be %v, but it was %v", expected.ID, expected.Overall, actual.Overall)                          //nolint:testifylint // round-trip value; exact equality is the assertion
+	assert.Equal(t, expected.Cleanup, actual.Cleanup, "expected Cleanup for recipe rating %s to be %v, but it was %v", expected.ID, expected.Cleanup, actual.Cleanup)                          //nolint:testifylint // round-trip value; exact equality is the assertion
+	assert.Equal(t, expected.Difficulty, actual.Difficulty, "expected Difficulty for recipe rating %s to be %v, but it was %v", expected.ID, expected.Difficulty, actual.Difficulty)           //nolint:testifylint // round-trip value; exact equality is the assertion
 	assert.NotZero(t, actual.CreatedAt)
 }
 

--- a/backend/testing/integration/apiserver/mealplanning_recipe_step_ingredients_test.go
+++ b/backend/testing/integration/apiserver/mealplanning_recipe_step_ingredients_test.go
@@ -27,7 +27,7 @@ func checkRecipeStepIngredientEquality(t *testing.T, stepIndex, ingIndex int, ex
 	assert.False(t, actual.CreatedAt.IsZero(), "expected step %d ingredient %d to have CreatedAt", stepIndex, ingIndex)
 	assert.NotEmpty(t, actual.BelongsToRecipeStep, "expected step %d ingredient %d to have BelongsToRecipeStep", stepIndex, ingIndex)
 	assert.Equal(t, expected.Name, actual.Name, "expected step %d ingredient %d Name", stepIndex, ingIndex)
-	assert.Equal(t, expected.MinQuantity, actual.MinQuantity, "expected step %d ingredient %d MinQuantity", stepIndex, ingIndex)
+	assert.Equal(t, expected.MinQuantity, actual.MinQuantity, "expected step %d ingredient %d MinQuantity", stepIndex, ingIndex) //nolint:testifylint // round-trip value; exact equality is the assertion
 	assert.Equal(t, expected.MaxQuantity, actual.MaxQuantity, "expected step %d ingredient %d MaxQuantity", stepIndex, ingIndex)
 	assert.Equal(t, expected.QuantityNotes, actual.QuantityNotes, "expected step %d ingredient %d QuantityNotes", stepIndex, ingIndex)
 	assert.Equal(t, expected.IngredientNotes, actual.IngredientNotes, "expected step %d ingredient %d IngredientNotes", stepIndex, ingIndex)
@@ -41,7 +41,7 @@ func checkRecipeStepIngredientEquality(t *testing.T, stepIndex, ingIndex int, ex
 	}
 	if expected.ProductPercentageToUse != nil {
 		require.NotNil(t, actual.ProductPercentageToUse, "expected step %d ingredient %d ProductPercentageToUse non-nil", stepIndex, ingIndex)
-		assert.Equal(t, *expected.ProductPercentageToUse, *actual.ProductPercentageToUse, "expected step %d ingredient %d ProductPercentageToUse", stepIndex, ingIndex)
+		assert.Equal(t, *expected.ProductPercentageToUse, *actual.ProductPercentageToUse, "expected step %d ingredient %d ProductPercentageToUse", stepIndex, ingIndex) //nolint:testifylint // round-trip value; exact equality is the assertion
 	}
 	// MeasurementUnit comparison by ID (and ranges already compared above)
 	assert.Equal(t, expected.MeasurementUnit.ID, actual.MeasurementUnit.ID, "expected step %d ingredient %d MeasurementUnit.ID", stepIndex, ingIndex)

--- a/backend/testing/integration/apiserver/mealplanning_recipes_test.go
+++ b/backend/testing/integration/apiserver/mealplanning_recipes_test.go
@@ -21,7 +21,7 @@ func checkRecipeEquality(t *testing.T, expected, actual *mealplanning.Recipe) {
 	assert.NotEmpty(t, actual.ID)
 	assert.Equal(t, expected.Name, actual.Name, "expected Name for recipe %s to be %v, but it was %v", expected.ID, expected.Name, actual.Name)
 	assert.Equal(t, expected.InspiredByRecipeID, actual.InspiredByRecipeID, "expected InspiredByRecipeID for recipe %s to be %v, but it was %v", expected.ID, expected.InspiredByRecipeID, actual.InspiredByRecipeID)
-	assert.Equal(t, expected.MinEstimatedPortions, actual.MinEstimatedPortions, "expected MinEstimatedPortions for recipe %s to be %v, but it was %v", expected.ID, expected.MinEstimatedPortions, actual.MinEstimatedPortions)
+	assert.Equal(t, expected.MinEstimatedPortions, actual.MinEstimatedPortions, "expected MinEstimatedPortions for recipe %s to be %v, but it was %v", expected.ID, expected.MinEstimatedPortions, actual.MinEstimatedPortions) //nolint:testifylint // round-trip value; exact equality is the assertion
 	assert.Equal(t, expected.MaxEstimatedPortions, actual.MaxEstimatedPortions, "expected MaxEstimatedPortions for recipe %s to be %v, but it was %v", expected.ID, expected.MaxEstimatedPortions, actual.MaxEstimatedPortions)
 	assert.Equal(t, expected.PluralPortionName, actual.PluralPortionName, "expected PluralPortionName for recipe %s to be %v, but it was %v", expected.ID, expected.PluralPortionName, actual.PluralPortionName)
 	assert.Equal(t, expected.Description, actual.Description, "expected Description for recipe %s to be %v, but it was %v", expected.ID, expected.Description, actual.Description)
@@ -516,7 +516,7 @@ func TestRecipes_Updating(T *testing.T) {
 		assert.Equal(t, newRecipe.Source, actualRecipe.Source, "recipe source should be updated")
 		assert.Equal(t, newRecipe.Description, actualRecipe.Description, "recipe description should be updated")
 		assert.Equal(t, newRecipe.InspiredByRecipeID, actualRecipe.InspiredByRecipeID, "recipe inspired by recipe ID should be updated")
-		assert.Equal(t, newRecipe.MinEstimatedPortions, actualRecipe.MinEstimatedPortions, "recipe estimated portions should be updated")
+		assert.Equal(t, newRecipe.MinEstimatedPortions, actualRecipe.MinEstimatedPortions, "recipe estimated portions should be updated") //nolint:testifylint // round-trip value; exact equality is the assertion
 		assert.Equal(t, newRecipe.MaxEstimatedPortions, actualRecipe.MaxEstimatedPortions, "recipe estimated portions should be updated")
 		assert.Equal(t, newRecipe.PortionName, actualRecipe.PortionName, "recipe portion name should be updated")
 		assert.Equal(t, newRecipe.PluralPortionName, actualRecipe.PluralPortionName, "recipe plural portion name should be updated")
@@ -1158,8 +1158,8 @@ func TestRecipes_CreationWithDiscreteProducts(T *testing.T) {
 		assert.Equal(t, "beef patties", step0Product.Name)
 		// Verify discrete product fields
 		require.NotNil(t, step0Product.MinItemQuantity, "discrete product should have ItemQuantity.Min set")
-		assert.Equal(t, float32(4), *step0Product.MinItemQuantity, "ItemQuantity should be 4 patties")
-		assert.Equal(t, float32(4), *step0Product.MinMeasurementQuantity, "MeasurementQuantity should be 4 oz per patty")
+		assert.Equal(t, float32(4), *step0Product.MinItemQuantity, "ItemQuantity should be 4 patties")                    //nolint:testifylint // round-trip value; exact equality is the assertion
+		assert.Equal(t, float32(4), *step0Product.MinMeasurementQuantity, "MeasurementQuantity should be 4 oz per patty") //nolint:testifylint // round-trip value; exact equality is the assertion
 
 		// Verify step 1 has continuous product (sauce)
 		require.Len(t, createdRecipe.Steps[1].Products, 1)
@@ -1168,7 +1168,7 @@ func TestRecipes_CreationWithDiscreteProducts(T *testing.T) {
 		// Verify continuous product fields (ItemQuantity should be empty)
 		assert.Nil(t, step1Product.MinItemQuantity, "continuous product should not have ItemQuantity.Min set")
 		assert.Nil(t, step1Product.MaxItemQuantity, "continuous product should not have ItemQuantity.Max set")
-		assert.Equal(t, float32(8), *step1Product.MinMeasurementQuantity, "MeasurementQuantity should be 8 oz total")
+		assert.Equal(t, float32(8), *step1Product.MinMeasurementQuantity, "MeasurementQuantity should be 8 oz total") //nolint:testifylint // round-trip value; exact equality is the assertion
 
 		// Verify we can retrieve the recipe and products are still correct
 		retrieved, err := adminClient.GetRecipe(ctx, &mealplanninggrpc.GetRecipeRequest{
@@ -1183,8 +1183,8 @@ func TestRecipes_CreationWithDiscreteProducts(T *testing.T) {
 		retrievedStep0Product := retrievedRecipe.Steps[0].Products[0]
 		assert.Equal(t, "beef patties", retrievedStep0Product.Name)
 		require.NotNil(t, retrievedStep0Product.MinItemQuantity)
-		assert.Equal(t, float32(4), *retrievedStep0Product.MinItemQuantity)
-		assert.Equal(t, float32(4), *retrievedStep0Product.MinMeasurementQuantity)
+		assert.Equal(t, float32(4), *retrievedStep0Product.MinItemQuantity)        //nolint:testifylint // round-trip value; exact equality is the assertion
+		assert.Equal(t, float32(4), *retrievedStep0Product.MinMeasurementQuantity) //nolint:testifylint // round-trip value; exact equality is the assertion
 
 		// Verify continuous product is still correct after retrieval
 		require.Len(t, retrievedRecipe.Steps[1].Products, 1)
@@ -1192,7 +1192,7 @@ func TestRecipes_CreationWithDiscreteProducts(T *testing.T) {
 		assert.Equal(t, "special sauce", retrievedStep1Product.Name)
 		assert.Nil(t, retrievedStep1Product.MinItemQuantity)
 		assert.Nil(t, retrievedStep1Product.MaxItemQuantity)
-		assert.Equal(t, float32(8), *retrievedStep1Product.MinMeasurementQuantity)
+		assert.Equal(t, float32(8), *retrievedStep1Product.MinMeasurementQuantity) //nolint:testifylint // round-trip value; exact equality is the assertion
 
 		// Cleanup
 		_, err = adminClient.ArchiveRecipe(ctx, &mealplanninggrpc.ArchiveRecipeRequest{
@@ -1288,9 +1288,9 @@ func TestRecipes_StepProducts_Discrete(T *testing.T) {
 		assert.Equal(t, "cookies", product.Name)
 		// Verify ItemQuantity.Min is set (indicates discrete)
 		require.NotNil(t, product.MinItemQuantity, "discrete product should have ItemQuantity.Min set")
-		assert.Equal(t, float32(12), *product.MinItemQuantity, "ItemQuantity should be 12 cookies")
+		assert.Equal(t, float32(12), *product.MinItemQuantity, "ItemQuantity should be 12 cookies") //nolint:testifylint // round-trip value; exact equality is the assertion
 		// Verify MeasurementQuantity represents per-item measurement
-		assert.Equal(t, float32(2), *product.MinMeasurementQuantity, "MeasurementQuantity should be 2 oz per cookie")
+		assert.Equal(t, float32(2), *product.MinMeasurementQuantity, "MeasurementQuantity should be 2 oz per cookie") //nolint:testifylint // round-trip value; exact equality is the assertion
 
 		// Cleanup
 		_, err = adminClient.ArchiveRecipe(ctx, &mealplanninggrpc.ArchiveRecipeRequest{
@@ -1384,10 +1384,10 @@ func TestRecipes_StepProducts_Discrete(T *testing.T) {
 		// Verify ItemQuantity.Max is set (indicates discrete with range)
 		require.NotNil(t, product.MinItemQuantity, "discrete product should have ItemQuantity.Min set")
 		require.NotNil(t, product.MaxItemQuantity, "discrete product with range should have ItemQuantity.Max set")
-		assert.Equal(t, float32(8), *product.MinItemQuantity, "ItemQuantity.Min should be 8 slices")
-		assert.Equal(t, float32(10), *product.MaxItemQuantity, "ItemQuantity.Max should be 10 slices")
+		assert.Equal(t, float32(8), *product.MinItemQuantity, "ItemQuantity.Min should be 8 slices")   //nolint:testifylint // round-trip value; exact equality is the assertion
+		assert.Equal(t, float32(10), *product.MaxItemQuantity, "ItemQuantity.Max should be 10 slices") //nolint:testifylint // round-trip value; exact equality is the assertion
 		// Verify MeasurementQuantity represents per-item measurement
-		assert.Equal(t, float32(1), *product.MinMeasurementQuantity, "MeasurementQuantity should be 1 oz per slice")
+		assert.Equal(t, float32(1), *product.MinMeasurementQuantity, "MeasurementQuantity should be 1 oz per slice") //nolint:testifylint // round-trip value; exact equality is the assertion
 
 		// Cleanup
 		_, err = adminClient.ArchiveRecipe(ctx, &mealplanninggrpc.ArchiveRecipeRequest{
@@ -1485,7 +1485,7 @@ func TestRecipes_StepProducts_Continuous(T *testing.T) {
 		assert.Nil(t, product.MinItemQuantity, "continuous product should not have ItemQuantity.Min set")
 		assert.Nil(t, product.MaxItemQuantity, "continuous product should not have ItemQuantity.Max set")
 		// Verify MeasurementQuantity represents total quantity
-		assert.Equal(t, float32(16), *product.MinMeasurementQuantity, "MeasurementQuantity should be 16 oz total")
+		assert.Equal(t, float32(16), *product.MinMeasurementQuantity, "MeasurementQuantity should be 16 oz total") //nolint:testifylint // round-trip value; exact equality is the assertion
 
 		// Cleanup
 		_, err = adminClient.ArchiveRecipe(ctx, &mealplanninggrpc.ArchiveRecipeRequest{
@@ -1764,7 +1764,7 @@ func TestRecipes_StepProducts_EdgeCases(T *testing.T) {
 		assert.Nil(t, product.MinItemQuantity, "continuous product should not have ItemQuantity.Min set")
 		assert.Nil(t, product.MaxItemQuantity, "continuous product should not have ItemQuantity.Max set")
 		// Verify MeasurementQuantity represents total quantity
-		assert.Equal(t, float32(32), *product.MinMeasurementQuantity, "MeasurementQuantity should be 32 oz total")
+		assert.Equal(t, float32(32), *product.MinMeasurementQuantity, "MeasurementQuantity should be 32 oz total") //nolint:testifylint // round-trip value; exact equality is the assertion
 
 		// Cleanup
 		_, err = adminClient.ArchiveRecipe(ctx, &mealplanninggrpc.ArchiveRecipeRequest{

--- a/backend/testing/integration/apiserver/mealplanning_valid_vessels_test.go
+++ b/backend/testing/integration/apiserver/mealplanning_valid_vessels_test.go
@@ -25,10 +25,10 @@ func checkValidVesselEquality(t *testing.T, expected, actual *mealplanning.Valid
 	assert.Equal(t, expected.PluralName, actual.PluralName, "expected ValidVessel PluralName")
 	assert.Equal(t, expected.IconPath, actual.IconPath, "expected ValidVessel IconPath")
 	assert.Equal(t, expected.Shape, actual.Shape, "expected ValidVessel Shape")
-	assert.Equal(t, expected.WidthInMillimeters, actual.WidthInMillimeters, "expected ValidVessel WidthInMillimeters")
-	assert.Equal(t, expected.LengthInMillimeters, actual.LengthInMillimeters, "expected ValidVessel LengthInMillimeters")
-	assert.Equal(t, expected.HeightInMillimeters, actual.HeightInMillimeters, "expected ValidVessel HeightInMillimeters")
-	assert.Equal(t, expected.Capacity, actual.Capacity, "expected ValidVessel Capacity")
+	assert.Equal(t, expected.WidthInMillimeters, actual.WidthInMillimeters, "expected ValidVessel WidthInMillimeters")    //nolint:testifylint // round-trip value; exact equality is the assertion
+	assert.Equal(t, expected.LengthInMillimeters, actual.LengthInMillimeters, "expected ValidVessel LengthInMillimeters") //nolint:testifylint // round-trip value; exact equality is the assertion
+	assert.Equal(t, expected.HeightInMillimeters, actual.HeightInMillimeters, "expected ValidVessel HeightInMillimeters") //nolint:testifylint // round-trip value; exact equality is the assertion
+	assert.Equal(t, expected.Capacity, actual.Capacity, "expected ValidVessel Capacity")                                  //nolint:testifylint // round-trip value; exact equality is the assertion
 	assert.Equal(t, expected.DisplayInSummaryLists, actual.DisplayInSummaryLists, "expected ValidVessel DisplayInSummaryLists")
 	assert.Equal(t, expected.IncludeInGeneratedInstructions, actual.IncludeInGeneratedInstructions, "expected ValidVessel IncludeInGeneratedInstructions")
 	assert.Equal(t, expected.UsableForStorage, actual.UsableForStorage, "expected ValidVessel UsableForStorage")


### PR DESCRIPTION
Follow-up to #1282, which enabled `testifylint` and deferred its 62 `float-compare` findings by disabling that one checker. This resolves all 62 and deletes the `disable:` block from `backend/.golangci.yml`.

The 62 split in two, which is why no single mechanical fix applied.

## Group A — real arithmetic, now asserts a tolerance (30 sites)

Grocery list quantities are aggregated across recipes and scaled by portion count before being rounded to a tenth; measurement unit conversions multiply or divide by an arbitrary modifier. Both can land a few ULPs off an expectation that happens to be exactly representable today, so exact equality is a latent flake.

Each file gets one documented relative epsilon rather than a global one:

| group | epsilon | why |
|---|---|---|
| `grocerylistpreparation/list_creator_test.go` (19) | `1e-6` | Aggregation only adds and scales, and the result is quantized to a tenth — a genuinely wrong quantity is off by at least 0.1. |
| `valid_measurement_unit_conversion_test.go` (11) | `1e-5` | Looser, because a conversion divides by a modifier that is itself inexact. |

Both stay orders of magnitude below the rounding granularity, so a wrong scale factor or modifier still fails. Spot-checked by mutating one expectation from `100` to `100.05` — the test fails as it should.

The two conversion cases expecting zero use `InDelta`, since relative error is undefined against zero.

## Group B — round-trip, exact equality is correct (32 sites)

These write a `float32` through the API or database and read it back with **no arithmetic in between**. The value should return bit-identical and that is precisely what the assertion checks — switching them to `InEpsilon` would weaken a meaningful assertion into one that passes when serialization silently loses precision. They keep `assert.Equal` behind an explanatory `//nolint:testifylint`.

The issue suggested helper-level `//nolint` to cut the comment count. That doesn't work: golangci-lint v2.10.1 reports a function-level directive on these helpers as *unused* and still flags every line inside. Per-line is also the better outcome — it keeps `testifylint`'s other checks (`expected-actual`, `require-error`, `len`, …) live in helpers that are otherwise untouched.

## Verification

- `make golang_lint` — **0 issues** against the pinned containerized v2.10.1 that CI uses (before this change, with `float-compare` re-enabled: exactly the 62 findings the issue lists).
- `make test` — passes.
- `go vet ./internal/... ./testing/...` — clean. The Group B integration tests under `testing/integration/apiserver` need a live environment, so they are compile-verified here rather than executed.

## One thing noticed, not changed

`valid_measurement_unit_conversion_test.go:173` and `:285` already used `assert.InDelta(t, expected, result, 0.00001)` against `473.176` and `2.11338`. `float32` ULP at 473 is ~6e-5, so that absolute delta is *smaller than one ULP* — those assertions effectively demand bit-identity and pass only by luck. Same class of latent flake this issue is about, but `float-compare` doesn't flag them and they're outside the stated scope, so I left them. Happy to fix in a follow-up.

Closes #1283

🤖 Generated with [Claude Code](https://claude.com/claude-code)