### PR TITLE
refactor(jobs): run the message pools as a jobs.PoolGroup

### DIFF
--- a/backend/internal/functions/datachangemessagehandler/data_change_message_handler.go
+++ b/backend/internal/functions/datachangemessagehandler/data_change_message_handler.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sync"
 
 	"github.com/primandproper/dinnerdonebetter/backend/internal/config"
 	"github.com/primandproper/dinnerdonebetter/backend/internal/domain/audit"
@@ -46,11 +45,7 @@ const (
 // Returns true if the event was handled. May return emails to be published by the caller.
 type OutboundNotificationHandler func(ctx context.Context, msg *audit.DataChangeMessage, user *identity.User) (handled bool, emailType string, emails []*queuemessages.OutboundEmailMessage, err error)
 
-var (
-	errRequiredDataIsNil = errors.New("required data is nil")
-
-	errPoolsAlreadyStarted = errors.New("job pools already started")
-)
+var errRequiredDataIsNil = errors.New("required data is nil")
 
 // AsyncDataChangeMessageHandler is a cross-cutting event router that dispatches domain events to
 // email and mobile notifications, and runs the Syncer that applies each search index's events.
@@ -91,12 +86,11 @@ type AsyncDataChangeMessageHandler struct {
 	metricsProvider                           metrics.Provider
 	searchSyncers                             []SearchSyncer
 	deadLetter                                jobs.DeadLetterFunc
+	poolGroup                                 *jobs.PoolGroup
 	queuesConfig                              queuescfg.Config
 	baseURL                                   string
 	outboundNotificationHandlers              []OutboundNotificationHandler
-	pools                                     []*jobs.Pool
 	poolsConfig                               config.WorkerPoolsConfig
-	poolsWG                                   sync.WaitGroup
 }
 
 func (a *AsyncDataChangeMessageHandler) recordMessagesProcessed(ctx context.Context, topic, status string) {
@@ -235,6 +229,11 @@ func NewAsyncDataChangeMessageHandler(
 	handler.outboundNotificationHandlers = []OutboundNotificationHandler{
 		handler.handleMealPlanningOutboundNotification,
 		handler.handleIdentityOutboundNotification,
+	}
+
+	// Built last, because the specs read the handler's own event handler factories.
+	if handler.poolGroup, err = newPoolGroup(ctx, handler); err != nil {
+		return nil, fmt.Errorf("configuring job pool group: %w", err)
 	}
 
 	return handler, nil

--- a/backend/internal/functions/datachangemessagehandler/data_change_message_handler_test.go
+++ b/backend/internal/functions/datachangemessagehandler/data_change_message_handler_test.go
@@ -139,6 +139,7 @@ func TestNewAsyncDataChangeMessageHandler(t *testing.T) {
 		tracerProvider := tracingnoop.NewTracerProvider()
 		cfg := &config.AsyncMessageHandlerConfig{
 			Queues: queuescfg.Config{
+				DataChangesTopicName:         "data-changes",
 				OutboundEmailsTopicName:      "outbound-emails",
 				SearchIndexRequestsTopicName: "search-index-requests",
 				MobileNotificationsTopicName: "mobile-notifications",

--- a/backend/internal/functions/datachangemessagehandler/pools.go
+++ b/backend/internal/functions/datachangemessagehandler/pools.go
@@ -2,52 +2,28 @@ package datachangemessagehandler
 
 import (
 	"context"
-	"errors"
-	"sync"
-	"time"
 
 	"github.com/primandproper/platform-go/v10/jobs"
-	"github.com/primandproper/platform-go/v10/observability"
 )
 
-// partialStartDrainTimeout bounds the teardown of pools that did start when a later one failed
-// to build. Start is about to return an error and the process is about to exit, so this only
-// needs to be long enough for in-flight handlers to finish, not for a graceful drain.
-const partialStartDrainTimeout = 15 * time.Second
-
-// poolSpec pairs a topic with the pool that drains it. The topic comes from the queues config
-// and the knobs from the pools config, so a topic name is never spelled twice.
-type poolSpec struct {
-	handler jobs.Handler
-	cfg     *jobs.PoolConfig
-	topic   string
-}
-
-// Start builds a jobs.Pool per topic and begins consuming. Each pool owns its own workers,
-// retry policy, and dead-letter path; Close stops them.
+// poolSpecs describes every topic this process drains: what to consume, with which knobs, and
+// which handler. The topic comes from the queues config and the knobs from the pools config, so
+// a topic name is never spelled twice.
 //
-// This replaces the previous arrangement of six bare messagequeue.Consumers sharing a stop
-// channel. The handlers are unchanged — jobs.Handler has the same signature the event handler
-// factories already returned — but a failure is now retried with backoff and a message that
-// exhausts its attempts is dead-lettered rather than logged and forgotten.
-func (a *AsyncDataChangeMessageHandler) Start(ctx context.Context) error {
-	ctx, span := a.tracer.StartSpan(ctx)
-	defer span.End()
-
-	if len(a.pools) > 0 {
-		return errPoolsAlreadyStarted
-	}
-
-	specs := []poolSpec{
+// A spec's Config is copied by the group rather than retained, which is what lets the search
+// specs below share one config value without all of them ending up on whichever topic was
+// written last.
+func (a *AsyncDataChangeMessageHandler) poolSpecs() []jobs.PoolSpec {
+	specs := []jobs.PoolSpec{
 		{
-			topic:   a.queuesConfig.DataChangesTopicName,
-			cfg:     &a.poolsConfig.DataChanges,
-			handler: a.DataChangesEventHandler(a.queuesConfig.DataChangesTopicName),
+			Topic:   a.queuesConfig.DataChangesTopicName,
+			Config:  &a.poolsConfig.DataChanges,
+			Handler: a.DataChangesEventHandler(a.queuesConfig.DataChangesTopicName),
 		},
 		{
-			topic:   a.queuesConfig.OutboundEmailsTopicName,
-			cfg:     &a.poolsConfig.OutboundEmails,
-			handler: a.OutboundEmailsEventHandler(a.queuesConfig.OutboundEmailsTopicName),
+			Topic:   a.queuesConfig.OutboundEmailsTopicName,
+			Config:  &a.poolsConfig.OutboundEmails,
+			Handler: a.OutboundEmailsEventHandler(a.queuesConfig.OutboundEmailsTopicName),
 		},
 		// There is no webhook execution pool and no user data aggregation pool. A webhook
 		// delivery is a dispatch row the delivery worker claims, and an export is a request
@@ -55,106 +31,56 @@ func (a *AsyncDataChangeMessageHandler) Start(ctx context.Context) error {
 		// lets one endpoint's copy of one event, or one subject's export, be the unit of
 		// retry rather than the whole fan-out.
 		{
-			topic:   a.queuesConfig.MobileNotificationsTopicName,
-			cfg:     &a.poolsConfig.MobileNotifications,
-			handler: a.MobileNotificationsEventHandler(a.queuesConfig.MobileNotificationsTopicName),
+			Topic:   a.queuesConfig.MobileNotificationsTopicName,
+			Config:  &a.poolsConfig.MobileNotifications,
+			Handler: a.MobileNotificationsEventHandler(a.queuesConfig.MobileNotificationsTopicName),
 		},
 	}
 
 	// One pool per search index, rather than one pool over one topic that switched on an
-	// index-type field. platform-go v10 keys an index event by its topic, so the fan-out that
-	// used to happen inside a handler happens here instead — which also means one index's
-	// backlog no longer sits behind another's, and a poison message dead-letters for its own
-	// index alone.
-	//
-	// Each gets a copy of the search pool config rather than a share of it: the loop below
-	// writes the topic onto the config it is given, and nine specs pointing at one struct
-	// would leave all nine consuming whichever topic was assigned last.
+	// index-type field. platform-go keys an index event by its topic, so the fan-out that used
+	// to happen inside a handler happens here instead — which also means one index's backlog no
+	// longer sits behind another's, and a poison message dead-letters for its own index alone.
 	for _, syncer := range a.searchSyncers {
-		poolCfg := a.poolsConfig.SearchIndexRequests
-		specs = append(specs, poolSpec{
-			topic:   syncer.Topic,
-			cfg:     &poolCfg,
-			handler: syncer.Handle,
+		specs = append(specs, jobs.PoolSpec{
+			Topic:   syncer.Topic,
+			Config:  &a.poolsConfig.SearchIndexRequests,
+			Handler: syncer.Handle,
 		})
 	}
 
-	for i := range specs {
-		spec := &specs[i]
-
-		// Topic is not part of the pools config; it lives in the queues config, which is
-		// what the publishers on the other side of these topics already read.
-		spec.cfg.Topic = spec.topic
-
-		pool, err := jobs.NewPool(
-			ctx,
-			spec.cfg,
-			a.consumerProvider,
-			spec.handler,
-			jobs.WithPoolDeadLetter(a.deadLetter),
-			jobs.WithPoolLogger(a.logger),
-			jobs.WithPoolTracerProvider(a.tracerProvider),
-			jobs.WithPoolMetricsProvider(a.metricsProvider),
-		)
-		if err != nil {
-			// Close whatever already started, so a failure partway through does not leave
-			// half the topics being consumed by a process that is about to exit. The
-			// deadline is here because this is a teardown on the error path, not the
-			// operator-controlled drain that Close normally performs.
-			closeCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), partialStartDrainTimeout)
-			if closeErr := a.Close(closeCtx); closeErr != nil {
-				a.logger.Error("closing partially started job pools", closeErr)
-			}
-			cancel()
-
-			return observability.PrepareAndLogError(err, a.logger, span, "building job pool for topic %q", spec.topic)
-		}
-
-		// Run is started as soon as the pool is built rather than after the whole set is,
-		// because Pool.Close waits on the goroutine Run owns: a pool that was constructed
-		// but never run has nothing to signal that wait, and closing it would block until
-		// its context expired.
-		a.pools = append(a.pools, pool)
-		a.poolsWG.Add(1)
-		go func(p *jobs.Pool) {
-			defer a.poolsWG.Done()
-			// Run takes no context on purpose: tied to a server context it would stop
-			// mid-message the instant that context was canceled. Close is the stop signal.
-			p.Run()
-		}(pool)
-	}
-
-	return nil
+	return specs
 }
 
-// Close stops every pool and waits for in-flight handlers to drain. The context bounds the
-// wait; when it expires the pools cancel their workers and Close reports why.
-func (a *AsyncDataChangeMessageHandler) Close(ctx context.Context) error {
-	var (
-		wg   sync.WaitGroup
-		mu   sync.Mutex
-		errs []error
+// newPoolGroup assembles the group that drains every topic above.
+//
+// It is built at construction rather than at Start so that the reasons a group refuses to exist —
+// a pool config that will not validate, two specs resolving to one topic, a handler that is nil —
+// are reported by the thing that wires this process together, before anything is consuming. What
+// is left for Start is the broker.
+func newPoolGroup(ctx context.Context, a *AsyncDataChangeMessageHandler) (*jobs.PoolGroup, error) {
+	return jobs.NewPoolGroup(
+		ctx,
+		a.poolSpecs(),
+		a.consumerProvider,
+		jobs.WithPoolGroupDeadLetter(a.deadLetter),
+		jobs.WithPoolGroupLogger(a.logger),
+		jobs.WithPoolGroupTracerProvider(a.tracerProvider),
+		jobs.WithPoolGroupMetricsProvider(a.metricsProvider),
 	)
+}
 
-	for _, pool := range a.pools {
-		wg.Add(1)
-		go func(p *jobs.Pool) {
-			defer wg.Done()
-			if err := p.Close(ctx); err != nil {
-				mu.Lock()
-				errs = append(errs, err)
-				mu.Unlock()
-			}
-		}(pool)
-	}
+// Start begins consuming every topic, or none of them.
+//
+// The handlers are unchanged — jobs.Handler has the same signature the event handler factories
+// already returned — but a failure is retried with backoff and a message that exhausts its
+// attempts is dead-lettered rather than logged and forgotten.
+func (a *AsyncDataChangeMessageHandler) Start(ctx context.Context) error {
+	return a.poolGroup.Start(ctx)
+}
 
-	wg.Wait()
-	a.poolsWG.Wait()
-	a.pools = nil
-
-	if len(errs) > 0 {
-		return errors.Join(errs...)
-	}
-
-	return nil
+// Close stops every pool and waits for in-flight handlers to drain. The context bounds the wait;
+// when it expires the pools cancel their workers and Close reports why.
+func (a *AsyncDataChangeMessageHandler) Close(ctx context.Context) error {
+	return a.poolGroup.Close(ctx)
 }

--- a/backend/internal/functions/datachangemessagehandler/pools_test.go
+++ b/backend/internal/functions/datachangemessagehandler/pools_test.go
@@ -23,16 +23,25 @@ import (
 )
 
 // blockingConsumer stands in for a real messagequeue.Consumer: it blocks in Consume until the
-// pool closes its stop channel, which is what lets a test assert that Close actually drains
-// rather than returning while consumers are still running.
+// pool closes its stop channel, which is what lets a test assert that a drain actually happened
+// rather than that a slice was emptied.
 type blockingConsumer struct {
 	started chan struct{}
+	stopped chan struct{}
 	once    sync.Once
+}
+
+func newBlockingConsumer() *blockingConsumer {
+	return &blockingConsumer{
+		started: make(chan struct{}),
+		stopped: make(chan struct{}),
+	}
 }
 
 func (c *blockingConsumer) Consume(ctx context.Context, _ chan<- error) {
 	c.once.Do(func() { close(c.started) })
 	<-ctx.Done()
+	close(c.stopped)
 }
 
 func buildTestPoolsHandler(t *testing.T, consumerProvider messagequeue.ConsumerProvider) *AsyncDataChangeMessageHandler {
@@ -45,7 +54,7 @@ func buildTestPoolsHandler(t *testing.T, consumerProvider messagequeue.ConsumerP
 		MobileNotificationsTopicName: "mobile-notifications",
 	}
 
-	return &AsyncDataChangeMessageHandler{
+	handler := &AsyncDataChangeMessageHandler{
 		logger:           loggingnoop.NewLogger(),
 		tracer:           tracing.NewTracerForTest(t.Name()),
 		tracerProvider:   tracingnoop.NewTracerProvider(),
@@ -65,6 +74,12 @@ func buildTestPoolsHandler(t *testing.T, consumerProvider messagequeue.ConsumerP
 			},
 		},
 	}
+
+	group, err := newPoolGroup(t.Context(), handler)
+	require.NoError(t, err)
+	handler.poolGroup = group
+
+	return handler
 }
 
 func TestAsyncDataChangeMessageHandler_Start(T *testing.T) {
@@ -86,7 +101,7 @@ func TestAsyncDataChangeMessageHandler_Start(T *testing.T) {
 				topics = append(topics, topic)
 				hat.Unlock()
 
-				return &blockingConsumer{started: make(chan struct{})}, nil
+				return newBlockingConsumer(), nil
 			},
 		}
 
@@ -99,16 +114,20 @@ func TestAsyncDataChangeMessageHandler_Start(T *testing.T) {
 			assert.NoError(t, handler.Close(closeCtx))
 		})
 
-		assert.Len(t, handler.pools, 4)
-
-		hat.Lock()
-		defer hat.Unlock()
-		assert.ElementsMatch(t, []string{
+		expectedTopics := []string{
 			"data-changes",
 			"outbound-emails",
 			"search-users",
 			"mobile-notifications",
-		}, topics)
+		}
+
+		// What the group says it drains, and what it actually subscribed to, are separate
+		// claims — the first is resolved at construction and the second is the broker's record.
+		assert.ElementsMatch(t, expectedTopics, handler.poolGroup.Topics())
+
+		hat.Lock()
+		defer hat.Unlock()
+		assert.ElementsMatch(t, expectedTopics, topics)
 	})
 
 	T.Run("with already started pools", func(t *testing.T) {
@@ -118,7 +137,7 @@ func TestAsyncDataChangeMessageHandler_Start(T *testing.T) {
 
 		consumerProvider := &msgqueuemock.ConsumerProviderMock{
 			NewConsumerFunc: func(context.Context, string, messagequeue.ConsumerFunc) (messagequeue.Consumer, error) {
-				return &blockingConsumer{started: make(chan struct{})}, nil
+				return newBlockingConsumer(), nil
 			},
 		}
 
@@ -131,7 +150,7 @@ func TestAsyncDataChangeMessageHandler_Start(T *testing.T) {
 			assert.NoError(t, handler.Close(closeCtx))
 		})
 
-		assert.ErrorIs(t, handler.Start(ctx), errPoolsAlreadyStarted)
+		assert.ErrorIs(t, handler.Start(ctx), jobs.ErrPoolGroupStarted)
 	})
 
 	T.Run("with error building a consumer", func(t *testing.T) {
@@ -140,25 +159,51 @@ func TestAsyncDataChangeMessageHandler_Start(T *testing.T) {
 		ctx := t.Context()
 		expected := errors.New("blah")
 
-		var calls int
+		var (
+			hat       sync.Mutex
+			consumers []*blockingConsumer
+			calls     int
+		)
 
 		consumerProvider := &msgqueuemock.ConsumerProviderMock{
 			NewConsumerFunc: func(context.Context, string, messagequeue.ConsumerFunc) (messagequeue.Consumer, error) {
+				hat.Lock()
+				defer hat.Unlock()
+
 				// Fail partway through so the partial-start cleanup path is what runs.
 				calls++
 				if calls > 2 {
 					return nil, expected
 				}
 
-				return &blockingConsumer{started: make(chan struct{})}, nil
+				c := newBlockingConsumer()
+				consumers = append(consumers, c)
+
+				return c, nil
 			},
 		}
 
 		handler := buildTestPoolsHandler(t, consumerProvider)
 
 		require.ErrorIs(t, handler.Start(ctx), expected)
-		// The pools that did start are closed rather than left consuming.
-		assert.Empty(t, handler.pools)
+
+		// The pools that did start are drained rather than left consuming.
+		hat.Lock()
+		started := make([]*blockingConsumer, len(consumers))
+		copy(started, consumers)
+		hat.Unlock()
+
+		require.Len(t, started, 2)
+		for _, c := range started {
+			select {
+			case <-c.stopped:
+			case <-time.After(5 * time.Second):
+				t.Fatal("timed out waiting for a partially started consumer to stop")
+			}
+		}
+
+		// A group is single-use, so a failed start is final rather than something to retry.
+		assert.ErrorIs(t, handler.Start(ctx), jobs.ErrPoolGroupStarted)
 	})
 }
 
@@ -177,7 +222,7 @@ func TestAsyncDataChangeMessageHandler_Close(T *testing.T) {
 
 		consumerProvider := &msgqueuemock.ConsumerProviderMock{
 			NewConsumerFunc: func(context.Context, string, messagequeue.ConsumerFunc) (messagequeue.Consumer, error) {
-				c := &blockingConsumer{started: make(chan struct{})}
+				c := newBlockingConsumer()
 
 				hat.Lock()
 				consumers = append(consumers, c)
@@ -210,12 +255,60 @@ func TestAsyncDataChangeMessageHandler_Close(T *testing.T) {
 		defer cancel()
 
 		require.NoError(t, handler.Close(closeCtx))
-		assert.Empty(t, handler.pools)
+
+		for _, c := range started {
+			select {
+			case <-c.stopped:
+			case <-time.After(5 * time.Second):
+				t.Fatal("timed out waiting for consumer to stop")
+			}
+		}
+	})
+
+	T.Run("with a second close", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+
+		consumerProvider := &msgqueuemock.ConsumerProviderMock{
+			NewConsumerFunc: func(context.Context, string, messagequeue.ConsumerFunc) (messagequeue.Consumer, error) {
+				return newBlockingConsumer(), nil
+			},
+		}
+
+		handler := buildTestPoolsHandler(t, consumerProvider)
+
+		require.NoError(t, handler.Start(ctx))
+
+		closeCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+		defer cancel()
+
+		require.NoError(t, handler.Close(closeCtx))
+		assert.NoError(t, handler.Close(closeCtx))
 	})
 
 	T.Run("without started pools", func(t *testing.T) {
 		t.Parallel()
 
 		assert.NoError(t, buildTestPoolsHandler(t, &msgqueuemock.ConsumerProviderMock{}).Close(t.Context()))
+	})
+}
+
+func TestNewPoolGroup(T *testing.T) {
+	T.Parallel()
+
+	T.Run("with two syncers on one topic", func(t *testing.T) {
+		t.Parallel()
+
+		handler := buildTestPoolsHandler(t, &msgqueuemock.ConsumerProviderMock{})
+		handler.searchSyncers = append(handler.searchSyncers, SearchSyncer{
+			Topic:  handler.searchSyncers[0].Topic,
+			Handle: func(context.Context, []byte) error { return nil },
+		})
+
+		// Caught at construction rather than from the middle of a start that has already
+		// brought other pools up.
+		_, err := newPoolGroup(t.Context(), handler)
+		assert.ErrorIs(t, err, jobs.ErrDuplicateTopic)
 	})
 }


### PR DESCRIPTION
Part of #1296, part of #1297. First of three independent #1296 items.

## What

`internal/functions/datachangemessagehandler/pools.go` built one `jobs.Pool` per topic in a loop, started each `Run` goroutine as it was constructed, and on a build failure drained what had already come up under a bounded timeout. That is `jobs.PoolGroup`, written out by hand — read the two side by side and the comments make the same three arguments:

- Start is all-or-nothing, because a partial start leaves a process that is on its way out still pulling messages off topics nothing will finish handling.
- The drain on the error path uses a bounded timeout rather than the operator-controlled one `Close` uses.
- A spec's config is **copied**, because specs sharing one `*PoolConfig` all end up consuming whichever topic was written last. Ours did this by hand (`poolCfg := a.poolsConfig.SearchIndexRequests`) and the comment said why.

This replaces the loop with `[]jobs.PoolSpec` + `jobs.PoolGroup`. `Start` and `Close` on `AsyncDataChangeMessageHandler` become passthroughs.

## The one judgment call

The group is built in the **constructor**, not at `Start`. `NewPoolGroup` copies, defaults and validates every config up front, so three failures move earlier:

- a pool config that will not validate
- two specs resolving to one topic — `ErrDuplicateTopic`, which the consumer provider would otherwise report from the middle of a start that had already brought other pools up
- a nil handler

What is left for `Start` is the broker: a subscription that cannot be established, or a meter that will not make an instrument.

This is consistent with how the rest of the constructor already behaves — the dead-letter publisher is built eagerly for exactly this reason ("a broken dead-letter topic should fail startup, not the first message that needs it"), and every error in this DI graph already surfaces through `do.MustInvoke`.

It caught one straight away: `TestNewAsyncDataChangeMessageHandler` was passing a config with no `DataChangesTopicName`. That used to construct fine and would have failed at `Start`.

## Kept

The comment explaining why there is one pool per search index rather than one pool switching on an index-type field. That reasoning is ours and is not obvious from the code.

## Tests

- The partial-start case now asserts the consumers that *did* start actually stopped, rather than that a private slice was emptied.
- New: a second `Close` is a no-op; two syncers colliding on one topic is rejected at construction.
- `errPoolsAlreadyStarted` is gone in favour of `jobs.ErrPoolGroupStarted`. A group is single-use, so a *failed* start is now also final — asserted.

`go build ./...`, `go vet ./...`, `gofmt`, and `golangci-lint run` on the package are all clean; package tests pass under `-race`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017iSaVKFpZdnMSt7W174AgB