### PR TITLE
fix(mcpserver): describe QueryFilter with the reflected schema

### DIFF
--- a/backend/internal/mcpserver/issuereports_issue_reports.go
+++ b/backend/internal/mcpserver/issuereports_issue_reports.go
@@ -50,7 +50,7 @@ var getIssueReportsTool = &mcp.Tool{
 	Name:        "GetIssueReports",
 	Description: "Get issue reports with optional filtering",
 	InputSchema: schemaObject(map[string]any{
-		"Filter": queryFilterSchema(),
+		"Filter": filtering.QueryFilterSchema(),
 	}),
 	OutputSchema: schemaObject(map[string]any{
 		"Results": arrayType(schemaObject(issueReportSchema)),
@@ -82,7 +82,7 @@ var getIssueReportsForAccountTool = &mcp.Tool{
 	Name:        "GetIssueReportsForAccount",
 	Description: "Get issue reports belonging to a specific account",
 	InputSchema: schemaObject(map[string]any{
-		"Filter": queryFilterSchema(),
+		"Filter": filtering.QueryFilterSchema(),
 	}),
 	OutputSchema: schemaObject(map[string]any{
 		"Results": arrayType(schemaObject(issueReportSchema)),

--- a/backend/internal/mcpserver/mealplanning_recipe_prep_tasks.go
+++ b/backend/internal/mcpserver/mealplanning_recipe_prep_tasks.go
@@ -84,7 +84,7 @@ var getRecipePrepTasksTool = &mcp.Tool{
 	Description: "Get recipe prep tasks with optional filtering",
 	InputSchema: schemaObject(map[string]any{
 		"RecipeID": stringField("The ID of the recipe"),
-		"Filter":   queryFilterSchema(),
+		"Filter":   filtering.QueryFilterSchema(),
 	}),
 	OutputSchema: schemaObject(map[string]any{
 		"Results": arrayType(schemaObject(recipePrepTasksSchema)),

--- a/backend/internal/mcpserver/mealplanning_recipe_step_completion_conditions.go
+++ b/backend/internal/mcpserver/mealplanning_recipe_step_completion_conditions.go
@@ -83,7 +83,7 @@ var getRecipeStepCompletionConditionsTool = &mcp.Tool{
 	InputSchema: schemaObject(map[string]any{
 		"RecipeID":     stringField("The ID of the recipe"),
 		"RecipeStepID": stringField("The ID of the recipe step"),
-		"Filter":       queryFilterSchema(),
+		"Filter":       filtering.QueryFilterSchema(),
 	}),
 	OutputSchema: schemaObject(map[string]any{
 		"Results": arrayType(schemaObject(recipeStepCompletionConditionsSchema)),

--- a/backend/internal/mcpserver/mealplanning_recipe_step_ingredients.go
+++ b/backend/internal/mcpserver/mealplanning_recipe_step_ingredients.go
@@ -84,7 +84,7 @@ var getRecipeStepIngredientsTool = &mcp.Tool{
 	InputSchema: schemaObject(map[string]any{
 		"RecipeID":     stringField("The ID of the recipe"),
 		"RecipeStepID": stringField("The ID of the recipe step"),
-		"Filter":       queryFilterSchema(),
+		"Filter":       filtering.QueryFilterSchema(),
 	}),
 	OutputSchema: schemaObject(map[string]any{
 		"Results": arrayType(schemaObject(recipeStepIngredientsSchema)),

--- a/backend/internal/mcpserver/mealplanning_recipe_step_instruments.go
+++ b/backend/internal/mcpserver/mealplanning_recipe_step_instruments.go
@@ -79,7 +79,7 @@ var getRecipeStepInstrumentsTool = &mcp.Tool{
 	InputSchema: schemaObject(map[string]any{
 		"RecipeID":     stringField("The ID of the recipe"),
 		"RecipeStepID": stringField("The ID of the recipe step"),
-		"Filter":       queryFilterSchema(),
+		"Filter":       filtering.QueryFilterSchema(),
 	}),
 	OutputSchema: schemaObject(map[string]any{
 		"Results": arrayType(schemaObject(recipeStepInstrumentsSchema)),

--- a/backend/internal/mcpserver/mealplanning_recipe_step_products.go
+++ b/backend/internal/mcpserver/mealplanning_recipe_step_products.go
@@ -88,7 +88,7 @@ var getRecipeStepProductsTool = &mcp.Tool{
 	InputSchema: schemaObject(map[string]any{
 		"RecipeID":     stringField("The ID of the recipe"),
 		"RecipeStepID": stringField("The ID of the recipe step"),
-		"Filter":       queryFilterSchema(),
+		"Filter":       filtering.QueryFilterSchema(),
 	}),
 	OutputSchema: schemaObject(map[string]any{
 		"Results": arrayType(schemaObject(recipeStepProductsSchema)),

--- a/backend/internal/mcpserver/mealplanning_recipe_step_vessels.go
+++ b/backend/internal/mcpserver/mealplanning_recipe_step_vessels.go
@@ -78,7 +78,7 @@ var getRecipeStepVesselsTool = &mcp.Tool{
 	InputSchema: schemaObject(map[string]any{
 		"RecipeID":     stringField("The ID of the recipe"),
 		"RecipeStepID": stringField("The ID of the recipe step"),
-		"Filter":       queryFilterSchema(),
+		"Filter":       filtering.QueryFilterSchema(),
 	}),
 	OutputSchema: schemaObject(map[string]any{
 		"Results": arrayType(schemaObject(recipeStepVesselsSchema)),

--- a/backend/internal/mcpserver/mealplanning_recipe_steps.go
+++ b/backend/internal/mcpserver/mealplanning_recipe_steps.go
@@ -96,7 +96,7 @@ var getRecipeStepsTool = &mcp.Tool{
 	Description: "Get recipe steps with optional filtering",
 	InputSchema: schemaObject(map[string]any{
 		"RecipeID": stringField("The ID of the recipe"),
-		"Filter":   queryFilterSchema(),
+		"Filter":   filtering.QueryFilterSchema(),
 	}),
 	OutputSchema: schemaObject(map[string]any{
 		"Results": arrayType(schemaObject(recipeStepsSchema)),

--- a/backend/internal/mcpserver/mealplanning_recipes.go
+++ b/backend/internal/mcpserver/mealplanning_recipes.go
@@ -78,7 +78,7 @@ var getRecipesTool = &mcp.Tool{
 	Name:        "GetRecipes",
 	Description: "Get recipes with optional filtering",
 	InputSchema: schemaObject(map[string]any{
-		"Filter": queryFilterSchema(),
+		"Filter": filtering.QueryFilterSchema(),
 	}),
 	OutputSchema: schemaObject(map[string]any{
 		"Results": arrayType(schemaObject(recipesSchema)),
@@ -118,7 +118,7 @@ var searchForRecipesTool = &mcp.Tool{
 	Description: "Search for recipes with optional filtering",
 	InputSchema: schemaObject(map[string]any{
 		"Query":  stringField("The search query string"),
-		"Filter": queryFilterSchema(),
+		"Filter": filtering.QueryFilterSchema(),
 	}),
 	OutputSchema: schemaObject(map[string]any{
 		"Results": arrayType(schemaObject(recipesSchema)),

--- a/backend/internal/mcpserver/mealplanning_valid_ingredient_measurement_units.go
+++ b/backend/internal/mcpserver/mealplanning_valid_ingredient_measurement_units.go
@@ -66,7 +66,7 @@ var getValidIngredientMeasurementUnitsTool = &mcp.Tool{
 	Name:        "GetValidIngredientMeasurementUnits",
 	Description: "Get valid ingredient measurement units with optional filtering",
 	InputSchema: schemaObject(map[string]any{
-		"Filter": queryFilterSchema(),
+		"Filter": filtering.QueryFilterSchema(),
 	}),
 	OutputSchema: schemaObject(map[string]any{
 		"Results": arrayType(schemaObject(validIngredientMeasurementUnitsSchema)),

--- a/backend/internal/mcpserver/mealplanning_valid_ingredient_preparations.go
+++ b/backend/internal/mcpserver/mealplanning_valid_ingredient_preparations.go
@@ -64,7 +64,7 @@ var getValidIngredientPreparationsTool = &mcp.Tool{
 	Name:        "GetValidIngredientPreparations",
 	Description: "Get valid ingredient preparations with optional filtering",
 	InputSchema: schemaObject(map[string]any{
-		"Filter": queryFilterSchema(),
+		"Filter": filtering.QueryFilterSchema(),
 	}),
 	OutputSchema: schemaObject(map[string]any{
 		"Results": arrayType(schemaObject(validIngredientPreparationsSchema)),

--- a/backend/internal/mcpserver/mealplanning_valid_ingredient_state_ingredients.go
+++ b/backend/internal/mcpserver/mealplanning_valid_ingredient_state_ingredients.go
@@ -64,7 +64,7 @@ var getValidIngredientStateIngredientsTool = &mcp.Tool{
 	Name:        "GetValidIngredientStateIngredients",
 	Description: "Get valid ingredient state ingredients with optional filtering",
 	InputSchema: schemaObject(map[string]any{
-		"Filter": queryFilterSchema(),
+		"Filter": filtering.QueryFilterSchema(),
 	}),
 	OutputSchema: schemaObject(map[string]any{
 		"Results": arrayType(schemaObject(validIngredientStateIngredientsSchema)),

--- a/backend/internal/mcpserver/mealplanning_valid_ingredient_states.go
+++ b/backend/internal/mcpserver/mealplanning_valid_ingredient_states.go
@@ -68,7 +68,7 @@ var searchForValidIngredientStatesTool = &mcp.Tool{
 	Name:        "SearchForValidIngredientStates",
 	Description: "Search for valid ingredient states with optional filtering and query string",
 	InputSchema: schemaObject(map[string]any{
-		"Filter": queryFilterSchema(),
+		"Filter": filtering.QueryFilterSchema(),
 		"Query": map[string]any{
 			"type":        strType,
 			"description": "The ingredient state name query",

--- a/backend/internal/mcpserver/mealplanning_valid_ingredients.go
+++ b/backend/internal/mcpserver/mealplanning_valid_ingredients.go
@@ -96,7 +96,7 @@ var searchForValidIngredientsTool = &mcp.Tool{
 	Name:        "SearchForValidIngredients",
 	Description: "Search for valid ingredients with optional filtering and query string",
 	InputSchema: schemaObject(map[string]any{
-		"Filter": queryFilterSchema(),
+		"Filter": filtering.QueryFilterSchema(),
 		"Query": map[string]any{
 			"type":        strType,
 			"description": "The ingredient name query",

--- a/backend/internal/mcpserver/mealplanning_valid_instruments.go
+++ b/backend/internal/mcpserver/mealplanning_valid_instruments.go
@@ -70,7 +70,7 @@ var searchForValidInstrumentsTool = &mcp.Tool{
 	Name:        "SearchForValidInstruments",
 	Description: "Search for valid instruments with optional filtering and query string",
 	InputSchema: schemaObject(map[string]any{
-		"Filter": queryFilterSchema(),
+		"Filter": filtering.QueryFilterSchema(),
 		"Query": map[string]any{
 			"type":        strType,
 			"description": "The instrument name query",

--- a/backend/internal/mcpserver/mealplanning_valid_measurement_unit_conversions.go
+++ b/backend/internal/mcpserver/mealplanning_valid_measurement_unit_conversions.go
@@ -67,7 +67,7 @@ var getValidMeasurementUnitConversionsForUnitTool = &mcp.Tool{
 	Name:        "GetValidMeasurementUnitConversionsForUnit",
 	Description: "Get valid measurement unit conversions for a specific measurement unit with optional filtering",
 	InputSchema: schemaObject(map[string]any{
-		"Filter":                 queryFilterSchema(),
+		"Filter":                 filtering.QueryFilterSchema(),
 		"ValidMeasurementUnitID": stringField("The ID of the valid measurement unit"),
 	}),
 	OutputSchema: schemaObject(map[string]any{

--- a/backend/internal/mcpserver/mealplanning_valid_measurement_units.go
+++ b/backend/internal/mcpserver/mealplanning_valid_measurement_units.go
@@ -71,7 +71,7 @@ var searchForValidMeasurementUnitsTool = &mcp.Tool{
 	Name:        "SearchForValidMeasurementUnits",
 	Description: "Search for valid measurement units with optional filtering and query string",
 	InputSchema: schemaObject(map[string]any{
-		"Filter": queryFilterSchema(),
+		"Filter": filtering.QueryFilterSchema(),
 		"Query": map[string]any{
 			"type":        strType,
 			"description": "The measurement unit name query",

--- a/backend/internal/mcpserver/mealplanning_valid_prep_task_configs.go
+++ b/backend/internal/mcpserver/mealplanning_valid_prep_task_configs.go
@@ -71,7 +71,7 @@ var getValidPrepTaskConfigsTool = &mcp.Tool{
 	Name:        "GetValidPrepTaskConfigs",
 	Description: "Get valid prep task configs with optional filtering. Prep task configs define how long prepped ingredients can be stored.",
 	InputSchema: schemaObject(map[string]any{
-		"Filter": queryFilterSchema(),
+		"Filter": filtering.QueryFilterSchema(),
 	}),
 	OutputSchema: schemaObject(map[string]any{
 		"Results": arrayType(schemaObject(validPrepTaskConfigsSchema)),
@@ -107,7 +107,7 @@ var getValidPrepTaskConfigsByIngredientTool = &mcp.Tool{
 	Description: "Get valid prep task configs for a specific ingredient. Use this to find storage information for a particular ingredient.",
 	InputSchema: schemaObject(map[string]any{
 		"ValidIngredientID": stringField("The ID of the ingredient to get prep task configs for"),
-		"Filter":            queryFilterSchema(),
+		"Filter":            filtering.QueryFilterSchema(),
 	}),
 	OutputSchema: schemaObject(map[string]any{
 		"Results": arrayType(schemaObject(validPrepTaskConfigsSchema)),
@@ -143,7 +143,7 @@ var getValidPrepTaskConfigsByPreparationTool = &mcp.Tool{
 	Description: "Get valid prep task configs for a specific preparation method. Use this to find storage information for ingredients prepared a certain way.",
 	InputSchema: schemaObject(map[string]any{
 		"ValidPreparationID": stringField("The ID of the preparation to get prep task configs for"),
-		"Filter":             queryFilterSchema(),
+		"Filter":             filtering.QueryFilterSchema(),
 	}),
 	OutputSchema: schemaObject(map[string]any{
 		"Results": arrayType(schemaObject(validPrepTaskConfigsSchema)),
@@ -181,7 +181,7 @@ var getValidPrepTaskConfigsByIngredientAndPreparationTool = &mcp.Tool{
 	InputSchema: schemaObject(map[string]any{
 		"ValidIngredientID":  stringField("The ID of the ingredient"),
 		"ValidPreparationID": stringField("The ID of the preparation"),
-		"Filter":             queryFilterSchema(),
+		"Filter":             filtering.QueryFilterSchema(),
 	}),
 	OutputSchema: schemaObject(map[string]any{
 		"Results": arrayType(schemaObject(validPrepTaskConfigsSchema)),

--- a/backend/internal/mcpserver/mealplanning_valid_preparation_instruments.go
+++ b/backend/internal/mcpserver/mealplanning_valid_preparation_instruments.go
@@ -64,7 +64,7 @@ var getValidPreparationInstrumentsTool = &mcp.Tool{
 	Name:        "GetValidPreparationInstruments",
 	Description: "Get valid preparation instruments with optional filtering",
 	InputSchema: schemaObject(map[string]any{
-		"Filter": queryFilterSchema(),
+		"Filter": filtering.QueryFilterSchema(),
 	}),
 	OutputSchema: schemaObject(map[string]any{
 		"Results": arrayType(schemaObject(validPreparationInstrumentsSchema)),

--- a/backend/internal/mcpserver/mealplanning_valid_preparation_vessels.go
+++ b/backend/internal/mcpserver/mealplanning_valid_preparation_vessels.go
@@ -64,7 +64,7 @@ var getValidPreparationVesselsTool = &mcp.Tool{
 	Name:        "GetValidPreparationVessels",
 	Description: "Get valid preparation vessels with optional filtering",
 	InputSchema: schemaObject(map[string]any{
-		"Filter": queryFilterSchema(),
+		"Filter": filtering.QueryFilterSchema(),
 	}),
 	OutputSchema: schemaObject(map[string]any{
 		"Results": arrayType(schemaObject(validPreparationVesselsSchema)),

--- a/backend/internal/mcpserver/mealplanning_valid_preparations.go
+++ b/backend/internal/mcpserver/mealplanning_valid_preparations.go
@@ -80,7 +80,7 @@ var searchForValidPreparationsTool = &mcp.Tool{
 	Name:        "SearchForValidPreparations",
 	Description: "Search for valid preparations with optional filtering and query string",
 	InputSchema: schemaObject(map[string]any{
-		"Filter": queryFilterSchema(),
+		"Filter": filtering.QueryFilterSchema(),
 		"Query": map[string]any{
 			"type":        strType,
 			"description": "The preparation name query",

--- a/backend/internal/mcpserver/mealplanning_valid_vessels.go
+++ b/backend/internal/mcpserver/mealplanning_valid_vessels.go
@@ -76,7 +76,7 @@ var searchForValidVesselsTool = &mcp.Tool{
 	Name:        "SearchForValidVessels",
 	Description: "Search for valid vessels with optional filtering and query string",
 	InputSchema: schemaObject(map[string]any{
-		"Filter": queryFilterSchema(),
+		"Filter": filtering.QueryFilterSchema(),
 		"Query": map[string]any{
 			"type":        strType,
 			"description": "The vessel name query",

--- a/backend/internal/mcpserver/schema.go
+++ b/backend/internal/mcpserver/schema.go
@@ -13,19 +13,18 @@ const (
 	dtFmt = "date-time"
 )
 
-// queryFilterSchema returns the JSON schema for a QueryFilter object.
-func queryFilterSchema() map[string]any {
-	return objectType(map[string]any{
-		"SortBy":          stringField("Field to sort by"),
-		"CreatedAfter":    timestampField("Filter results created after this timestamp (ISO 8601)"),
-		"CreatedBefore":   timestampField("Filter results created before this timestamp (ISO 8601)"),
-		"UpdatedAfter":    timestampField("Filter results updated after this timestamp (ISO 8601)"),
-		"UpdatedBefore":   timestampField("Filter results updated before this timestamp (ISO 8601)"),
-		"MaxResponseSize": intField("Maximum number of results to return"),
-		"IncludeArchived": boolField("Whether to include archived items"),
-		"Cursor":          stringField("Pagination cursor for fetching next page"),
-	})
-}
+// The schema for a QueryFilter is not here. filtering.QueryFilterSchema reflects it off the
+// struct, and the hand-written mirror that used to live here is why: it described SortBy as the
+// field to sort by rather than the direction to sort in and carried no enum, declared
+// MaxResponseSize as an unbounded integer, and — because the invocation structs below hand the
+// decoded object straight to encoding/json — keyed every property on the Go field name against
+// camelCase json tags, so a filter a model supplied was dropped in full and the list came back
+// unfiltered and plausible.
+//
+// The rest of this file has the same exposure. Every domain type's schema below is written out
+// by hand beside a struct that can move without it, and the drift would look the same. Replacing
+// those is a larger job than this one — the types are ours rather than platform's, so it means
+// deciding where their descriptions live — and it is not done here.
 
 func schemaObject(properties map[string]any) map[string]any {
 	return map[string]any{
@@ -67,13 +66,6 @@ func uintField(description string) map[string]any {
 		"type":        intType,
 		"description": description,
 		"minimum":     0,
-	}
-}
-
-func intField(description string) map[string]any {
-	return map[string]any{
-		"type":        intType,
-		"description": description,
 	}
 }
 

--- a/backend/internal/mcpserver/schema_test.go
+++ b/backend/internal/mcpserver/schema_test.go
@@ -1,10 +1,50 @@
 package mcpserver
 
 import (
+	"reflect"
+	"strings"
 	"testing"
 
+	"github.com/primandproper/platform-go/v10/filtering"
+
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+// TestFilterSchemaMatchesQueryFilter asserts that what a tool advertises for its Filter argument
+// is named the way the decoder reads it.
+//
+// A tool's invocation struct holds a *filtering.QueryFilter and the SDK unmarshals into it, so a
+// property the schema names something encoding/json does not recognize is not a wrong hint — it
+// is a filter that is discarded in full, answered with an unfiltered page that looks like a
+// filtered one. The hand-written schema this replaced named all eight of them that way.
+func TestFilterSchemaMatchesQueryFilter(t *testing.T) {
+	t.Parallel()
+
+	schema := filtering.QueryFilterSchema()
+
+	properties, ok := schema["properties"].(map[string]any)
+	require.True(t, ok, "schema has no properties object")
+
+	filterType := reflect.TypeOf(filtering.QueryFilter{})
+
+	expected := make([]string, 0, filterType.NumField())
+	for i := range filterType.NumField() {
+		name, _, _ := strings.Cut(filterType.Field(i).Tag.Get("json"), ",")
+		if name == "" || name == "-" {
+			continue
+		}
+
+		expected = append(expected, name)
+	}
+
+	actual := make([]string, 0, len(properties))
+	for name := range properties {
+		actual = append(actual, name)
+	}
+
+	assert.ElementsMatch(t, expected, actual)
+}
 
 func Test_objectType(T *testing.T) {
 	T.Parallel()

--- a/backend/internal/mcpserver/schema_test.go
+++ b/backend/internal/mcpserver/schema_test.go
@@ -26,11 +26,11 @@ func TestFilterSchemaMatchesQueryFilter(t *testing.T) {
 	properties, ok := schema["properties"].(map[string]any)
 	require.True(t, ok, "schema has no properties object")
 
-	filterType := reflect.TypeOf(filtering.QueryFilter{})
+	filterType := reflect.TypeFor[filtering.QueryFilter]()
 
 	expected := make([]string, 0, filterType.NumField())
-	for i := range filterType.NumField() {
-		name, _, _ := strings.Cut(filterType.Field(i).Tag.Get("json"), ",")
+	for field := range filterType.Fields() {
+		name, _, _ := strings.Cut(field.Tag.Get("json"), ",")
 		if name == "" || name == "-" {
 			continue
 		}

--- a/backend/internal/mcpserver/waitlists_waitlists.go
+++ b/backend/internal/mcpserver/waitlists_waitlists.go
@@ -58,7 +58,7 @@ var getWaitlistsTool = &mcp.Tool{
 	Name:        "GetWaitlists",
 	Description: "Get waitlists with optional filtering",
 	InputSchema: schemaObject(map[string]any{
-		"Filter": queryFilterSchema(),
+		"Filter": filtering.QueryFilterSchema(),
 	}),
 	OutputSchema: schemaObject(map[string]any{
 		"Results": arrayType(schemaObject(waitlistSchema)),
@@ -90,7 +90,7 @@ var getActiveWaitlistsTool = &mcp.Tool{
 	Name:        "GetActiveWaitlists",
 	Description: "Get waitlists that are currently active (not expired)",
 	InputSchema: schemaObject(map[string]any{
-		"Filter": queryFilterSchema(),
+		"Filter": filtering.QueryFilterSchema(),
 	}),
 	OutputSchema: schemaObject(map[string]any{
 		"Results": arrayType(schemaObject(waitlistSchema)),
@@ -148,7 +148,7 @@ var getWaitlistSignupsForWaitlistTool = &mcp.Tool{
 	Description: "Get all signups for a specific waitlist",
 	InputSchema: schemaObject(map[string]any{
 		"WaitlistID": stringField("The ID of the waitlist"),
-		"Filter":     queryFilterSchema(),
+		"Filter":     filtering.QueryFilterSchema(),
 	}),
 	OutputSchema: schemaObject(map[string]any{
 		"Results": arrayType(schemaObject(waitlistSignupSchema)),

--- a/backend/internal/mcpserver/webhooks_webhooks.go
+++ b/backend/internal/mcpserver/webhooks_webhooks.go
@@ -69,7 +69,7 @@ var getWebhooksTool = &mcp.Tool{
 	Name:        "GetWebhooks",
 	Description: "Get webhooks with optional filtering",
 	InputSchema: schemaObject(map[string]any{
-		"Filter": queryFilterSchema(),
+		"Filter": filtering.QueryFilterSchema(),
 	}),
 	OutputSchema: schemaObject(map[string]any{
 		"Results": arrayType(schemaObject(webhookSchema)),


### PR DESCRIPTION
Part of #1296, part of #1297. Second of three independent #1296 items.

## This is a live bug, not a tidiness change

`queryFilterSchema()` in `internal/mcpserver/schema.go` was a hand-written mirror of `filtering.QueryFilter`. The v10.1 commit that added `filtering.QueryFilterSchema()` (platform PR #254) describes it exactly:

> A consumer describing `QueryFilter` to a tool-calling model wrote the schema out by hand, and it drifted: `SortBy` was described as the field to sort by rather than the direction to sort in and carried no enum, `MaxResponseSize` was a bare integer …

Those two are misleading. The third one is broken:

```go
type SearchValidIngredientsInvocation struct {
	Filter *filtering.QueryFilter   // ← the SDK unmarshals into this
	Query  string
}
```

```go
// what we advertised          // what QueryFilter's tags say
"SortBy":          …           `json:"sortBy,omitempty"`
"CreatedAfter":    …           `json:"createdAfter,omitempty"`
"MaxResponseSize": …           `json:"maxResponseSize,omitempty"`
…
```

Every property was keyed on the Go field name against camelCase json tags. A filter a model supplied was discarded in full by `encoding/json`, and the tool answered with an **unfiltered page that looked like a filtered one** — no error, no log line. All eight fields, across all 32 list tools.

(The outer `"Filter"` key matched, because that field has no json tag. Only the inner ones were wrong.)

## The change

Delete `queryFilterSchema()`, call `filtering.QueryFilterSchema()` at all 32 sites. It reflects the document off the struct, so there is no second copy to drift; every constraint is a struct tag written once. Refs are inlined deliberately — a `$ref`/`$defs` document is the one thing a tool definition cannot carry, since a provider is handed the map unchanged and resolves nothing.

`intField` had no other caller and goes with it.

## Compatibility

The advertised property names change from `SortBy` to `sortBy` and so on. Nothing regresses: the PascalCase names were never decoded. A model that guessed camelCase already worked and still does.

## Test

`TestFilterSchemaMatchesQueryFilter` asserts the advertised property names are exactly the json tag names the decoder reads — the specific failure above, rather than a golden copy of the document.

## Noted, not fixed

The ticket asks whether the rest of `schema.go` has the same problem. It does: every domain type's schema is written out by hand beside a struct that can move without it. Those types are ours rather than platform's, so replacing them means deciding where their descriptions live. That is a larger job and is not in this PR; there is a comment in `schema.go` saying so.

`go build ./...`, `go vet ./...` and `gofmt` clean; package tests pass under `-race`. Remaining `golangci-lint` findings in the package (goconst, one gosec G710 in `oauth2_handler.go`) are pre-existing on `main` in files this PR does not touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017iSaVKFpZdnMSt7W174AgB