### PR TITLE
refactor(events): derive index events from a registered outbox side effect

### DIFF
--- a/backend/internal/indexevents/indexevents.go
+++ b/backend/internal/indexevents/indexevents.go
@@ -1,0 +1,213 @@
+/*
+Package indexevents says which writes feed which search index.
+
+A write that changes an indexed row owes the index an event. That obligation used to be an
+option on the emit call — every repository method that touched an indexed entity passed
+WithIndexUpsert or WithIndexDelete by hand, at forty call sites — and an obligation expressed as
+an option is one a call site can forget. A repository method that omitted it compiled, reviewed
+clean, and left the index stale until the next scheduled rebuild, with no test that would catch
+it and no metric that would show it.
+
+So the obligation is no longer a parameter. SideEffect is registered on the outbox Writer once,
+runs inside every Enqueue, and derives the index events from the data change messages the caller
+was already sending. The table below is the whole of what it knows, and it is the one place to
+edit when an entity becomes indexed.
+
+# What the table says
+
+Each row maps an event type to the index it feeds, whether the document is written or removed,
+and the key in the message's context that holds the document's ID. Everything a row needs is
+already in the message: the event type says what happened, and the context map carries the ID.
+
+An event type absent from the table produces no index event, which is right — most of them
+should not.
+
+# Two things that are easy to get wrong
+
+Archiving a *sub-entity* of an indexed document is an upsert, not a delete. Archiving a recipe
+step leaves the recipe indexed and changes what it says, so RecipeStepArchived upserts the
+recipe. Only archiving the indexed entity itself is a delete.
+
+The document ID is not always the ID of the thing that changed. Every recipe step, ingredient,
+instrument and vessel write reindexes its parent *recipe*, because the indexed recipe document
+embeds their names — so those rows read the recipe's ID out of the context, not the sub-entity's.
+*/
+package indexevents
+
+import (
+	"context"
+
+	"github.com/primandproper/dinnerdonebetter/backend/internal/domain/audit"
+	"github.com/primandproper/dinnerdonebetter/backend/internal/domain/identity"
+	identitykeys "github.com/primandproper/dinnerdonebetter/backend/internal/domain/identity/keys"
+	types "github.com/primandproper/dinnerdonebetter/backend/internal/domain/mealplanning"
+	mealplanningkeys "github.com/primandproper/dinnerdonebetter/backend/internal/domain/mealplanning/keys"
+	identityindexing "github.com/primandproper/dinnerdonebetter/backend/internal/services/identity/indexing"
+	mealplanningindexing "github.com/primandproper/dinnerdonebetter/backend/internal/services/mealplanning/indexing"
+
+	"github.com/primandproper/platform-go/v10/database"
+	platformerrors "github.com/primandproper/platform-go/v10/errors"
+	"github.com/primandproper/platform-go/v10/outbox"
+	searchsync "github.com/primandproper/platform-go/v10/search/sync"
+)
+
+// SideEffectName identifies this effect on the Writer. It appears in the error a duplicate or
+// nil registration is refused with.
+const SideEffectName = "search-index"
+
+// RecipeStepCreatedIndexTrigger stands in for an event type that does not exist.
+//
+// Creating a recipe step reindexes its recipe but announces nothing: there is no
+// recipe_step_created data change event, and there deliberately is not one. The constant existed
+// once and put the event in the generated webhook catalog, where it was subscribable and could
+// never fire; it was removed rather than made to fire, because a step creation reaches
+// subscribers as the recipe event that accompanies it.
+//
+// That decision stands, so this is a trigger rather than an event type: Emitter.EmitIndex passes
+// it to derive the index event without putting anything on the wire. It is not in the webhook
+// catalog, and nothing publishes it.
+const RecipeStepCreatedIndexTrigger = "recipe_step_created.index_only"
+
+// Spec is one row: the index an event feeds, what it does to the document, and where to find
+// the document's ID.
+type Spec struct {
+	// Index is the index's name, which the indexing packages declare as their IndexType
+	// constants. It is also the topic, because platform-go says which index an event belongs to
+	// by where it arrived.
+	Index string
+
+	// IDKey is the key in the message's context holding the ID the index holds the document
+	// under. It is not always the ID of the entity that changed — see the package doc.
+	IDKey string
+
+	// Op is whether the document is written or removed. Archival of the indexed entity counts
+	// as removal; archival of a sub-entity does not.
+	Op searchsync.Op
+}
+
+// byEventType is the table. Adding an indexed entity means adding rows here and nothing in the
+// repository layer.
+var byEventType = map[string]Spec{
+	// Users.
+	identity.UserSignedUpServiceEventType: {identityindexing.IndexTypeUsers, identitykeys.UserIDKey, searchsync.OpUpsert},
+	identity.UsernameChangedEventType:     {identityindexing.IndexTypeUsers, identitykeys.UserIDKey, searchsync.OpUpsert},
+	identity.EmailAddressChangedEventType: {identityindexing.IndexTypeUsers, identitykeys.UserIDKey, searchsync.OpUpsert},
+	identity.UserDetailsChangedEventType:  {identityindexing.IndexTypeUsers, identitykeys.UserIDKey, searchsync.OpUpsert},
+	identity.UserArchivedServiceEventType: {identityindexing.IndexTypeUsers, identitykeys.UserIDKey, searchsync.OpDelete},
+
+	// Meals.
+	types.MealCreatedServiceEventType:  {mealplanningindexing.IndexTypeMeals, mealplanningkeys.MealIDKey, searchsync.OpUpsert},
+	types.MealArchivedServiceEventType: {mealplanningindexing.IndexTypeMeals, mealplanningkeys.MealIDKey, searchsync.OpDelete},
+
+	// Recipes, and everything under them. The indexed recipe document embeds each step's
+	// preparation name and the names of its ingredients, instruments and vessels, so a write to
+	// any of those reindexes the recipe — which is why every row here reads RecipeIDKey, and why
+	// archiving a sub-entity is an upsert.
+	types.RecipeCreatedServiceEventType:  {mealplanningindexing.IndexTypeRecipes, mealplanningkeys.RecipeIDKey, searchsync.OpUpsert},
+	types.RecipeUpdatedServiceEventType:  {mealplanningindexing.IndexTypeRecipes, mealplanningkeys.RecipeIDKey, searchsync.OpUpsert},
+	types.RecipeArchivedServiceEventType: {mealplanningindexing.IndexTypeRecipes, mealplanningkeys.RecipeIDKey, searchsync.OpDelete},
+
+	RecipeStepCreatedIndexTrigger:            {mealplanningindexing.IndexTypeRecipes, mealplanningkeys.RecipeIDKey, searchsync.OpUpsert},
+	types.RecipeStepUpdatedServiceEventType:  {mealplanningindexing.IndexTypeRecipes, mealplanningkeys.RecipeIDKey, searchsync.OpUpsert},
+	types.RecipeStepArchivedServiceEventType: {mealplanningindexing.IndexTypeRecipes, mealplanningkeys.RecipeIDKey, searchsync.OpUpsert},
+
+	types.RecipeStepIngredientCreatedServiceEventType:  {mealplanningindexing.IndexTypeRecipes, mealplanningkeys.RecipeIDKey, searchsync.OpUpsert},
+	types.RecipeStepIngredientUpdatedServiceEventType:  {mealplanningindexing.IndexTypeRecipes, mealplanningkeys.RecipeIDKey, searchsync.OpUpsert},
+	types.RecipeStepIngredientArchivedServiceEventType: {mealplanningindexing.IndexTypeRecipes, mealplanningkeys.RecipeIDKey, searchsync.OpUpsert},
+
+	types.RecipeStepInstrumentCreatedServiceEventType:  {mealplanningindexing.IndexTypeRecipes, mealplanningkeys.RecipeIDKey, searchsync.OpUpsert},
+	types.RecipeStepInstrumentUpdatedServiceEventType:  {mealplanningindexing.IndexTypeRecipes, mealplanningkeys.RecipeIDKey, searchsync.OpUpsert},
+	types.RecipeStepInstrumentArchivedServiceEventType: {mealplanningindexing.IndexTypeRecipes, mealplanningkeys.RecipeIDKey, searchsync.OpUpsert},
+
+	types.RecipeStepVesselCreatedServiceEventType:  {mealplanningindexing.IndexTypeRecipes, mealplanningkeys.RecipeIDKey, searchsync.OpUpsert},
+	types.RecipeStepVesselUpdatedServiceEventType:  {mealplanningindexing.IndexTypeRecipes, mealplanningkeys.RecipeIDKey, searchsync.OpUpsert},
+	types.RecipeStepVesselArchivedServiceEventType: {mealplanningindexing.IndexTypeRecipes, mealplanningkeys.RecipeIDKey, searchsync.OpUpsert},
+
+	// The catalog entities, each its own index and its own document.
+	types.ValidIngredientCreatedServiceEventType:  {mealplanningindexing.IndexTypeValidIngredients, mealplanningkeys.ValidIngredientIDKey, searchsync.OpUpsert},
+	types.ValidIngredientUpdatedServiceEventType:  {mealplanningindexing.IndexTypeValidIngredients, mealplanningkeys.ValidIngredientIDKey, searchsync.OpUpsert},
+	types.ValidIngredientArchivedServiceEventType: {mealplanningindexing.IndexTypeValidIngredients, mealplanningkeys.ValidIngredientIDKey, searchsync.OpDelete},
+
+	types.ValidIngredientStateCreatedServiceEventType:  {mealplanningindexing.IndexTypeValidIngredientStates, mealplanningkeys.ValidIngredientStateIDKey, searchsync.OpUpsert},
+	types.ValidIngredientStateUpdatedServiceEventType:  {mealplanningindexing.IndexTypeValidIngredientStates, mealplanningkeys.ValidIngredientStateIDKey, searchsync.OpUpsert},
+	types.ValidIngredientStateArchivedServiceEventType: {mealplanningindexing.IndexTypeValidIngredientStates, mealplanningkeys.ValidIngredientStateIDKey, searchsync.OpDelete},
+
+	types.ValidInstrumentCreatedServiceEventType:  {mealplanningindexing.IndexTypeValidInstruments, mealplanningkeys.ValidInstrumentIDKey, searchsync.OpUpsert},
+	types.ValidInstrumentUpdatedServiceEventType:  {mealplanningindexing.IndexTypeValidInstruments, mealplanningkeys.ValidInstrumentIDKey, searchsync.OpUpsert},
+	types.ValidInstrumentArchivedServiceEventType: {mealplanningindexing.IndexTypeValidInstruments, mealplanningkeys.ValidInstrumentIDKey, searchsync.OpDelete},
+
+	types.ValidMeasurementUnitCreatedServiceEventType:  {mealplanningindexing.IndexTypeValidMeasurementUnits, mealplanningkeys.ValidMeasurementUnitIDKey, searchsync.OpUpsert},
+	types.ValidMeasurementUnitUpdatedServiceEventType:  {mealplanningindexing.IndexTypeValidMeasurementUnits, mealplanningkeys.ValidMeasurementUnitIDKey, searchsync.OpUpsert},
+	types.ValidMeasurementUnitArchivedServiceEventType: {mealplanningindexing.IndexTypeValidMeasurementUnits, mealplanningkeys.ValidMeasurementUnitIDKey, searchsync.OpDelete},
+
+	types.ValidPreparationCreatedServiceEventType:  {mealplanningindexing.IndexTypeValidPreparations, mealplanningkeys.ValidPreparationIDKey, searchsync.OpUpsert},
+	types.ValidPreparationUpdatedServiceEventType:  {mealplanningindexing.IndexTypeValidPreparations, mealplanningkeys.ValidPreparationIDKey, searchsync.OpUpsert},
+	types.ValidPreparationArchivedServiceEventType: {mealplanningindexing.IndexTypeValidPreparations, mealplanningkeys.ValidPreparationIDKey, searchsync.OpDelete},
+
+	types.ValidVesselCreatedServiceEventType:  {mealplanningindexing.IndexTypeValidVessels, mealplanningkeys.ValidVesselIDKey, searchsync.OpUpsert},
+	types.ValidVesselUpdatedServiceEventType:  {mealplanningindexing.IndexTypeValidVessels, mealplanningkeys.ValidVesselIDKey, searchsync.OpUpsert},
+	types.ValidVesselArchivedServiceEventType: {mealplanningindexing.IndexTypeValidVessels, mealplanningkeys.ValidVesselIDKey, searchsync.OpDelete},
+}
+
+// SideEffect derives the index events implied by the messages a caller enqueued.
+//
+// Register it once on the outbox Writer. It then runs inside every Enqueue, on the caller's
+// executor, so the index events are written by the same statement as the row change and commit
+// with it — an index event cannot outlive a rolled-back write, and a committed write cannot lose
+// its index event.
+//
+// The executor is unused: every row this needs is already in the message. It is in the signature
+// because an effect that has to read the database to decide is the reason the signature has one.
+func SideEffect(_ context.Context, _ database.SQLQueryExecutor, msgs []outbox.Message) ([]outbox.Message, error) {
+	var derived []outbox.Message
+
+	for i := range msgs {
+		// The outbox never looks inside a Payload, so the assertion is ours to make. A message
+		// that is not a data change message is another effect's business or nobody's.
+		msg, ok := msgs[i].Payload.(*audit.DataChangeMessage)
+		if !ok {
+			continue
+		}
+
+		spec, tabled := byEventType[msg.EventType]
+		if !tabled {
+			continue
+		}
+
+		documentID, isString := msg.Context[spec.IDKey].(string)
+		if !isString || documentID == "" {
+			// Refused rather than skipped, and the caller's transaction rolls back with it.
+			// Skipping would put back exactly the failure this package removes: a write that
+			// commits, an index that does not hear about it, and nothing anywhere that says so.
+			return nil, platformerrors.Errorf(
+				"deriving index event for %q: context has no document ID under %q",
+				msg.EventType, spec.IDKey,
+			)
+		}
+
+		// Built through searchsync so the outbox key is the document ID, which is what buys
+		// per-document ordering: at most one event per document in flight, however many relays
+		// are running.
+		derived = append(derived, searchsync.NewEvent(spec.Op, documentID).Message(spec.Index))
+	}
+
+	return derived, nil
+}
+
+// EventTypes reports every event type the table covers, for tests and for anything that wants to
+// assert the set rather than read it.
+func EventTypes() []string {
+	out := make([]string, 0, len(byEventType))
+	for eventType := range byEventType {
+		out = append(out, eventType)
+	}
+
+	return out
+}
+
+// SpecFor returns the row for an event type, if it has one.
+func SpecFor(eventType string) (Spec, bool) {
+	spec, ok := byEventType[eventType]
+
+	return spec, ok
+}

--- a/backend/internal/indexevents/indexevents_test.go
+++ b/backend/internal/indexevents/indexevents_test.go
@@ -1,0 +1,174 @@
+package indexevents
+
+import (
+	"testing"
+
+	"github.com/primandproper/dinnerdonebetter/backend/internal/domain/audit"
+
+	"github.com/primandproper/platform-go/v10/outbox"
+	searchsync "github.com/primandproper/platform-go/v10/search/sync"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func message(eventType string, context map[string]any) outbox.Message {
+	return outbox.Message{Topic: "data_changes", Payload: &audit.DataChangeMessage{EventType: eventType, Context: context}}
+}
+
+func TestSideEffect(T *testing.T) {
+	T.Parallel()
+
+	T.Run("derives an event keyed on the document", func(t *testing.T) {
+		t.Parallel()
+
+		spec, ok := SpecFor("valid_instrument_created")
+		require.True(t, ok)
+
+		derived, err := SideEffect(t.Context(), nil, []outbox.Message{
+			message("valid_instrument_created", map[string]any{spec.IDKey: "instrument_123"}),
+		})
+		require.NoError(t, err)
+		require.Len(t, derived, 1)
+
+		// The topic is the index: platform says which index an event belongs to by where it
+		// arrived.
+		assert.Equal(t, spec.Index, derived[0].Topic)
+
+		// The key is the document ID, which is what buys per-document ordering — at most one
+		// event per document in flight, however many relays are running.
+		assert.Equal(t, "instrument_123", derived[0].Key)
+
+		event, ok := derived[0].Payload.(searchsync.Event)
+		require.True(t, ok)
+		assert.Equal(t, "instrument_123", event.DocumentID)
+		assert.Equal(t, searchsync.OpUpsert, event.Op)
+	})
+
+	T.Run("derives one event per message", func(t *testing.T) {
+		t.Parallel()
+
+		instrument, ok := SpecFor("valid_instrument_created")
+		require.True(t, ok)
+		vessel, ok := SpecFor("valid_vessel_created")
+		require.True(t, ok)
+
+		derived, err := SideEffect(t.Context(), nil, []outbox.Message{
+			message("valid_instrument_created", map[string]any{instrument.IDKey: "a"}),
+			message("valid_vessel_created", map[string]any{vessel.IDKey: "b"}),
+		})
+		require.NoError(t, err)
+		assert.Len(t, derived, 2)
+	})
+
+	T.Run("archiving an indexed entity deletes its document", func(t *testing.T) {
+		t.Parallel()
+
+		spec, ok := SpecFor("valid_instrument_archived")
+		require.True(t, ok)
+
+		derived, err := SideEffect(t.Context(), nil, []outbox.Message{
+			message("valid_instrument_archived", map[string]any{spec.IDKey: "gone"}),
+		})
+		require.NoError(t, err)
+		require.Len(t, derived, 1)
+
+		event, ok := derived[0].Payload.(searchsync.Event)
+		require.True(t, ok)
+		assert.Equal(t, searchsync.OpDelete, event.Op)
+	})
+
+	T.Run("archiving a sub-entity reindexes its parent instead", func(t *testing.T) {
+		t.Parallel()
+
+		// An archived recipe step leaves the recipe indexed and changes what it says, so this
+		// is an upsert of the recipe rather than a delete of anything.
+		step, ok := SpecFor("recipe_step_archived")
+		require.True(t, ok)
+		recipe, ok := SpecFor("recipe_updated")
+		require.True(t, ok)
+
+		// The row reads the parent recipe's ID, which is the same key a recipe's own events use.
+		require.Equal(t, recipe.IDKey, step.IDKey)
+
+		derived, err := SideEffect(t.Context(), nil, []outbox.Message{
+			message("recipe_step_archived", map[string]any{step.IDKey: "recipe_1"}),
+		})
+		require.NoError(t, err)
+		require.Len(t, derived, 1)
+
+		assert.Equal(t, "recipe_1", derived[0].Key)
+
+		event, ok := derived[0].Payload.(searchsync.Event)
+		require.True(t, ok)
+		assert.Equal(t, searchsync.OpUpsert, event.Op)
+		assert.Equal(t, "recipe_1", event.DocumentID)
+	})
+
+	T.Run("an untabled event type derives nothing", func(t *testing.T) {
+		t.Parallel()
+
+		derived, err := SideEffect(t.Context(), nil, []outbox.Message{
+			message("webhook_created", map[string]any{"webhook_id": "wh_1"}),
+		})
+		require.NoError(t, err)
+		assert.Empty(t, derived)
+	})
+
+	T.Run("a payload that is not a data change message derives nothing", func(t *testing.T) {
+		t.Parallel()
+
+		derived, err := SideEffect(t.Context(), nil, []outbox.Message{
+			{Topic: "recipes", Payload: searchsync.NewEvent(searchsync.OpUpsert, "already_an_index_event")},
+		})
+		require.NoError(t, err)
+		assert.Empty(t, derived)
+	})
+
+	T.Run("with no document ID under the key the table names", func(t *testing.T) {
+		t.Parallel()
+
+		// Refused rather than skipped. Skipping would put back the failure this package
+		// removes: a write commits, the index never hears about it, and nothing says so.
+		_, err := SideEffect(t.Context(), nil, []outbox.Message{
+			message("valid_instrument_created", map[string]any{"some_other_key": "instrument_123"}),
+		})
+		assert.Error(t, err)
+	})
+
+	T.Run("with no messages", func(t *testing.T) {
+		t.Parallel()
+
+		derived, err := SideEffect(t.Context(), nil, nil)
+		require.NoError(t, err)
+		assert.Empty(t, derived)
+	})
+}
+
+func TestTable(T *testing.T) {
+	T.Parallel()
+
+	T.Run("every row names an index and a key", func(t *testing.T) {
+		t.Parallel()
+
+		for _, eventType := range EventTypes() {
+			spec, ok := SpecFor(eventType)
+			require.True(t, ok, eventType)
+
+			assert.NotEmpty(t, spec.Index, eventType)
+			assert.NotEmpty(t, spec.IDKey, eventType)
+			assert.Contains(t, []searchsync.Op{searchsync.OpUpsert, searchsync.OpDelete}, spec.Op, eventType)
+		}
+	})
+
+	T.Run("the index-only trigger is not a published event type", func(t *testing.T) {
+		t.Parallel()
+
+		// It stands in for an event that deliberately does not exist. If it ever collides with
+		// a real event type, every write of that type would derive a recipe reindex.
+		spec, ok := SpecFor(RecipeStepCreatedIndexTrigger)
+		require.True(t, ok)
+		assert.Equal(t, "recipes", spec.Index)
+		assert.Contains(t, RecipeStepCreatedIndexTrigger, ".index_only")
+	})
+}

--- a/backend/internal/repositories/postgres/events/do.go
+++ b/backend/internal/repositories/postgres/events/do.go
@@ -1,6 +1,7 @@
 package events
 
 import (
+	"github.com/primandproper/dinnerdonebetter/backend/internal/indexevents"
 	queuescfg "github.com/primandproper/dinnerdonebetter/backend/internal/queues/config"
 	"github.com/primandproper/dinnerdonebetter/backend/internal/repositories/postgres/webhookdispatch"
 
@@ -21,6 +22,11 @@ func RegisterOutboxEmitter(i do.Injector) {
 	do.Provide[*outbox.Writer](i, func(i do.Injector) (*outbox.Writer, error) {
 		return outbox.NewWriter(
 			dialect.Postgres,
+			// Every write to this outbox owes the search index an event, so the index event is
+			// registered here rather than passed per call. A repository method that changes an
+			// indexed row cannot fail to produce one by omitting an option it was never asked
+			// about; see internal/indexevents for which writes feed which index.
+			outbox.WithWriterSideEffect(indexevents.SideEffectName, indexevents.SideEffect),
 			outbox.WithWriterLogger(do.MustInvoke[logging.Logger](i)),
 			outbox.WithWriterTracerProvider(do.MustInvoke[tracing.Provider](i)),
 			outbox.WithWriterMetricsProvider(do.MustInvoke[metrics.Provider](i)),
@@ -46,6 +52,8 @@ func RegisterOutboxEmitter(i do.Injector) {
 		}
 
 		// NewEmitter returns nil for an empty topic, and a nil Emitter emits nothing.
-		return NewEmitter(do.MustInvoke[*outbox.Writer](i), topic, dispatcher), nil
+		// The same effect the writer was registered with, so EmitIndex derives from the same
+		// table rather than a second copy of it.
+		return NewEmitter(do.MustInvoke[*outbox.Writer](i), topic, dispatcher, indexevents.SideEffect), nil
 	})
 }

--- a/backend/internal/repositories/postgres/events/events.go
+++ b/backend/internal/repositories/postgres/events/events.go
@@ -38,6 +38,9 @@ import (
 type Emitter struct {
 	writer     *outbox.Writer
 	dispatcher *webhookdispatch.Dispatcher
+	// sideEffect is the same effect registered on the writer, kept so EmitIndex can run it
+	// over a message it never enqueues. See index_events.go.
+	sideEffect outbox.SideEffect
 	topic      string
 }
 
@@ -49,12 +52,12 @@ type Emitter struct {
 //
 // The dispatcher is separately optional and separately nil-safe, for the same reason at a
 // different granularity: a process with an outbox but no webhook tables still emits events.
-func NewEmitter(writer *outbox.Writer, topic string, dispatcher *webhookdispatch.Dispatcher) *Emitter {
+func NewEmitter(writer *outbox.Writer, topic string, dispatcher *webhookdispatch.Dispatcher, sideEffect outbox.SideEffect) *Emitter {
 	if writer == nil || topic == "" {
 		return nil
 	}
 
-	return &Emitter{writer: writer, topic: topic, dispatcher: dispatcher}
+	return &Emitter{writer: writer, topic: topic, dispatcher: dispatcher, sideEffect: sideEffect}
 }
 
 // EmitOption customizes one Emit.
@@ -62,9 +65,6 @@ type EmitOption func(*emitConfig)
 
 type emitConfig struct {
 	orderingKey string
-	// indexEvents are the search index events this write implies, already rendered as outbox
-	// messages bound for their index's topic. See index_events.go.
-	indexEvents []outbox.Message
 }
 
 // WithOrderingKey sets the webhook ordering key for this event, overriding the default of the
@@ -116,23 +116,21 @@ func (e *Emitter) Emit(ctx context.Context, q database.SQLQueryExecutor, logger 
 		}
 	}
 
-	// The data change event and every index event the same write implies are enqueued
-	// together, in one statement, inside the caller's transaction. That is what keeps a
-	// search index from diverging from the row the way it could when index events were
-	// published by a consumer downstream of the broker: there, the row committed and the
-	// index event was a second, unrelated write that could fail on its own, and nothing
-	// noticed until the next reindex.
-	msgs := make([]outbox.Message, 0, 1+len(cfg.indexEvents))
-	msgs = append(msgs, outbox.Message{
+	// The data change event is enqueued inside the caller's transaction, and the registered
+	// side effect derives this write's index events from it in the same statement. That is what
+	// keeps a search index from diverging from the row the way it could when index events were
+	// published by a consumer downstream of the broker: there, the row committed and the index
+	// event was a second, unrelated write that could fail on its own, and nothing noticed until
+	// the next reindex.
+	msg2 := outbox.Message{
 		Topic:   e.topic,
 		Payload: msg,
 		// Ordering is per account: two events for the same account publish in the order
 		// they were written, and events for different accounts do not wait on each other.
 		Key: msg.AccountID,
-	})
-	msgs = append(msgs, cfg.indexEvents...)
+	}
 
-	if err := e.writer.Enqueue(ctx, q, msgs...); err != nil {
+	if err := e.writer.Enqueue(ctx, q, msg2); err != nil {
 		return err
 	}
 

--- a/backend/internal/repositories/postgres/events/index_events.go
+++ b/backend/internal/repositories/postgres/events/index_events.go
@@ -3,8 +3,10 @@ package events
 import (
 	"context"
 
+	"github.com/primandproper/dinnerdonebetter/backend/internal/domain/audit"
+
 	"github.com/primandproper/platform-go/v10/database"
-	searchsync "github.com/primandproper/platform-go/v10/search/sync"
+	"github.com/primandproper/platform-go/v10/outbox"
 )
 
 /*
@@ -26,55 +28,41 @@ The topic is the index: platform-go says which index an event belongs to by wher
 because a searchsync.Event carries a document ID and an operation and nothing else. The
 document ID becomes the outbox key, which is what buys per-document ordering — at most one
 event per document is ever in flight, however many relays are running.
+
+# Where the events come from
+
+Nothing here decides which write feeds which index. That is a registered outbox side effect,
+supplied at construction, and it derives the index events from the data change messages this
+Emitter already sends. It used to be an EmitOption every call site passed by hand, which made a
+thing every write owes into a thing a call site could forget.
 */
 
-// WithIndexUpsert says this write left a row that the index named by topic should hold.
-//
-// topic is the index's name, which the indexing packages declare as their IndexType constants;
-// documentID is the row's ID, which must be the ID the index holds the document under.
-func WithIndexUpsert(topic, documentID string) EmitOption {
-	return withIndexEvent(topic, documentID, searchsync.OpUpsert)
-}
-
-// WithIndexDelete says this write removed the row, so the index should stop holding it.
-//
-// Archival counts as removal: an archived row is one the search index must not return, and the
-// Syncer applies a delete without reading anything back.
-func WithIndexDelete(topic, documentID string) EmitOption {
-	return withIndexEvent(topic, documentID, searchsync.OpDelete)
-}
-
-func withIndexEvent(topic, documentID string, op searchsync.Op) EmitOption {
-	return func(c *emitConfig) {
-		c.indexEvents = append(c.indexEvents, searchsync.NewEvent(op, documentID).Message(topic))
-	}
-}
-
-// EmitIndex enqueues index events for a write that emits no data change event of its own.
+// EmitIndex enqueues the index events a trigger implies, without announcing anything.
 //
 // Emit is the usual path, because a write worth indexing is nearly always a write worth
-// announcing, and passing the index event as an option to it keeps the two from being written
-// apart. This exists for the writes where that is not true — where announcing the change would
-// put an event on the wire that nothing puts there today, which is a decision about the public
-// event stream rather than about the index.
+// announcing, and the side effect derives the index event from the announcement. This exists for
+// the writes where that is not true — where putting the event on the wire would be a decision
+// about the public event stream rather than about the index.
 //
-// It takes the same EmitOptions as Emit and reads only the index ones, so a call site does not
-// have to know which of the two it is using.
-func (e *Emitter) EmitIndex(ctx context.Context, q database.SQLQueryExecutor, opts ...EmitOption) error {
-	if e == nil {
+// It runs the same side effect over the same shape of message, so such a write reads out of the
+// same table as every other. The message itself is never enqueued; only what the effect derives
+// from it is.
+func (e *Emitter) EmitIndex(ctx context.Context, q database.SQLQueryExecutor, trigger string, metadata map[string]any) error {
+	if e == nil || e.sideEffect == nil {
 		return nil
 	}
 
-	cfg := &emitConfig{}
-	for _, opt := range opts {
-		if opt != nil {
-			opt(cfg)
-		}
+	derived, err := e.sideEffect(ctx, q, []outbox.Message{{
+		Topic:   e.topic,
+		Payload: &audit.DataChangeMessage{EventType: trigger, Context: metadata},
+	}})
+	if err != nil {
+		return err
 	}
 
-	if len(cfg.indexEvents) == 0 {
+	if len(derived) == 0 {
 		return nil
 	}
 
-	return e.writer.Enqueue(ctx, q, cfg.indexEvents...)
+	return e.writer.Enqueue(ctx, q, derived...)
 }

--- a/backend/internal/repositories/postgres/identity/client_test.go
+++ b/backend/internal/repositories/postgres/identity/client_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/primandproper/dinnerdonebetter/backend/internal/domain/audit"
+	"github.com/primandproper/dinnerdonebetter/backend/internal/indexevents"
 	"github.com/primandproper/dinnerdonebetter/backend/internal/repositories/postgres/auditlogentries"
 	"github.com/primandproper/dinnerdonebetter/backend/internal/repositories/postgres/events"
 	"github.com/primandproper/dinnerdonebetter/backend/internal/repositories/postgres/identity/generated"
@@ -92,10 +93,10 @@ func buildDatabaseClientForTest(t *testing.T) (*repository, audit.Repository) {
 
 	// A real emitter, so the tests exercise the same path production does: the data change
 	// event and the search index event are further statements in the repository's transaction.
-	outboxWriter, err := outbox.NewWriter(dialect.Postgres, outbox.WithWriterLogger(loggingnoop.NewLogger()))
+	outboxWriter, err := outbox.NewWriter(dialect.Postgres, outbox.WithWriterLogger(loggingnoop.NewLogger()), outbox.WithWriterSideEffect(indexevents.SideEffectName, indexevents.SideEffect))
 	require.NoError(t, err)
 
-	c := ProvideIdentityRepository(loggingnoop.NewLogger(), tracingnoop.NewTracerProvider(), auditLogRepo, pgc, events.NewEmitter(outboxWriter, testDataChangesTopic, nil))
+	c := ProvideIdentityRepository(loggingnoop.NewLogger(), tracingnoop.NewTracerProvider(), auditLogRepo, pgc, events.NewEmitter(outboxWriter, testDataChangesTopic, nil, indexevents.SideEffect))
 	require.NoError(t, err)
 
 	return c.(*repository), auditLogRepo

--- a/backend/internal/repositories/postgres/identity/users.go
+++ b/backend/internal/repositories/postgres/identity/users.go
@@ -13,9 +13,7 @@ import (
 	"github.com/primandproper/dinnerdonebetter/backend/internal/domain/identity"
 	identitykeys "github.com/primandproper/dinnerdonebetter/backend/internal/domain/identity/keys"
 	"github.com/primandproper/dinnerdonebetter/backend/internal/domain/uploadedmedia"
-	"github.com/primandproper/dinnerdonebetter/backend/internal/repositories/postgres/events"
 	"github.com/primandproper/dinnerdonebetter/backend/internal/repositories/postgres/identity/generated"
-	identityindexing "github.com/primandproper/dinnerdonebetter/backend/internal/services/identity/indexing"
 
 	"github.com/primandproper/platform-go/v10/database"
 	platformerrors "github.com/primandproper/platform-go/v10/errors"
@@ -682,7 +680,7 @@ func (r *repository) CreateUser(ctx context.Context, input *identity.UserDatabas
 			identitykeys.AccountIDKey:                  account.ID,
 			identitykeys.UserIDKey:                     input.ID,
 			identitykeys.UserEmailVerificationTokenKey: token,
-		}, events.WithIndexUpsert(identityindexing.IndexTypeUsers, input.ID)); emitErr != nil {
+		}); emitErr != nil {
 			return observability.PrepareError(emitErr, span, "enqueuing data change event")
 		}
 
@@ -848,7 +846,7 @@ func (r *repository) UpdateUserUsername(ctx context.Context, userID, newUsername
 		// rows it describes.
 		if emitErr := r.events.Emit(ctx, tx, logger, identity.UsernameChangedEventType, "", map[string]any{
 			identitykeys.UserIDKey: userID,
-		}, events.WithIndexUpsert(identityindexing.IndexTypeUsers, userID)); emitErr != nil {
+		}); emitErr != nil {
 			return observability.PrepareError(emitErr, span, "enqueuing data change event")
 		}
 
@@ -910,7 +908,7 @@ func (r *repository) UpdateUserEmailAddress(ctx context.Context, userID, newEmai
 		// rows it describes.
 		if emitErr := r.events.Emit(ctx, tx, logger, identity.EmailAddressChangedEventType, "", map[string]any{
 			identitykeys.UserIDKey: userID,
-		}, events.WithIndexUpsert(identityindexing.IndexTypeUsers, userID)); emitErr != nil {
+		}); emitErr != nil {
 			return observability.PrepareError(emitErr, span, "enqueuing data change event")
 		}
 
@@ -981,7 +979,7 @@ func (r *repository) UpdateUserDetails(ctx context.Context, userID string, input
 		// rows it describes.
 		if emitErr := r.events.Emit(ctx, tx, logger, identity.UserDetailsChangedEventType, "", map[string]any{
 			identitykeys.UserIDKey: userID,
-		}, events.WithIndexUpsert(identityindexing.IndexTypeUsers, userID)); emitErr != nil {
+		}); emitErr != nil {
 			return observability.PrepareError(emitErr, span, "enqueuing data change event")
 		}
 
@@ -1287,7 +1285,7 @@ func (r *repository) ArchiveUser(ctx context.Context, userID string) error {
 		// rows it describes.
 		if emitErr := r.events.Emit(ctx, tx, logger, identity.UserArchivedServiceEventType, "", map[string]any{
 			identitykeys.UserIDKey: userID,
-		}, events.WithIndexDelete(identityindexing.IndexTypeUsers, userID)); emitErr != nil {
+		}); emitErr != nil {
 			return observability.PrepareError(emitErr, span, "enqueuing data change event")
 		}
 

--- a/backend/internal/repositories/postgres/mealplanning/client.go
+++ b/backend/internal/repositories/postgres/mealplanning/client.go
@@ -66,22 +66,21 @@ func ProvideMealPlanningRepository(
 // The enumeration tables (valid ingredients, vessels, preparations, and friends) are global
 // catalog data owned by no account, so they pass "".
 //
-// opts come after the write because Go puts the variadic parameter last. A write to an indexed
-// table passes events.WithIndexUpsert or events.WithIndexDelete here, which is what puts the
-// search index event in the same transaction as the row.
+// It takes no EmitOptions. It used to, so that a write to an indexed table could pass the search
+// index event as one — which made a thing every such write owes into a thing a call site could
+// forget. That obligation is registered on the outbox writer now; see internal/indexevents.
 func (q *repository) withEvent(
 	ctx context.Context,
 	logger logging.Logger,
 	eventType, accountID string,
 	metadata map[string]any,
 	write func(tx database.SQLQueryExecutor) error,
-	opts ...events.EmitOption,
 ) error {
 	return q.WithTransaction(ctx, func(tx database.SQLQueryExecutor) error {
 		if err := write(tx); err != nil {
 			return err
 		}
 
-		return q.events.Emit(ctx, tx, logger, eventType, accountID, metadata, opts...)
+		return q.events.Emit(ctx, tx, logger, eventType, accountID, metadata)
 	})
 }

--- a/backend/internal/repositories/postgres/mealplanning/client_test.go
+++ b/backend/internal/repositories/postgres/mealplanning/client_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/primandproper/dinnerdonebetter/backend/internal/domain/audit"
+	"github.com/primandproper/dinnerdonebetter/backend/internal/indexevents"
 	"github.com/primandproper/dinnerdonebetter/backend/internal/repositories/postgres/auditlogentries"
 	"github.com/primandproper/dinnerdonebetter/backend/internal/repositories/postgres/events"
 	"github.com/primandproper/dinnerdonebetter/backend/internal/repositories/postgres/identity"
@@ -66,7 +67,7 @@ func buildDatabaseClientForTest(t *testing.T) (*repository, audit.Repository) {
 
 	// A real emitter, so the tests exercise the same path production does: the event is
 	// another statement in the repository's transaction.
-	outboxWriter, err := outbox.NewWriter(dialect.Postgres, outbox.WithWriterLogger(loggingnoop.NewLogger()))
+	outboxWriter, err := outbox.NewWriter(dialect.Postgres, outbox.WithWriterLogger(loggingnoop.NewLogger()), outbox.WithWriterSideEffect(indexevents.SideEffectName, indexevents.SideEffect))
 	require.NoError(t, err)
 
 	c := ProvideMealPlanningRepository(
@@ -75,7 +76,7 @@ func buildDatabaseClientForTest(t *testing.T) (*repository, audit.Repository) {
 		auditLogEntryRepo,
 		identitiesRepo,
 		pgc,
-		events.NewEmitter(outboxWriter, testDataChangesTopic, nil),
+		events.NewEmitter(outboxWriter, testDataChangesTopic, nil, indexevents.SideEffect),
 	)
 
 	return c.(*repository), auditLogEntryRepo

--- a/backend/internal/repositories/postgres/mealplanning/meals.go
+++ b/backend/internal/repositories/postgres/mealplanning/meals.go
@@ -9,9 +9,7 @@ import (
 	identitykeys "github.com/primandproper/dinnerdonebetter/backend/internal/domain/identity/keys"
 	"github.com/primandproper/dinnerdonebetter/backend/internal/domain/mealplanning"
 	mealplanningkeys "github.com/primandproper/dinnerdonebetter/backend/internal/domain/mealplanning/keys"
-	"github.com/primandproper/dinnerdonebetter/backend/internal/repositories/postgres/events"
 	"github.com/primandproper/dinnerdonebetter/backend/internal/repositories/postgres/mealplanning/generated"
-	mealplanningindexing "github.com/primandproper/dinnerdonebetter/backend/internal/services/mealplanning/indexing"
 
 	"github.com/primandproper/platform-go/v10/database"
 	platformerrors "github.com/primandproper/platform-go/v10/errors"
@@ -649,7 +647,7 @@ func (q *repository) CreateMeal(ctx context.Context, input *mealplanning.MealDat
 		// rows it describes.
 		if emitErr := q.events.Emit(ctx, tx, q.logger, mealplanning.MealCreatedServiceEventType, "", map[string]any{
 			mealplanningkeys.MealIDKey: input.ID,
-		}, events.WithIndexUpsert(mealplanningindexing.IndexTypeMeals, input.ID)); emitErr != nil {
+		}); emitErr != nil {
 			return observability.PrepareError(emitErr, span, "enqueuing data change event")
 		}
 
@@ -749,7 +747,7 @@ func (q *repository) ArchiveMeal(ctx context.Context, mealID, userID string) err
 		}
 
 		return nil
-	}, events.WithIndexDelete(mealplanningindexing.IndexTypeMeals, mealID)); err != nil {
+	}); err != nil {
 		return err
 	}
 

--- a/backend/internal/repositories/postgres/mealplanning/recipe_step_ingredients.go
+++ b/backend/internal/repositories/postgres/mealplanning/recipe_step_ingredients.go
@@ -6,9 +6,7 @@ import (
 
 	"github.com/primandproper/dinnerdonebetter/backend/internal/domain/mealplanning"
 	mealplanningkeys "github.com/primandproper/dinnerdonebetter/backend/internal/domain/mealplanning/keys"
-	"github.com/primandproper/dinnerdonebetter/backend/internal/repositories/postgres/events"
 	"github.com/primandproper/dinnerdonebetter/backend/internal/repositories/postgres/mealplanning/generated"
-	mealplanningindexing "github.com/primandproper/dinnerdonebetter/backend/internal/services/mealplanning/indexing"
 
 	"github.com/primandproper/platform-go/v10/database"
 	platformerrors "github.com/primandproper/platform-go/v10/errors"
@@ -538,7 +536,7 @@ func (q *repository) CreateRecipeStepIngredient(ctx context.Context, recipeID st
 		created, createErr = q.createRecipeStepIngredient(ctx, tx, input)
 
 		return createErr
-	}, events.WithIndexUpsert(mealplanningindexing.IndexTypeRecipes, recipeID)); err != nil {
+	}); err != nil {
 		return nil, err
 	}
 
@@ -599,7 +597,7 @@ func (q *repository) UpdateRecipeStepIngredient(ctx context.Context, recipeID st
 		})
 
 		return updateErr
-	}, events.WithIndexUpsert(mealplanningindexing.IndexTypeRecipes, recipeID)); err != nil {
+	}); err != nil {
 		return observability.PrepareAndLogError(err, logger, span, "updating recipe step ingredient")
 	}
 
@@ -645,7 +643,7 @@ func (q *repository) ArchiveRecipeStepIngredient(ctx context.Context, recipeID, 
 		}
 
 		return nil
-	}, events.WithIndexUpsert(mealplanningindexing.IndexTypeRecipes, recipeID)); err != nil {
+	}); err != nil {
 		return err
 	}
 

--- a/backend/internal/repositories/postgres/mealplanning/recipe_step_instruments.go
+++ b/backend/internal/repositories/postgres/mealplanning/recipe_step_instruments.go
@@ -6,9 +6,7 @@ import (
 
 	"github.com/primandproper/dinnerdonebetter/backend/internal/domain/mealplanning"
 	mealplanningkeys "github.com/primandproper/dinnerdonebetter/backend/internal/domain/mealplanning/keys"
-	"github.com/primandproper/dinnerdonebetter/backend/internal/repositories/postgres/events"
 	"github.com/primandproper/dinnerdonebetter/backend/internal/repositories/postgres/mealplanning/generated"
-	mealplanningindexing "github.com/primandproper/dinnerdonebetter/backend/internal/services/mealplanning/indexing"
 
 	"github.com/primandproper/platform-go/v10/database"
 	platformerrors "github.com/primandproper/platform-go/v10/errors"
@@ -381,7 +379,7 @@ func (q *repository) CreateRecipeStepInstrument(ctx context.Context, recipeID st
 		created, createErr = q.createRecipeStepInstrument(ctx, tx, input)
 
 		return createErr
-	}, events.WithIndexUpsert(mealplanningindexing.IndexTypeRecipes, recipeID)); err != nil {
+	}); err != nil {
 		return nil, err
 	}
 
@@ -426,7 +424,7 @@ func (q *repository) UpdateRecipeStepInstrument(ctx context.Context, recipeID st
 		})
 
 		return updateErr
-	}, events.WithIndexUpsert(mealplanningindexing.IndexTypeRecipes, recipeID)); err != nil {
+	}); err != nil {
 		return observability.PrepareAndLogError(err, logger, span, "updating recipe step instrument")
 	}
 
@@ -472,7 +470,7 @@ func (q *repository) ArchiveRecipeStepInstrument(ctx context.Context, recipeID, 
 		}
 
 		return nil
-	}, events.WithIndexUpsert(mealplanningindexing.IndexTypeRecipes, recipeID)); err != nil {
+	}); err != nil {
 		return err
 	}
 

--- a/backend/internal/repositories/postgres/mealplanning/recipe_step_vessels.go
+++ b/backend/internal/repositories/postgres/mealplanning/recipe_step_vessels.go
@@ -6,9 +6,7 @@ import (
 
 	"github.com/primandproper/dinnerdonebetter/backend/internal/domain/mealplanning"
 	mealplanningkeys "github.com/primandproper/dinnerdonebetter/backend/internal/domain/mealplanning/keys"
-	"github.com/primandproper/dinnerdonebetter/backend/internal/repositories/postgres/events"
 	"github.com/primandproper/dinnerdonebetter/backend/internal/repositories/postgres/mealplanning/generated"
-	mealplanningindexing "github.com/primandproper/dinnerdonebetter/backend/internal/services/mealplanning/indexing"
 
 	"github.com/primandproper/platform-go/v10/database"
 	platformerrors "github.com/primandproper/platform-go/v10/errors"
@@ -452,7 +450,7 @@ func (q *repository) CreateRecipeStepVessel(ctx context.Context, recipeID string
 		created, createErr = q.createRecipeStepVessel(ctx, tx, input)
 
 		return createErr
-	}, events.WithIndexUpsert(mealplanningindexing.IndexTypeRecipes, recipeID)); err != nil {
+	}); err != nil {
 		return nil, err
 	}
 
@@ -497,7 +495,7 @@ func (q *repository) UpdateRecipeStepVessel(ctx context.Context, recipeID string
 		})
 
 		return updateErr
-	}, events.WithIndexUpsert(mealplanningindexing.IndexTypeRecipes, recipeID)); err != nil {
+	}); err != nil {
 		return observability.PrepareAndLogError(err, logger, span, "updating recipe step vessel")
 	}
 
@@ -543,7 +541,7 @@ func (q *repository) ArchiveRecipeStepVessel(ctx context.Context, recipeID, reci
 		}
 
 		return nil
-	}, events.WithIndexUpsert(mealplanningindexing.IndexTypeRecipes, recipeID)); err != nil {
+	}); err != nil {
 		return err
 	}
 

--- a/backend/internal/repositories/postgres/mealplanning/recipe_steps.go
+++ b/backend/internal/repositories/postgres/mealplanning/recipe_steps.go
@@ -7,9 +7,8 @@ import (
 	"github.com/primandproper/dinnerdonebetter/backend/internal/domain/mealplanning"
 	mealplanningkeys "github.com/primandproper/dinnerdonebetter/backend/internal/domain/mealplanning/keys"
 	"github.com/primandproper/dinnerdonebetter/backend/internal/domain/uploadedmedia"
-	"github.com/primandproper/dinnerdonebetter/backend/internal/repositories/postgres/events"
+	"github.com/primandproper/dinnerdonebetter/backend/internal/indexevents"
 	"github.com/primandproper/dinnerdonebetter/backend/internal/repositories/postgres/mealplanning/generated"
-	mealplanningindexing "github.com/primandproper/dinnerdonebetter/backend/internal/services/mealplanning/indexing"
 
 	"github.com/primandproper/platform-go/v10/database"
 	platformerrors "github.com/primandproper/platform-go/v10/errors"
@@ -623,11 +622,12 @@ func (q *repository) createRecipeStep(ctx context.Context, db database.SQLQueryE
 // document: the indexed subset holds each step's preparation name and the names of its
 // ingredients, instruments and vessels.
 //
-// This enqueues the index event alone rather than going through withEvent, because there is no
+// This derives the index event alone rather than going through withEvent, because there is no
 // recipe_step_created data change event to attach it to. The constant existed and put the event
 // in the generated webhook catalog, where it was subscribable and could never fire; it was
 // removed rather than made to fire, because a step creation reaches subscribers as the recipe
-// event that accompanies it.
+// event that accompanies it. That still holds, so this passes a trigger rather than an event
+// type — it reads out of the same table as everything else and puts nothing on the wire.
 func (q *repository) CreateRecipeStep(ctx context.Context, input *mealplanning.RecipeStepDatabaseCreationInput) (*mealplanning.RecipeStep, error) {
 	ctx, span := q.tracer.StartSpan(ctx)
 	defer span.End()
@@ -644,7 +644,9 @@ func (q *repository) CreateRecipeStep(ctx context.Context, input *mealplanning.R
 			return createErr
 		}
 
-		return q.events.EmitIndex(ctx, tx, events.WithIndexUpsert(mealplanningindexing.IndexTypeRecipes, input.BelongsToRecipe))
+		return q.events.EmitIndex(ctx, tx, indexevents.RecipeStepCreatedIndexTrigger, map[string]any{
+			mealplanningkeys.RecipeIDKey: input.BelongsToRecipe,
+		})
 	}); err != nil {
 		return nil, err
 	}
@@ -684,7 +686,7 @@ func (q *repository) UpdateRecipeStep(ctx context.Context, updated *mealplanning
 		})
 
 		return updateErr
-	}, events.WithIndexUpsert(mealplanningindexing.IndexTypeRecipes, updated.BelongsToRecipe)); err != nil {
+	}); err != nil {
 		return observability.PrepareAndLogError(err, logger, span, "updating recipe step")
 	}
 
@@ -727,7 +729,7 @@ func (q *repository) ArchiveRecipeStep(ctx context.Context, recipeID, recipeStep
 		}
 
 		return nil
-	}, events.WithIndexUpsert(mealplanningindexing.IndexTypeRecipes, recipeID)); err != nil {
+	}); err != nil {
 		return err
 	}
 

--- a/backend/internal/repositories/postgres/mealplanning/recipes.go
+++ b/backend/internal/repositories/postgres/mealplanning/recipes.go
@@ -11,9 +11,7 @@ import (
 	mealplanningkeys "github.com/primandproper/dinnerdonebetter/backend/internal/domain/mealplanning/keys"
 	"github.com/primandproper/dinnerdonebetter/backend/internal/domain/mealplanning/recipevalidator"
 	"github.com/primandproper/dinnerdonebetter/backend/internal/domain/uploadedmedia"
-	"github.com/primandproper/dinnerdonebetter/backend/internal/repositories/postgres/events"
 	"github.com/primandproper/dinnerdonebetter/backend/internal/repositories/postgres/mealplanning/generated"
-	mealplanningindexing "github.com/primandproper/dinnerdonebetter/backend/internal/services/mealplanning/indexing"
 
 	"github.com/primandproper/platform-go/v10/database"
 	platformerrors "github.com/primandproper/platform-go/v10/errors"
@@ -1074,7 +1072,7 @@ func (q *repository) CreateRecipe(ctx context.Context, input *mealplanning.Recip
 		// rows it describes.
 		if emitErr := q.events.Emit(ctx, tx, logger, mealplanning.RecipeCreatedServiceEventType, "", map[string]any{
 			mealplanningkeys.RecipeIDKey: input.ID,
-		}, events.WithIndexUpsert(mealplanningindexing.IndexTypeRecipes, input.ID)); emitErr != nil {
+		}); emitErr != nil {
 			return observability.PrepareError(emitErr, span, "enqueuing data change event")
 		}
 
@@ -1261,7 +1259,7 @@ func (q *repository) UpdateRecipe(ctx context.Context, updated *mealplanning.Rec
 		logger.Info("recipe updated")
 
 		return nil
-	}, events.WithIndexUpsert(mealplanningindexing.IndexTypeRecipes, updated.ID))
+	})
 }
 
 // UpdateRecipeStatus updates a particular recipe's status exclusively.
@@ -1293,7 +1291,7 @@ func (q *repository) UpdateRecipeStatus(ctx context.Context, recipeID, newStatus
 		}
 
 		return nil
-	}, events.WithIndexUpsert(mealplanningindexing.IndexTypeRecipes, recipeID))
+	})
 }
 
 // MarkRecipeAsIndexed updates a particular recipe's last_indexed_at value.
@@ -1474,7 +1472,7 @@ func (q *repository) ArchiveRecipe(ctx context.Context, recipeID, userID string)
 		}
 
 		return nil
-	}, events.WithIndexDelete(mealplanningindexing.IndexTypeRecipes, recipeID))
+	})
 }
 
 // AddRecipeImage adds an uploaded media image to a recipe.

--- a/backend/internal/repositories/postgres/mealplanning/valid_ingredient_states.go
+++ b/backend/internal/repositories/postgres/mealplanning/valid_ingredient_states.go
@@ -6,9 +6,7 @@ import (
 
 	types "github.com/primandproper/dinnerdonebetter/backend/internal/domain/mealplanning"
 	mealplanningkeys "github.com/primandproper/dinnerdonebetter/backend/internal/domain/mealplanning/keys"
-	"github.com/primandproper/dinnerdonebetter/backend/internal/repositories/postgres/events"
 	"github.com/primandproper/dinnerdonebetter/backend/internal/repositories/postgres/mealplanning/generated"
-	mealplanningindexing "github.com/primandproper/dinnerdonebetter/backend/internal/services/mealplanning/indexing"
 
 	"github.com/primandproper/platform-go/v10/database"
 	platformerrors "github.com/primandproper/platform-go/v10/errors"
@@ -276,7 +274,7 @@ func (q *repository) CreateValidIngredientState(ctx context.Context, input *type
 			Slug:          input.Slug,
 			AttributeType: generated.IngredientAttributeType(input.AttributeType),
 		})
-	}, events.WithIndexUpsert(mealplanningindexing.IndexTypeValidIngredientStates, input.ID)); err != nil {
+	}); err != nil {
 		return nil, observability.PrepareAndLogError(err, logger, span, "performing valid ingredient state creation query")
 	}
 
@@ -322,7 +320,7 @@ func (q *repository) UpdateValidIngredientState(ctx context.Context, updated *ty
 		})
 
 		return updateErr
-	}, events.WithIndexUpsert(mealplanningindexing.IndexTypeValidIngredientStates, updated.ID)); err != nil {
+	}); err != nil {
 		return observability.PrepareAndLogError(err, logger, span, "updating valid ingredient state")
 	}
 
@@ -379,5 +377,5 @@ func (q *repository) ArchiveValidIngredientState(ctx context.Context, validIngre
 		}
 
 		return nil
-	}, events.WithIndexDelete(mealplanningindexing.IndexTypeValidIngredientStates, validIngredientStateID))
+	})
 }

--- a/backend/internal/repositories/postgres/mealplanning/valid_ingredients.go
+++ b/backend/internal/repositories/postgres/mealplanning/valid_ingredients.go
@@ -6,9 +6,7 @@ import (
 
 	"github.com/primandproper/dinnerdonebetter/backend/internal/domain/mealplanning"
 	mealplanningkeys "github.com/primandproper/dinnerdonebetter/backend/internal/domain/mealplanning/keys"
-	"github.com/primandproper/dinnerdonebetter/backend/internal/repositories/postgres/events"
 	"github.com/primandproper/dinnerdonebetter/backend/internal/repositories/postgres/mealplanning/generated"
-	mealplanningindexing "github.com/primandproper/dinnerdonebetter/backend/internal/services/mealplanning/indexing"
 
 	"github.com/primandproper/platform-go/v10/database"
 	platformerrors "github.com/primandproper/platform-go/v10/errors"
@@ -567,7 +565,7 @@ func (q *repository) CreateValidIngredient(ctx context.Context, input *mealplann
 			IsAcid:                                  input.IsAcid,
 			IsHeat:                                  input.IsHeat,
 		})
-	}, events.WithIndexUpsert(mealplanningindexing.IndexTypeValidIngredients, input.ID)); err != nil {
+	}); err != nil {
 		return nil, observability.PrepareAndLogError(err, logger, span, "performing valid ingredient creation query")
 	}
 
@@ -669,7 +667,7 @@ func (q *repository) UpdateValidIngredient(ctx context.Context, updated *mealpla
 		})
 
 		return updateErr
-	}, events.WithIndexUpsert(mealplanningindexing.IndexTypeValidIngredients, updated.ID)); err != nil {
+	}); err != nil {
 		return observability.PrepareAndLogError(err, logger, span, "updating valid ingredient")
 	}
 
@@ -726,5 +724,5 @@ func (q *repository) ArchiveValidIngredient(ctx context.Context, validIngredient
 		}
 
 		return nil
-	}, events.WithIndexDelete(mealplanningindexing.IndexTypeValidIngredients, validIngredientID))
+	})
 }

--- a/backend/internal/repositories/postgres/mealplanning/valid_instruments.go
+++ b/backend/internal/repositories/postgres/mealplanning/valid_instruments.go
@@ -6,9 +6,7 @@ import (
 
 	types "github.com/primandproper/dinnerdonebetter/backend/internal/domain/mealplanning"
 	mealplanningkeys "github.com/primandproper/dinnerdonebetter/backend/internal/domain/mealplanning/keys"
-	"github.com/primandproper/dinnerdonebetter/backend/internal/repositories/postgres/events"
 	"github.com/primandproper/dinnerdonebetter/backend/internal/repositories/postgres/mealplanning/generated"
-	mealplanningindexing "github.com/primandproper/dinnerdonebetter/backend/internal/services/mealplanning/indexing"
 
 	"github.com/primandproper/platform-go/v10/database"
 	platformerrors "github.com/primandproper/platform-go/v10/errors"
@@ -373,7 +371,7 @@ func (q *repository) CreateValidInstrument(ctx context.Context, input *types.Val
 			DisplayInSummaryLists:          input.DisplayInSummaryLists,
 			IncludeInGeneratedInstructions: input.IncludeInGeneratedInstructions,
 		})
-	}, events.WithIndexUpsert(mealplanningindexing.IndexTypeValidInstruments, input.ID)); err != nil {
+	}); err != nil {
 		return nil, observability.PrepareAndLogError(err, logger, span, "performing valid instrument creation query")
 	}
 
@@ -422,7 +420,7 @@ func (q *repository) UpdateValidInstrument(ctx context.Context, updated *types.V
 		})
 
 		return updateErr
-	}, events.WithIndexUpsert(mealplanningindexing.IndexTypeValidInstruments, updated.ID)); err != nil {
+	}); err != nil {
 		return observability.PrepareAndLogError(err, logger, span, "updating valid instrument")
 	}
 
@@ -479,5 +477,5 @@ func (q *repository) ArchiveValidInstrument(ctx context.Context, validInstrument
 		}
 
 		return nil
-	}, events.WithIndexDelete(mealplanningindexing.IndexTypeValidInstruments, validInstrumentID))
+	})
 }

--- a/backend/internal/repositories/postgres/mealplanning/valid_measurement_units.go
+++ b/backend/internal/repositories/postgres/mealplanning/valid_measurement_units.go
@@ -6,9 +6,7 @@ import (
 
 	types "github.com/primandproper/dinnerdonebetter/backend/internal/domain/mealplanning"
 	mealplanningkeys "github.com/primandproper/dinnerdonebetter/backend/internal/domain/mealplanning/keys"
-	"github.com/primandproper/dinnerdonebetter/backend/internal/repositories/postgres/events"
 	"github.com/primandproper/dinnerdonebetter/backend/internal/repositories/postgres/mealplanning/generated"
-	mealplanningindexing "github.com/primandproper/dinnerdonebetter/backend/internal/services/mealplanning/indexing"
 
 	"github.com/primandproper/platform-go/v10/database"
 	platformerrors "github.com/primandproper/platform-go/v10/errors"
@@ -392,7 +390,7 @@ func (q *repository) CreateValidMeasurementUnit(ctx context.Context, input *type
 			Metric:      input.Metric,
 			Imperial:    input.Imperial,
 		})
-	}, events.WithIndexUpsert(mealplanningindexing.IndexTypeValidMeasurementUnits, input.ID)); err != nil {
+	}); err != nil {
 		return nil, observability.PrepareAndLogError(err, logger, span, "performing valid measurement unit creation query")
 	}
 
@@ -443,7 +441,7 @@ func (q *repository) UpdateValidMeasurementUnit(ctx context.Context, updated *ty
 		})
 
 		return updateErr
-	}, events.WithIndexUpsert(mealplanningindexing.IndexTypeValidMeasurementUnits, updated.ID)); err != nil {
+	}); err != nil {
 		return observability.PrepareAndLogError(err, logger, span, "updating valid measurement unit")
 	}
 
@@ -500,5 +498,5 @@ func (q *repository) ArchiveValidMeasurementUnit(ctx context.Context, validMeasu
 		}
 
 		return nil
-	}, events.WithIndexDelete(mealplanningindexing.IndexTypeValidMeasurementUnits, validMeasurementUnitID))
+	})
 }

--- a/backend/internal/repositories/postgres/mealplanning/valid_preparations.go
+++ b/backend/internal/repositories/postgres/mealplanning/valid_preparations.go
@@ -6,9 +6,7 @@ import (
 
 	"github.com/primandproper/dinnerdonebetter/backend/internal/domain/mealplanning"
 	mealplanningkeys "github.com/primandproper/dinnerdonebetter/backend/internal/domain/mealplanning/keys"
-	"github.com/primandproper/dinnerdonebetter/backend/internal/repositories/postgres/events"
 	"github.com/primandproper/dinnerdonebetter/backend/internal/repositories/postgres/mealplanning/generated"
-	mealplanningindexing "github.com/primandproper/dinnerdonebetter/backend/internal/services/mealplanning/indexing"
 
 	"github.com/primandproper/platform-go/v10/database"
 	platformerrors "github.com/primandproper/platform-go/v10/errors"
@@ -375,7 +373,7 @@ func (q *repository) CreateValidPreparation(ctx context.Context, input *mealplan
 			PastTense:                   input.PastTense,
 			Slug:                        input.Slug,
 		})
-	}, events.WithIndexUpsert(mealplanningindexing.IndexTypeValidPreparations, input.ID)); err != nil {
+	}); err != nil {
 		return nil, observability.PrepareAndLogError(err, logger, span, "performing valid preparation creation query")
 	}
 
@@ -444,7 +442,7 @@ func (q *repository) UpdateValidPreparation(ctx context.Context, updated *mealpl
 		})
 
 		return updateErr
-	}, events.WithIndexUpsert(mealplanningindexing.IndexTypeValidPreparations, updated.ID)); err != nil {
+	}); err != nil {
 		return observability.PrepareAndLogError(err, logger, span, "updating valid preparation")
 	}
 
@@ -501,5 +499,5 @@ func (q *repository) ArchiveValidPreparation(ctx context.Context, validPreparati
 		}
 
 		return nil
-	}, events.WithIndexDelete(mealplanningindexing.IndexTypeValidPreparations, validPreparationID))
+	})
 }

--- a/backend/internal/repositories/postgres/mealplanning/valid_vessels.go
+++ b/backend/internal/repositories/postgres/mealplanning/valid_vessels.go
@@ -7,9 +7,7 @@ import (
 
 	types "github.com/primandproper/dinnerdonebetter/backend/internal/domain/mealplanning"
 	mealplanningkeys "github.com/primandproper/dinnerdonebetter/backend/internal/domain/mealplanning/keys"
-	"github.com/primandproper/dinnerdonebetter/backend/internal/repositories/postgres/events"
 	"github.com/primandproper/dinnerdonebetter/backend/internal/repositories/postgres/mealplanning/generated"
-	mealplanningindexing "github.com/primandproper/dinnerdonebetter/backend/internal/services/mealplanning/indexing"
 
 	"github.com/primandproper/platform-go/v10/database"
 	platformerrors "github.com/primandproper/platform-go/v10/errors"
@@ -416,7 +414,7 @@ func (q *repository) CreateValidVessel(ctx context.Context, input *types.ValidVe
 			DisplayInSummaryLists:          input.DisplayInSummaryLists,
 			UsableForStorage:               input.UsableForStorage,
 		})
-	}, events.WithIndexUpsert(mealplanningindexing.IndexTypeValidVessels, input.ID)); err != nil {
+	}); err != nil {
 		return nil, observability.PrepareAndLogError(err, logger, span, "performing valid vessel creation query")
 	}
 
@@ -485,7 +483,7 @@ func (q *repository) UpdateValidVessel(ctx context.Context, updated *types.Valid
 		})
 
 		return updateErr
-	}, events.WithIndexUpsert(mealplanningindexing.IndexTypeValidVessels, updated.ID)); err != nil {
+	}); err != nil {
 		return observability.PrepareAndLogError(err, logger, span, "updating valid vessel")
 	}
 
@@ -542,5 +540,5 @@ func (q *repository) ArchiveValidVessel(ctx context.Context, validVesselID strin
 		}
 
 		return nil
-	}, events.WithIndexDelete(mealplanningindexing.IndexTypeValidVessels, validVesselID))
+	})
 }

--- a/backend/internal/repositories/postgres/webhooks/delivery_test.go
+++ b/backend/internal/repositories/postgres/webhooks/delivery_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/primandproper/dinnerdonebetter/backend/internal/domain/webhooks/catalog"
 	"github.com/primandproper/dinnerdonebetter/backend/internal/domain/webhooks/converters"
 	"github.com/primandproper/dinnerdonebetter/backend/internal/domain/webhooks/fakes"
+	"github.com/primandproper/dinnerdonebetter/backend/internal/indexevents"
 	"github.com/primandproper/dinnerdonebetter/backend/internal/repositories/postgres/auditlogentries"
 	"github.com/primandproper/dinnerdonebetter/backend/internal/repositories/postgres/events"
 	pgtesting "github.com/primandproper/dinnerdonebetter/backend/internal/repositories/postgres/testing"
@@ -113,7 +114,7 @@ func buildDeliveryHarness(t *testing.T) (*repository, *events.Emitter, *webhooks
 	writer, err := outbox.NewWriter(dialect.Postgres)
 	require.NoError(t, err)
 
-	emitter := events.NewEmitter(writer, "data_changes", dispatcher)
+	emitter := events.NewEmitter(writer, "data_changes", dispatcher, indexevents.SideEffect)
 	require.NotNil(t, emitter)
 
 	repo := ProvideWebhooksRepository(loggingnoop.NewLogger(), tracingnoop.NewTracerProvider(), auditRepo, pgc, emitter, dispatcher)


### PR DESCRIPTION
Part of #1291, part of #1297. See [my earlier comment on the issue](https://github.com/primandproper/dinnerdonebetter/issues/1291#issuecomment-5321403847) for the `EmitIndex` question this settles — I took **option 2**, and there is a section below on why.

## What

A write that changes an indexed row owes the search index an event. That obligation was an `EmitOption`, passed by hand at **40 call sites across 13 files**. An obligation expressed as an option is one a call site can forget: a repository method that omitted it compiled, reviewed clean, and left the index stale until the next scheduled rebuild — no test would catch it, no metric would show it.

It is now `outbox.WithWriterSideEffect`, registered once on the Writer, deriving the index events from the data change messages the `Emitter` already sends. `internal/indexevents` holds the whole of what it knows:

```go
types.ValidInstrumentCreatedServiceEventType:  {IndexTypeValidInstruments, ValidInstrumentIDKey, OpUpsert},
types.ValidInstrumentUpdatedServiceEventType:  {IndexTypeValidInstruments, ValidInstrumentIDKey, OpUpsert},
types.ValidInstrumentArchivedServiceEventType: {IndexTypeValidInstruments, ValidInstrumentIDKey, OpDelete},
```

Everything a row needs is already in the message — the event type says what happened, the context map carries the ID.

## Behaviour is unchanged, and it is checked rather than asserted

The table was **derived from what the 40 call sites already did**, not written fresh. Two mechanical checks over the tree before touching anything:

- all 40 sites have their document ID present in the context under exactly one well-known key, so every row is expressible;
- **0** sites emitting a tabled event type omitted an index option, so no write gains or loses one.

39 event types, no conflicts — no event type wanted two different rows.

## The two rows that are easy to get wrong

Both are in the package doc and both have tests:

**Archiving a sub-entity is an upsert, not a delete.** An archived recipe step leaves the recipe indexed and changes what it says, so `RecipeStepArchived` upserts the recipe. Only archiving the indexed entity itself deletes.

**The document ID is often not the ID of the thing that changed.** Every recipe step, ingredient, instrument and vessel write reindexes its parent *recipe*, because the indexed recipe document embeds their names — so those 12 rows read `RecipeIDKey`, not the sub-entity's key.

## Ordering

Preserved by construction: events are built through `searchsync.NewEvent(op, docID).Message(topic)`, which sets `Key: e.DocumentID`. Same function the options used. Asserted in `TestSideEffect`.

## Why `EmitIndex` stays (option 2)

It has exactly one call site, and it exists because `recipe_step_created` was **deliberately removed** from the webhook catalog — it was subscribable and could never fire, and was removed rather than made to fire, because a step creation reaches subscribers as the recipe event that accompanies it.

Making `EmitIndex` go away means reversing that, which is a decision about the public event stream rather than about the index. So it stays and reads out of the same table: it passes a *trigger* (`recipe_step_created.index_only`, not in the catalog, never published), runs the same effect, and enqueues only what the effect derives.

That means the DoD line "`WithIndexUpsert` / `WithIndexDelete` are gone" is met — both are deleted — while "`EmitIndex` goes away" is not. Deliberate; say the word if you'd rather reintroduce the event.

## A missing document ID is refused, not skipped

If a tabled event type arrives without its ID, the effect errors and the caller's transaction rolls back. Skipping would put back exactly the failure this removes: a write commits, the index never hears, nothing says so.

## Two things that fell out

**13 repository files no longer import the indexing packages at all.** That is the point — adding an indexed entity is a table edit now, and `goimports` removing those lines is the proof.

**`withEvent` no longer takes `EmitOption`s** — `unparam` flagged it once nothing passed one. Note `events.WithOrderingKey` also has no callers, but that predates this PR and I left it alone.

## Verification

- `go build ./...`, `go vet ./...`, `gofmt`, `go fix` — clean
- `go test ./internal/...` — clean
- **`RUN_CONTAINER_TESTS=true go test ./internal/repositories/postgres/...`** against real Postgres containers — clean. These are the ones that matter: `TestQuerier_Integration_IndexEventsCommitWithTheirWrite`, `RecipeStepWritesReindexTheirRecipe`, `UserIndexEventsCommitWithTheirWrite` and friends assert the exact document IDs, operations and ordering keys produced.
- `golangci-lint` — clean on the touched packages; remaining findings (`goconst` in `users.go`, `cannot inline` in tests) are pre-existing in files this does not touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017iSaVKFpZdnMSt7W174AgB