### PR TITLE
refactor(queries): build the valid_* standard queries on database/querygen

### DIFF
--- a/backend/cmd/tools/codegen/queries/mealplanning_valid_ingredient_groups.go
+++ b/backend/cmd/tools/codegen/queries/mealplanning_valid_ingredient_groups.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"fmt"
+	"slices"
 	"strings"
+
+	"github.com/primandproper/platform-go/v11/database/querygen"
 
 	"github.com/cristalhq/builq"
 )
@@ -29,7 +32,6 @@ func buildValidIngredientGroupsQueries(database string) []*Query {
 	switch database {
 	case postgres:
 
-		groupInsertColumns := filterForInsert(validIngredientGroupsColumns)
 		groupMemberInsertColumns := filterForInsert(validIngredientGroupMembersColumns)
 
 		fullMemberSelectColumns := mergeColumns(
@@ -42,95 +44,52 @@ func buildValidIngredientGroupsQueries(database string) []*Query {
 			2,
 		)
 
-		return []*Query{
-			{
-				Annotation: QueryAnnotation{
-					Name: "ArchiveValidIngredientGroup",
-					Type: ExecRowsType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET %s = %s WHERE %s IS NULL AND %s = sqlc.arg(%s);`,
-					validIngredientGroupsTableName,
-					archivedAtColumn,
-					currentTimeExpression,
-					archivedAtColumn,
-					idColumn,
-					idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "ArchiveValidIngredientGroupMember",
-					Type: ExecRowsType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
+		return slices.Concat(
+			querygen.StandardCRUD(validIngredientGroupsTableName, validIngredientGroupsColumns,
+				querygen.WithEntity("ValidIngredientGroup", "ValidIngredientGroups"),
+				querygen.WithOmitted(querygen.ListQuery),
+			),
+			[]*Query{
+				{
+					Annotation: QueryAnnotation{
+						Name: "ArchiveValidIngredientGroupMember",
+						Type: ExecRowsType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
 	%s = %s
 WHERE %s IS NULL
 	AND %s = sqlc.arg(%s)
 	AND %s = sqlc.arg(%s);`,
-					validIngredientGroupMembersTableName,
-					archivedAtColumn, currentTimeExpression,
-					archivedAtColumn,
-					idColumn, idColumn,
-					belongsToGroupColumn, belongsToGroupColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CreateValidIngredientGroup",
-					Type: ExecType,
+						validIngredientGroupMembersTableName,
+						archivedAtColumn, currentTimeExpression,
+						archivedAtColumn,
+						idColumn, idColumn,
+						belongsToGroupColumn, belongsToGroupColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`INSERT INTO %s (
+				{
+					Annotation: QueryAnnotation{
+						Name: "CreateValidIngredientGroupMember",
+						Type: ExecType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`INSERT INTO %s (
 	%s
 ) VALUES (
 	%s
 );`,
-					validIngredientGroupsTableName,
-					strings.Join(groupInsertColumns, ",\n\t"),
-					strings.Join(applyToEach(groupInsertColumns, func(i int, s string) string {
-						return fmt.Sprintf("sqlc.arg(%s)", s)
-					}), ",\n\t"),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CreateValidIngredientGroupMember",
-					Type: ExecType,
+						validIngredientGroupMembersTableName,
+						strings.Join(groupMemberInsertColumns, ",\n\t"),
+						strings.Join(applyToEach(groupMemberInsertColumns, func(i int, s string) string {
+							return fmt.Sprintf("sqlc.arg(%s)", s)
+						}), ",\n\t"),
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`INSERT INTO %s (
-	%s
-) VALUES (
-	%s
-);`,
-					validIngredientGroupMembersTableName,
-					strings.Join(groupMemberInsertColumns, ",\n\t"),
-					strings.Join(applyToEach(groupMemberInsertColumns, func(i int, s string) string {
-						return fmt.Sprintf("sqlc.arg(%s)", s)
-					}), ",\n\t"),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CheckValidIngredientGroupExistence",
-					Type: OneType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT EXISTS (
-	SELECT %s.%s
-	FROM %s
-	WHERE %s.%s IS NULL
-		AND %s.%s = sqlc.arg(%s)
-);`,
-					validIngredientGroupsTableName, idColumn,
-					validIngredientGroupsTableName,
-					validIngredientGroupsTableName, archivedAtColumn,
-					validIngredientGroupsTableName, idColumn, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetValidIngredientGroups",
-					Type: ManyType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetValidIngredientGroups",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s
@@ -140,29 +99,29 @@ WHERE
 	%s
 GROUP BY %s.%s
 %s;`,
-					strings.Join(applyToEach(validIngredientGroupsColumns, func(i int, s string) string {
-						return fmt.Sprintf("%s.%s", validIngredientGroupsTableName, s)
-					}), ",\n\t"),
-					buildFilterCountSelect(validIngredientGroupsTableName, true, true, []string{}),
-					buildTotalCountSelect(validIngredientGroupsTableName, true, []string{}),
-					validIngredientGroupsTableName,
-					validIngredientGroupsTableName,
-					archivedAtColumn,
-					buildFilterConditions(
+						strings.Join(applyToEach(validIngredientGroupsColumns, func(i int, s string) string {
+							return fmt.Sprintf("%s.%s", validIngredientGroupsTableName, s)
+						}), ",\n\t"),
+						buildFilterCountSelect(validIngredientGroupsTableName, true, true, []string{}),
+						buildTotalCountSelect(validIngredientGroupsTableName, true, []string{}),
 						validIngredientGroupsTableName,
-						true,
-						true,
-					),
-					validIngredientGroupsTableName, idColumn,
-					buildCursorLimitClause(validIngredientGroupsTableName),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetValidIngredientGroupMembers",
-					Type: ManyType,
+						validIngredientGroupsTableName,
+						archivedAtColumn,
+						buildFilterConditions(
+							validIngredientGroupsTableName,
+							true,
+							true,
+						),
+						validIngredientGroupsTableName, idColumn,
+						buildCursorLimitClause(validIngredientGroupsTableName),
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetValidIngredientGroupMembers",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s
 FROM %s
 	JOIN %s ON %s.%s = %s.%s
@@ -171,42 +130,21 @@ WHERE
 	%s.%s IS NULL
 	AND %s.%s IS NULL
 	AND %s.%s = sqlc.arg(%s);`,
-					strings.Join(fullMemberSelectColumns, ",\n\t"),
-					validIngredientGroupMembersTableName,
-					validIngredientGroupsTableName, validIngredientGroupsTableName, idColumn, validIngredientGroupMembersTableName, belongsToGroupColumn,
-					validIngredientsTableName, validIngredientsTableName, idColumn, validIngredientGroupMembersTableName, validIngredientGroupMemberValidIngredientColumn,
-					validIngredientGroupsTableName, archivedAtColumn,
-					validIngredientGroupMembersTableName, archivedAtColumn,
-					validIngredientGroupMembersTableName, belongsToGroupColumn, belongsToGroupColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetValidIngredientGroup",
-					Type: OneType,
+						strings.Join(fullMemberSelectColumns, ",\n\t"),
+						validIngredientGroupMembersTableName,
+						validIngredientGroupsTableName, validIngredientGroupsTableName, idColumn, validIngredientGroupMembersTableName, belongsToGroupColumn,
+						validIngredientsTableName, validIngredientsTableName, idColumn, validIngredientGroupMembersTableName, validIngredientGroupMemberValidIngredientColumn,
+						validIngredientGroupsTableName, archivedAtColumn,
+						validIngredientGroupMembersTableName, archivedAtColumn,
+						validIngredientGroupMembersTableName, belongsToGroupColumn, belongsToGroupColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
-	%s
-FROM %s
-WHERE %s.%s IS NULL
-AND %s.%s = sqlc.arg(%s);`,
-					strings.Join(applyToEach(validIngredientGroupsColumns, func(i int, s string) string {
-						return fmt.Sprintf("%s.%s", validIngredientGroupsTableName, s)
-					}), ",\n\t"),
-					validIngredientGroupsTableName,
-					validIngredientGroupsTableName,
-					archivedAtColumn,
-					validIngredientGroupsTableName,
-					idColumn,
-					idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "SearchForValidIngredientGroups",
-					Type: ManyType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "SearchForValidIngredientGroups",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s
@@ -217,66 +155,46 @@ WHERE
 	%s
 GROUP BY %s.%s
 %s;`,
-					strings.Join(applyToEach(validIngredientGroupsColumns, func(i int, s string) string {
-						return fmt.Sprintf("%s.%s", validIngredientGroupsTableName, s)
-					}), ",\n\t"),
-					buildFilterCountSelect(validIngredientGroupsTableName, true, true, []string{}, fmt.Sprintf("%s.%s %s", validIngredientGroupsTableName, nameColumn, buildILIKEForArgument("name"))),
-					buildTotalCountSelect(validIngredientGroupsTableName, true, []string{}),
-					validIngredientGroupsTableName,
-					validIngredientGroupsTableName,
-					archivedAtColumn,
-					validIngredientGroupsTableName, nameColumn, buildILIKEForArgument("name"),
-					buildFilterConditions(
+						strings.Join(applyToEach(validIngredientGroupsColumns, func(i int, s string) string {
+							return fmt.Sprintf("%s.%s", validIngredientGroupsTableName, s)
+						}), ",\n\t"),
+						buildFilterCountSelect(validIngredientGroupsTableName, true, true, []string{}, fmt.Sprintf("%s.%s %s", validIngredientGroupsTableName, nameColumn, buildILIKEForArgument("name"))),
+						buildTotalCountSelect(validIngredientGroupsTableName, true, []string{}),
 						validIngredientGroupsTableName,
-						true,
-						true,
-					),
-					validIngredientGroupsTableName, idColumn,
-					buildCursorLimitClause(validIngredientGroupsTableName),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetValidIngredientGroupsWithIDs",
-					Type: ManyType,
+						validIngredientGroupsTableName,
+						archivedAtColumn,
+						validIngredientGroupsTableName, nameColumn, buildILIKEForArgument("name"),
+						buildFilterConditions(
+							validIngredientGroupsTableName,
+							true,
+							true,
+						),
+						validIngredientGroupsTableName, idColumn,
+						buildCursorLimitClause(validIngredientGroupsTableName),
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetValidIngredientGroupsWithIDs",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s
 FROM %s
 WHERE %s.%s IS NULL
 	AND %s.%s = ANY(sqlc.arg(ids)::text[]);`,
-					strings.Join(applyToEach(validIngredientGroupsColumns, func(i int, s string) string {
-						return fmt.Sprintf("%s.%s", validIngredientGroupsTableName, s)
-					}), ",\n\t"),
-					validIngredientGroupsTableName,
-					validIngredientGroupsTableName,
-					archivedAtColumn,
-					validIngredientGroupsTableName,
-					idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "UpdateValidIngredientGroup",
-					Type: ExecRowsType,
+						strings.Join(applyToEach(validIngredientGroupsColumns, func(i int, s string) string {
+							return fmt.Sprintf("%s.%s", validIngredientGroupsTableName, s)
+						}), ",\n\t"),
+						validIngredientGroupsTableName,
+						validIngredientGroupsTableName,
+						archivedAtColumn,
+						validIngredientGroupsTableName,
+						idColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
-	%s,
-	%s = %s
-WHERE %s IS NULL
-	AND %s = sqlc.arg(%s);`,
-					validIngredientGroupsTableName,
-					strings.Join(applyToEach(filterForUpdate(validIngredientGroupsColumns), func(i int, s string) string {
-						return fmt.Sprintf("%s = sqlc.arg(%s)", s, s)
-					}), ",\n\t"),
-					lastUpdatedAtColumn,
-					currentTimeExpression,
-					archivedAtColumn,
-					idColumn,
-					idColumn,
-				)),
 			},
-		}
+		)
 	default:
 		return nil
 	}

--- a/backend/cmd/tools/codegen/queries/mealplanning_valid_ingredient_states.go
+++ b/backend/cmd/tools/codegen/queries/mealplanning_valid_ingredient_states.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"fmt"
+	"slices"
 	"strings"
+
+	"github.com/primandproper/platform-go/v11/database/querygen"
 
 	"github.com/cristalhq/builq"
 )
@@ -33,66 +36,18 @@ func buildValidIngredientStatesQueries(database string) []*Query {
 	switch database {
 	case postgres:
 
-		insertColumns := filterForInsert(validIngredientStatesColumns)
-
-		return []*Query{
-			{
-				Annotation: QueryAnnotation{
-					Name: "ArchiveValidIngredientState",
-					Type: ExecRowsType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET %s = %s WHERE %s IS NULL AND %s = sqlc.arg(%s);`,
-					validIngredientStatesTableName,
-					archivedAtColumn,
-					currentTimeExpression,
-					archivedAtColumn,
-					idColumn,
-					idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CreateValidIngredientState",
-					Type: ExecType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`INSERT INTO %s (
-	%s
-) VALUES (
-	%s
-);`,
-					validIngredientStatesTableName,
-					strings.Join(insertColumns, ",\n\t"),
-					strings.Join(applyToEach(insertColumns, func(i int, s string) string {
-						return fmt.Sprintf("sqlc.arg(%s)", s)
-					}), ",\n\t"),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CheckValidIngredientStateExistence",
-					Type: OneType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT EXISTS (
-	SELECT %s.%s
-	FROM %s
-	WHERE %s.%s IS NULL
-		AND %s.%s = sqlc.arg(%s)
-);`,
-					validIngredientStatesTableName, idColumn,
-					validIngredientStatesTableName,
-					validIngredientStatesTableName,
-					archivedAtColumn,
-					validIngredientStatesTableName,
-					idColumn,
-					idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetValidIngredientStates",
-					Type: ManyType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+		return slices.Concat(
+			querygen.StandardCRUD(validIngredientStatesTableName, validIngredientStatesColumns,
+				querygen.WithEntity("ValidIngredientState", "ValidIngredientStates"),
+				querygen.WithOmitted(querygen.ListQuery),
+			),
+			[]*Query{
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetValidIngredientStates",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s
@@ -102,101 +57,73 @@ WHERE
 	%s
 GROUP BY %s.%s
 %s;`,
-					strings.Join(applyToEach(validIngredientStatesColumns, func(i int, s string) string {
-						return fmt.Sprintf("%s.%s", validIngredientStatesTableName, s)
-					}), ",\n\t"),
-					buildFilterCountSelect(validIngredientStatesTableName, true, true, []string{}),
-					buildTotalCountSelect(validIngredientStatesTableName, true, []string{}),
-					validIngredientStatesTableName,
-					validIngredientStatesTableName,
-					archivedAtColumn,
-					buildFilterConditions(
+						strings.Join(applyToEach(validIngredientStatesColumns, func(i int, s string) string {
+							return fmt.Sprintf("%s.%s", validIngredientStatesTableName, s)
+						}), ",\n\t"),
+						buildFilterCountSelect(validIngredientStatesTableName, true, true, []string{}),
+						buildTotalCountSelect(validIngredientStatesTableName, true, []string{}),
 						validIngredientStatesTableName,
-						true,
-						true,
-					),
-					validIngredientStatesTableName, idColumn,
-					buildCursorLimitClause(validIngredientStatesTableName),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "ScanValidIngredientStateIDsForReindex",
-					Type: ManyType,
+						validIngredientStatesTableName,
+						archivedAtColumn,
+						buildFilterConditions(
+							validIngredientStatesTableName,
+							true,
+							true,
+						),
+						validIngredientStatesTableName, idColumn,
+						buildCursorLimitClause(validIngredientStatesTableName),
+					)),
 				},
-				Content: buildReindexScanQuery(validIngredientStatesTableName),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetValidIngredientStatesNeedingIndexing",
-					Type: ManyType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT %s.%s
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetValidIngredientStatesNeedingIndexing",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT %s.%s
 FROM %s
 WHERE %s.%s IS NULL
 	AND (
 	%s.%s IS NULL
 	OR %s.%s < %s - '24 hours'::INTERVAL
 );`,
-					validIngredientStatesTableName,
-					idColumn,
-					validIngredientStatesTableName,
-					validIngredientStatesTableName,
-					archivedAtColumn,
-					validIngredientStatesTableName,
-					lastIndexedAtColumn,
-					validIngredientStatesTableName,
-					lastIndexedAtColumn,
-					currentTimeExpression,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetValidIngredientState",
-					Type: OneType,
+						validIngredientStatesTableName,
+						idColumn,
+						validIngredientStatesTableName,
+						validIngredientStatesTableName,
+						archivedAtColumn,
+						validIngredientStatesTableName,
+						lastIndexedAtColumn,
+						validIngredientStatesTableName,
+						lastIndexedAtColumn,
+						currentTimeExpression,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
-	%s
-FROM %s
-WHERE %s.%s IS NULL
-AND %s.%s = sqlc.arg(%s);`,
-					strings.Join(applyToEach(validIngredientStatesColumns, func(i int, s string) string {
-						return fmt.Sprintf("%s.%s", validIngredientStatesTableName, s)
-					}), ",\n\t"),
-					validIngredientStatesTableName,
-					validIngredientStatesTableName,
-					archivedAtColumn,
-					validIngredientStatesTableName,
-					idColumn,
-					idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetValidIngredientStatesWithIDs",
-					Type: ManyType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetValidIngredientStatesWithIDs",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s
 FROM %s
 WHERE %s.%s IS NULL
 	AND %s.%s = ANY(sqlc.arg(ids)::text[]);`,
-					strings.Join(applyToEach(validIngredientStatesColumns, func(i int, s string) string {
-						return fmt.Sprintf("%s.%s", validIngredientStatesTableName, s)
-					}), ",\n\t"),
-					validIngredientStatesTableName,
-					validIngredientStatesTableName,
-					archivedAtColumn,
-					validIngredientStatesTableName,
-					idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "SearchForValidIngredientStates",
-					Type: ManyType,
+						strings.Join(applyToEach(validIngredientStatesColumns, func(i int, s string) string {
+							return fmt.Sprintf("%s.%s", validIngredientStatesTableName, s)
+						}), ",\n\t"),
+						validIngredientStatesTableName,
+						validIngredientStatesTableName,
+						archivedAtColumn,
+						validIngredientStatesTableName,
+						idColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "SearchForValidIngredientStates",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s
@@ -205,61 +132,41 @@ WHERE %s.%s IS NULL
 	AND %s.%s %s
 	%s
 %s;`,
-					strings.Join(applyToEach(validIngredientStatesColumns, func(i int, s string) string {
-						return fmt.Sprintf("%s.%s", validIngredientStatesTableName, s)
-					}), ",\n\t"),
-					buildFilterCountSelect(validIngredientStatesTableName, true, true, []string{}),
-					buildTotalCountSelect(validIngredientStatesTableName, true, []string{}),
-					validIngredientStatesTableName,
-					validIngredientStatesTableName,
-					archivedAtColumn,
-					validIngredientStatesTableName,
-					nameColumn,
-					buildILIKEForArgument("name_query"),
-					buildFilterConditions(
+						strings.Join(applyToEach(validIngredientStatesColumns, func(i int, s string) string {
+							return fmt.Sprintf("%s.%s", validIngredientStatesTableName, s)
+						}), ",\n\t"),
+						buildFilterCountSelect(validIngredientStatesTableName, true, true, []string{}),
+						buildTotalCountSelect(validIngredientStatesTableName, true, []string{}),
 						validIngredientStatesTableName,
-						true,
-						true,
-					),
-					buildCursorLimitClause(validIngredientStatesTableName),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "UpdateValidIngredientState",
-					Type: ExecRowsType,
+						validIngredientStatesTableName,
+						archivedAtColumn,
+						validIngredientStatesTableName,
+						nameColumn,
+						buildILIKEForArgument("name_query"),
+						buildFilterConditions(
+							validIngredientStatesTableName,
+							true,
+							true,
+						),
+						buildCursorLimitClause(validIngredientStatesTableName),
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
-	%s,
-	%s = %s
-WHERE %s IS NULL
-	AND %s = sqlc.arg(%s);`,
-					validIngredientStatesTableName,
-					strings.Join(applyToEach(filterForUpdate(validIngredientStatesColumns), func(i int, s string) string {
-						return fmt.Sprintf("%s = sqlc.arg(%s)", s, s)
-					}), ",\n\t"),
-					lastUpdatedAtColumn,
-					currentTimeExpression,
-					archivedAtColumn,
-					idColumn,
-					idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "UpdateValidIngredientStateLastIndexedAt",
-					Type: ExecRowsType,
+				{
+					Annotation: QueryAnnotation{
+						Name: "UpdateValidIngredientStateLastIndexedAt",
+						Type: ExecRowsType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET %s = %s WHERE %s = sqlc.arg(%s) AND %s IS NULL;`,
+						validIngredientStatesTableName,
+						lastIndexedAtColumn,
+						currentTimeExpression,
+						idColumn,
+						idColumn,
+						archivedAtColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET %s = %s WHERE %s = sqlc.arg(%s) AND %s IS NULL;`,
-					validIngredientStatesTableName,
-					lastIndexedAtColumn,
-					currentTimeExpression,
-					idColumn,
-					idColumn,
-					archivedAtColumn,
-				)),
 			},
-		}
+		)
 	default:
 		return nil
 	}

--- a/backend/cmd/tools/codegen/queries/mealplanning_valid_ingredients.go
+++ b/backend/cmd/tools/codegen/queries/mealplanning_valid_ingredients.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"fmt"
+	"slices"
 	"strings"
+
+	"github.com/primandproper/platform-go/v11/database/querygen"
 
 	"github.com/cristalhq/builq"
 )
@@ -62,72 +65,22 @@ func buildValidIngredientsQueries(database string) []*Query {
 	switch database {
 	case postgres:
 
-		insertColumns := filterForInsert(validIngredientsColumns)
-
-		return []*Query{
-			{
-				Annotation: QueryAnnotation{
-					Name: "ArchiveValidIngredient",
-					Type: ExecRowsType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET %s = %s WHERE %s IS NULL AND %s = sqlc.arg(%s);`,
-					validIngredientsTableName,
-					archivedAtColumn,
-					currentTimeExpression,
-					archivedAtColumn,
-					idColumn,
-					idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CreateValidIngredient",
-					Type: ExecType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`INSERT INTO %s (
-	%s
-) VALUES (
-	%s
-);`,
-					validIngredientsTableName,
-					strings.Join(insertColumns, ",\n\t"),
-					strings.Join(applyToEach(insertColumns, func(i int, s string) string {
-						switch s {
-						case "minimum_ideal_storage_temperature_in_celsius",
-							"maximum_ideal_storage_temperature_in_celsius":
-							return fmt.Sprintf("sqlc.narg(%s)", s)
-						default:
-							return fmt.Sprintf("sqlc.arg(%s)", s)
-						}
-					}), ",\n\t"),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CheckValidIngredientExistence",
-					Type: OneType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT EXISTS (
-	SELECT %s.%s
-	FROM %s
-	WHERE %s.%s IS NULL
-		AND %s.%s = sqlc.arg(%s)
-);`,
-					validIngredientsTableName, idColumn,
-					validIngredientsTableName,
-					validIngredientsTableName,
-					archivedAtColumn,
-					validIngredientsTableName,
-					idColumn,
-					idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetValidIngredients",
-					Type: ManyType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+		return slices.Concat(
+			querygen.StandardCRUD(validIngredientsTableName, validIngredientsColumns,
+				querygen.WithEntity("ValidIngredient", "ValidIngredients"),
+				querygen.WithNullable(
+					"minimum_ideal_storage_temperature_in_celsius",
+					"maximum_ideal_storage_temperature_in_celsius",
+				),
+				querygen.WithOmitted(querygen.ListQuery),
+			),
+			[]*Query{
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetValidIngredients",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s
@@ -137,119 +90,91 @@ WHERE
 	%s
 GROUP BY %s.%s
 %s;`,
-					strings.Join(applyToEach(validIngredientsColumns, func(i int, s string) string {
-						return fmt.Sprintf("%s.%s", validIngredientsTableName, s)
-					}), ",\n\t"),
-					buildFilterCountSelect(validIngredientsTableName, true, true, []string{}),
-					buildTotalCountSelect(validIngredientsTableName, true, []string{}),
-					validIngredientsTableName,
-					validIngredientsTableName,
-					archivedAtColumn,
-					buildFilterConditions(
+						strings.Join(applyToEach(validIngredientsColumns, func(i int, s string) string {
+							return fmt.Sprintf("%s.%s", validIngredientsTableName, s)
+						}), ",\n\t"),
+						buildFilterCountSelect(validIngredientsTableName, true, true, []string{}),
+						buildTotalCountSelect(validIngredientsTableName, true, []string{}),
 						validIngredientsTableName,
-						true,
-						true,
-					),
-					validIngredientsTableName, idColumn,
-					buildCursorLimitClause(validIngredientsTableName),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "ScanValidIngredientIDsForReindex",
-					Type: ManyType,
+						validIngredientsTableName,
+						archivedAtColumn,
+						buildFilterConditions(
+							validIngredientsTableName,
+							true,
+							true,
+						),
+						validIngredientsTableName, idColumn,
+						buildCursorLimitClause(validIngredientsTableName),
+					)),
 				},
-				Content: buildReindexScanQuery(validIngredientsTableName),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetValidIngredientsNeedingIndexing",
-					Type: ManyType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT %s.%s
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetValidIngredientsNeedingIndexing",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT %s.%s
 FROM %s
 WHERE %s.%s IS NULL
 	AND (
 	%s.%s IS NULL
 	OR %s.%s < %s - '24 hours'::INTERVAL
 );`,
-					validIngredientsTableName,
-					idColumn,
-					validIngredientsTableName,
-					validIngredientsTableName,
-					archivedAtColumn,
-					validIngredientsTableName,
-					lastIndexedAtColumn,
-					validIngredientsTableName,
-					lastIndexedAtColumn,
-					currentTimeExpression,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetValidIngredient",
-					Type: OneType,
+						validIngredientsTableName,
+						idColumn,
+						validIngredientsTableName,
+						validIngredientsTableName,
+						archivedAtColumn,
+						validIngredientsTableName,
+						lastIndexedAtColumn,
+						validIngredientsTableName,
+						lastIndexedAtColumn,
+						currentTimeExpression,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
-	%s
-FROM %s
-WHERE %s.%s IS NULL
-AND %s.%s = sqlc.arg(%s);`,
-					strings.Join(applyToEach(validIngredientsColumns, func(i int, s string) string {
-						return fmt.Sprintf("%s.%s", validIngredientsTableName, s)
-					}), ",\n\t"),
-					validIngredientsTableName,
-					validIngredientsTableName,
-					archivedAtColumn,
-					validIngredientsTableName,
-					idColumn,
-					idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetRandomValidIngredient",
-					Type: OneType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetRandomValidIngredient",
+						Type: OneType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s
 FROM %s
 WHERE %s.%s IS NULL
 ORDER BY RANDOM() LIMIT 1;`,
-					strings.Join(applyToEach(validIngredientsColumns, func(i int, s string) string {
-						return fmt.Sprintf("%s.%s", validIngredientsTableName, s)
-					}), ",\n\t"),
-					validIngredientsTableName,
-					validIngredientsTableName,
-					archivedAtColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetValidIngredientsWithIDs",
-					Type: ManyType,
+						strings.Join(applyToEach(validIngredientsColumns, func(i int, s string) string {
+							return fmt.Sprintf("%s.%s", validIngredientsTableName, s)
+						}), ",\n\t"),
+						validIngredientsTableName,
+						validIngredientsTableName,
+						archivedAtColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetValidIngredientsWithIDs",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s
 FROM %s
 WHERE %s.%s IS NULL
 	AND %s.%s = ANY(sqlc.arg(ids)::text[]);`,
-					strings.Join(applyToEach(validIngredientsColumns, func(i int, s string) string {
-						return fmt.Sprintf("%s.%s", validIngredientsTableName, s)
-					}), ",\n\t"),
-					validIngredientsTableName,
-					validIngredientsTableName,
-					archivedAtColumn,
-					validIngredientsTableName,
-					idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "SearchForValidIngredients",
-					Type: ManyType,
+						strings.Join(applyToEach(validIngredientsColumns, func(i int, s string) string {
+							return fmt.Sprintf("%s.%s", validIngredientsTableName, s)
+						}), ",\n\t"),
+						validIngredientsTableName,
+						validIngredientsTableName,
+						archivedAtColumn,
+						validIngredientsTableName,
+						idColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "SearchForValidIngredients",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s
@@ -258,31 +183,31 @@ WHERE %s.%s IS NULL
 	AND %s.%s %s
 	%s
 %s;`,
-					strings.Join(applyToEach(validIngredientsColumns, func(i int, s string) string {
-						return fmt.Sprintf("%s.%s", validIngredientsTableName, s)
-					}), ",\n\t"),
-					buildFilterCountSelect(validIngredientsTableName, true, true, []string{}),
-					buildTotalCountSelect(validIngredientsTableName, true, []string{}),
-					validIngredientsTableName,
-					validIngredientsTableName,
-					archivedAtColumn,
-					validIngredientsTableName,
-					nameColumn,
-					buildILIKEForArgument("name_query"),
-					buildFilterConditions(
+						strings.Join(applyToEach(validIngredientsColumns, func(i int, s string) string {
+							return fmt.Sprintf("%s.%s", validIngredientsTableName, s)
+						}), ",\n\t"),
+						buildFilterCountSelect(validIngredientsTableName, true, true, []string{}),
+						buildTotalCountSelect(validIngredientsTableName, true, []string{}),
 						validIngredientsTableName,
-						true,
-						true,
-					),
-					buildCursorLimitClause(validIngredientsTableName),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "SearchValidIngredientsByPreparationAndIngredientName",
-					Type: ManyType,
+						validIngredientsTableName,
+						archivedAtColumn,
+						validIngredientsTableName,
+						nameColumn,
+						buildILIKEForArgument("name_query"),
+						buildFilterConditions(
+							validIngredientsTableName,
+							true,
+							true,
+						),
+						buildCursorLimitClause(validIngredientsTableName),
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "SearchValidIngredientsByPreparationAndIngredientName",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s
 FROM %s
 	JOIN %s ON %s.%s = %s.%s
@@ -292,64 +217,38 @@ WHERE %s.%s IS NULL
 	AND %s.%s IS NULL
 	AND %s.%s = sqlc.arg(%s)
 	AND %s.%s %s;`,
-					strings.Join(applyToEach(validIngredientsColumns, func(i int, s string) string {
-						if i == 0 {
-							return fmt.Sprintf("DISTINCT(%s.%s)", validIngredientsTableName, s)
-						}
-						return fmt.Sprintf("%s.%s", validIngredientsTableName, s)
-					}), ",\n\t"),
-					validIngredientPreparationsTableName,
-					validIngredientsTableName, validIngredientPreparationsTableName, validIngredientIDColumn, validIngredientsTableName, idColumn,
-					validPreparationsTableName, validIngredientPreparationsTableName, validPreparationIDColumn, validPreparationsTableName, idColumn,
-					validIngredientPreparationsTableName, archivedAtColumn,
-					validIngredientsTableName, archivedAtColumn,
-					validPreparationsTableName, archivedAtColumn,
-					validIngredientPreparationsTableName, validPreparationIDColumn, validPreparationIDColumn,
-					validIngredientsTableName, nameColumn, buildILIKEForArgument("name_query"),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "UpdateValidIngredient",
-					Type: ExecRowsType,
+						strings.Join(applyToEach(validIngredientsColumns, func(i int, s string) string {
+							if i == 0 {
+								return fmt.Sprintf("DISTINCT(%s.%s)", validIngredientsTableName, s)
+							}
+							return fmt.Sprintf("%s.%s", validIngredientsTableName, s)
+						}), ",\n\t"),
+						validIngredientPreparationsTableName,
+						validIngredientsTableName, validIngredientPreparationsTableName, validIngredientIDColumn, validIngredientsTableName, idColumn,
+						validPreparationsTableName, validIngredientPreparationsTableName, validPreparationIDColumn, validPreparationsTableName, idColumn,
+						validIngredientPreparationsTableName, archivedAtColumn,
+						validIngredientsTableName, archivedAtColumn,
+						validPreparationsTableName, archivedAtColumn,
+						validIngredientPreparationsTableName, validPreparationIDColumn, validPreparationIDColumn,
+						validIngredientsTableName, nameColumn, buildILIKEForArgument("name_query"),
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
-	%s,
-	%s = %s
-WHERE %s IS NULL
-	AND %s = sqlc.arg(%s);`,
-					validIngredientsTableName,
-					strings.Join(applyToEach(filterForUpdate(validIngredientsColumns), func(i int, s string) string {
-						switch s {
-						case "minimum_ideal_storage_temperature_in_celsius",
-							"maximum_ideal_storage_temperature_in_celsius":
-							return fmt.Sprintf("%s = sqlc.narg(%s)", s, s)
-						default:
-							return fmt.Sprintf("%s = sqlc.arg(%s)", s, s)
-						}
-					}), ",\n\t"),
-					lastUpdatedAtColumn,
-					currentTimeExpression,
-					archivedAtColumn,
-					idColumn,
-					idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "UpdateValidIngredientLastIndexedAt",
-					Type: ExecRowsType,
+				{
+					Annotation: QueryAnnotation{
+						Name: "UpdateValidIngredientLastIndexedAt",
+						Type: ExecRowsType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET %s = %s WHERE %s = sqlc.arg(%s) AND %s IS NULL;`,
+						validIngredientsTableName,
+						lastIndexedAtColumn,
+						currentTimeExpression,
+						idColumn,
+						idColumn,
+						archivedAtColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET %s = %s WHERE %s = sqlc.arg(%s) AND %s IS NULL;`,
-					validIngredientsTableName,
-					lastIndexedAtColumn,
-					currentTimeExpression,
-					idColumn,
-					idColumn,
-					archivedAtColumn,
-				)),
 			},
-		}
+		)
 	default:
 		return nil
 	}

--- a/backend/cmd/tools/codegen/queries/mealplanning_valid_instruments.go
+++ b/backend/cmd/tools/codegen/queries/mealplanning_valid_instruments.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"fmt"
+	"slices"
 	"strings"
+
+	"github.com/primandproper/platform-go/v11/database/querygen"
 
 	"github.com/cristalhq/builq"
 )
@@ -37,66 +40,18 @@ func buildValidInstrumentsQueries(database string) []*Query {
 	switch database {
 	case postgres:
 
-		insertColumns := filterForInsert(validInstrumentsColumns)
-
-		return []*Query{
-			{
-				Annotation: QueryAnnotation{
-					Name: "ArchiveValidInstrument",
-					Type: ExecRowsType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET %s = %s WHERE %s IS NULL AND %s = sqlc.arg(%s);`,
-					validInstrumentsTableName,
-					archivedAtColumn,
-					currentTimeExpression,
-					archivedAtColumn,
-					idColumn,
-					idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CreateValidInstrument",
-					Type: ExecType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`INSERT INTO %s (
-	%s
-) VALUES (
-	%s
-);`,
-					validInstrumentsTableName,
-					strings.Join(insertColumns, ",\n\t"),
-					strings.Join(applyToEach(insertColumns, func(i int, s string) string {
-						return fmt.Sprintf("sqlc.arg(%s)", s)
-					}), ",\n\t"),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CheckValidInstrumentExistence",
-					Type: OneType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT EXISTS (
-	SELECT %s.%s
-	FROM %s
-	WHERE %s.%s IS NULL
-		AND %s.%s = sqlc.arg(%s)
-);`,
-					validInstrumentsTableName, idColumn,
-					validInstrumentsTableName,
-					validInstrumentsTableName,
-					archivedAtColumn,
-					validInstrumentsTableName,
-					idColumn,
-					idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetValidInstruments",
-					Type: ManyType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+		return slices.Concat(
+			querygen.StandardCRUD(validInstrumentsTableName, validInstrumentsColumns,
+				querygen.WithEntity("ValidInstrument", "ValidInstruments"),
+				querygen.WithOmitted(querygen.ListQuery),
+			),
+			[]*Query{
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetValidInstruments",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s
@@ -106,119 +61,91 @@ WHERE
 	%s
 GROUP BY %s.%s
 %s;`,
-					strings.Join(applyToEach(validInstrumentsColumns, func(i int, s string) string {
-						return fmt.Sprintf("%s.%s", validInstrumentsTableName, s)
-					}), ",\n\t"),
-					buildFilterCountSelect(validInstrumentsTableName, true, true, []string{}),
-					buildTotalCountSelect(validInstrumentsTableName, true, []string{}),
-					validInstrumentsTableName,
-					validInstrumentsTableName,
-					archivedAtColumn,
-					buildFilterConditions(
+						strings.Join(applyToEach(validInstrumentsColumns, func(i int, s string) string {
+							return fmt.Sprintf("%s.%s", validInstrumentsTableName, s)
+						}), ",\n\t"),
+						buildFilterCountSelect(validInstrumentsTableName, true, true, []string{}),
+						buildTotalCountSelect(validInstrumentsTableName, true, []string{}),
 						validInstrumentsTableName,
-						true,
-						true,
-					),
-					validInstrumentsTableName, idColumn,
-					buildCursorLimitClause(validInstrumentsTableName),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "ScanValidInstrumentIDsForReindex",
-					Type: ManyType,
+						validInstrumentsTableName,
+						archivedAtColumn,
+						buildFilterConditions(
+							validInstrumentsTableName,
+							true,
+							true,
+						),
+						validInstrumentsTableName, idColumn,
+						buildCursorLimitClause(validInstrumentsTableName),
+					)),
 				},
-				Content: buildReindexScanQuery(validInstrumentsTableName),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetValidInstrumentsNeedingIndexing",
-					Type: ManyType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT %s.%s
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetValidInstrumentsNeedingIndexing",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT %s.%s
 FROM %s
 WHERE %s.%s IS NULL
 	AND (
 	%s.%s IS NULL
 	OR %s.%s < %s - '24 hours'::INTERVAL
 );`,
-					validInstrumentsTableName,
-					idColumn,
-					validInstrumentsTableName,
-					validInstrumentsTableName,
-					archivedAtColumn,
-					validInstrumentsTableName,
-					lastIndexedAtColumn,
-					validInstrumentsTableName,
-					lastIndexedAtColumn,
-					currentTimeExpression,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetValidInstrument",
-					Type: OneType,
+						validInstrumentsTableName,
+						idColumn,
+						validInstrumentsTableName,
+						validInstrumentsTableName,
+						archivedAtColumn,
+						validInstrumentsTableName,
+						lastIndexedAtColumn,
+						validInstrumentsTableName,
+						lastIndexedAtColumn,
+						currentTimeExpression,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
-	%s
-FROM %s
-WHERE %s.%s IS NULL
-AND %s.%s = sqlc.arg(%s);`,
-					strings.Join(applyToEach(validInstrumentsColumns, func(i int, s string) string {
-						return fmt.Sprintf("%s.%s", validInstrumentsTableName, s)
-					}), ",\n\t"),
-					validInstrumentsTableName,
-					validInstrumentsTableName,
-					archivedAtColumn,
-					validInstrumentsTableName,
-					idColumn,
-					idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetRandomValidInstrument",
-					Type: OneType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetRandomValidInstrument",
+						Type: OneType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s
 FROM %s
 WHERE %s.%s IS NULL
 ORDER BY RANDOM() LIMIT 1;`,
-					strings.Join(applyToEach(validInstrumentsColumns, func(i int, s string) string {
-						return fmt.Sprintf("%s.%s", validInstrumentsTableName, s)
-					}), ",\n\t"),
-					validInstrumentsTableName,
-					validInstrumentsTableName,
-					archivedAtColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetValidInstrumentsWithIDs",
-					Type: ManyType,
+						strings.Join(applyToEach(validInstrumentsColumns, func(i int, s string) string {
+							return fmt.Sprintf("%s.%s", validInstrumentsTableName, s)
+						}), ",\n\t"),
+						validInstrumentsTableName,
+						validInstrumentsTableName,
+						archivedAtColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetValidInstrumentsWithIDs",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s
 FROM %s
 WHERE %s.%s IS NULL
 	AND %s.%s = ANY(sqlc.arg(ids)::text[]);`,
-					strings.Join(applyToEach(validInstrumentsColumns, func(i int, s string) string {
-						return fmt.Sprintf("%s.%s", validInstrumentsTableName, s)
-					}), ",\n\t"),
-					validInstrumentsTableName,
-					validInstrumentsTableName,
-					archivedAtColumn,
-					validInstrumentsTableName,
-					idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "SearchForValidInstruments",
-					Type: ManyType,
+						strings.Join(applyToEach(validInstrumentsColumns, func(i int, s string) string {
+							return fmt.Sprintf("%s.%s", validInstrumentsTableName, s)
+						}), ",\n\t"),
+						validInstrumentsTableName,
+						validInstrumentsTableName,
+						archivedAtColumn,
+						validInstrumentsTableName,
+						idColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "SearchForValidInstruments",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s
@@ -227,31 +154,31 @@ WHERE %s.%s IS NULL
 	AND %s.%s %s
 	%s
 %s;`,
-					strings.Join(applyToEach(validInstrumentsColumns, func(i int, s string) string {
-						return fmt.Sprintf("%s.%s", validInstrumentsTableName, s)
-					}), ",\n\t"),
-					buildFilterCountSelect(validInstrumentsTableName, true, true, []string{}),
-					buildTotalCountSelect(validInstrumentsTableName, true, []string{}),
-					validInstrumentsTableName,
-					validInstrumentsTableName,
-					archivedAtColumn,
-					validInstrumentsTableName,
-					nameColumn,
-					buildILIKEForArgument("name_query"),
-					buildFilterConditions(
+						strings.Join(applyToEach(validInstrumentsColumns, func(i int, s string) string {
+							return fmt.Sprintf("%s.%s", validInstrumentsTableName, s)
+						}), ",\n\t"),
+						buildFilterCountSelect(validInstrumentsTableName, true, true, []string{}),
+						buildTotalCountSelect(validInstrumentsTableName, true, []string{}),
 						validInstrumentsTableName,
-						true,
-						true,
-					),
-					buildCursorLimitClause(validInstrumentsTableName),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "SearchForValidInstrumentsNotOwnedByAccount",
-					Type: ManyType,
+						validInstrumentsTableName,
+						archivedAtColumn,
+						validInstrumentsTableName,
+						nameColumn,
+						buildILIKEForArgument("name_query"),
+						buildFilterConditions(
+							validInstrumentsTableName,
+							true,
+							true,
+						),
+						buildCursorLimitClause(validInstrumentsTableName),
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "SearchForValidInstrumentsNotOwnedByAccount",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s
@@ -260,64 +187,44 @@ WHERE %s.%s IS NULL
 	AND %s.%s %s
 	%s
 %s;`,
-					strings.Join(applyToEach(validInstrumentsColumns, func(i int, s string) string {
-						return fmt.Sprintf("%s.%s", validInstrumentsTableName, s)
-					}), ",\n\t"),
-					buildFilterCountSelect(validInstrumentsTableName, true, true, []string{},
-						validInstrumentsTableName+".id NOT IN (SELECT valid_instrument_id FROM account_instrument_ownerships WHERE account_instrument_ownerships.belongs_to_account = sqlc.arg(account_id) AND account_instrument_ownerships.archived_at IS NULL)"),
-					buildTotalCountSelect(validInstrumentsTableName, true, []string{},
-						validInstrumentsTableName+".id NOT IN (SELECT valid_instrument_id FROM account_instrument_ownerships WHERE account_instrument_ownerships.belongs_to_account = sqlc.arg(account_id) AND account_instrument_ownerships.archived_at IS NULL)"),
-					validInstrumentsTableName,
-					validInstrumentsTableName,
-					archivedAtColumn,
-					validInstrumentsTableName,
-					nameColumn,
-					buildILIKEForArgument("name_query"),
-					buildFilterConditions(
+						strings.Join(applyToEach(validInstrumentsColumns, func(i int, s string) string {
+							return fmt.Sprintf("%s.%s", validInstrumentsTableName, s)
+						}), ",\n\t"),
+						buildFilterCountSelect(validInstrumentsTableName, true, true, []string{},
+							validInstrumentsTableName+".id NOT IN (SELECT valid_instrument_id FROM account_instrument_ownerships WHERE account_instrument_ownerships.belongs_to_account = sqlc.arg(account_id) AND account_instrument_ownerships.archived_at IS NULL)"),
+						buildTotalCountSelect(validInstrumentsTableName, true, []string{},
+							validInstrumentsTableName+".id NOT IN (SELECT valid_instrument_id FROM account_instrument_ownerships WHERE account_instrument_ownerships.belongs_to_account = sqlc.arg(account_id) AND account_instrument_ownerships.archived_at IS NULL)"),
 						validInstrumentsTableName,
-						true,
-						true,
-						validInstrumentsTableName+".id NOT IN (SELECT valid_instrument_id FROM account_instrument_ownerships WHERE account_instrument_ownerships.belongs_to_account = sqlc.arg(account_id) AND account_instrument_ownerships.archived_at IS NULL)",
-					),
-					buildCursorLimitClause(validInstrumentsTableName),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "UpdateValidInstrument",
-					Type: ExecRowsType,
+						validInstrumentsTableName,
+						archivedAtColumn,
+						validInstrumentsTableName,
+						nameColumn,
+						buildILIKEForArgument("name_query"),
+						buildFilterConditions(
+							validInstrumentsTableName,
+							true,
+							true,
+							validInstrumentsTableName+".id NOT IN (SELECT valid_instrument_id FROM account_instrument_ownerships WHERE account_instrument_ownerships.belongs_to_account = sqlc.arg(account_id) AND account_instrument_ownerships.archived_at IS NULL)",
+						),
+						buildCursorLimitClause(validInstrumentsTableName),
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
-	%s,
-	%s = %s
-WHERE %s IS NULL
-	AND %s = sqlc.arg(%s);`,
-					validInstrumentsTableName,
-					strings.Join(applyToEach(filterForUpdate(validInstrumentsColumns), func(i int, s string) string {
-						return fmt.Sprintf("%s = sqlc.arg(%s)", s, s)
-					}), ",\n\t"),
-					lastUpdatedAtColumn,
-					currentTimeExpression,
-					archivedAtColumn,
-					idColumn,
-					idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "UpdateValidInstrumentLastIndexedAt",
-					Type: ExecRowsType,
+				{
+					Annotation: QueryAnnotation{
+						Name: "UpdateValidInstrumentLastIndexedAt",
+						Type: ExecRowsType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET %s = %s WHERE %s = sqlc.arg(%s) AND %s IS NULL;`,
+						validInstrumentsTableName,
+						lastIndexedAtColumn,
+						currentTimeExpression,
+						idColumn,
+						idColumn,
+						archivedAtColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET %s = %s WHERE %s = sqlc.arg(%s) AND %s IS NULL;`,
-					validInstrumentsTableName,
-					lastIndexedAtColumn,
-					currentTimeExpression,
-					idColumn,
-					idColumn,
-					archivedAtColumn,
-				)),
 			},
-		}
+		)
 	default:
 		return nil
 	}

--- a/backend/cmd/tools/codegen/queries/mealplanning_valid_measurement_units.go
+++ b/backend/cmd/tools/codegen/queries/mealplanning_valid_measurement_units.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"fmt"
+	"slices"
 	"strings"
+
+	"github.com/primandproper/platform-go/v11/database/querygen"
 
 	"github.com/cristalhq/builq"
 )
@@ -38,63 +41,18 @@ func buildValidMeasurementUnitsQueries(database string) []*Query {
 	switch database {
 	case postgres:
 
-		insertColumns := filterForInsert(validMeasurementUnitsColumns)
-
-		return []*Query{
-			{
-				Annotation: QueryAnnotation{
-					Name: "ArchiveValidMeasurementUnit",
-					Type: ExecRowsType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET %s = %s WHERE %s IS NULL AND %s = sqlc.arg(%s);`,
-					validMeasurementUnitsTableName,
-					archivedAtColumn,
-					currentTimeExpression,
-					archivedAtColumn,
-					idColumn,
-					idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CreateValidMeasurementUnit",
-					Type: ExecType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`INSERT INTO %s (
-	%s
-) VALUES (
-	%s
-);`,
-					validMeasurementUnitsTableName,
-					strings.Join(insertColumns, ",\n\t"),
-					strings.Join(applyToEach(insertColumns, func(i int, s string) string {
-						return fmt.Sprintf("sqlc.arg(%s)", s)
-					}), ",\n\t"),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CheckValidMeasurementUnitExistence",
-					Type: OneType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT EXISTS (
-	SELECT %s.%s
-	FROM %s
-	WHERE %s.%s IS NULL
-		AND %s.%s = sqlc.arg(%s)
-);`,
-					validMeasurementUnitsTableName, idColumn,
-					validMeasurementUnitsTableName,
-					validMeasurementUnitsTableName, archivedAtColumn,
-					validMeasurementUnitsTableName, idColumn, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetValidMeasurementUnits",
-					Type: ManyType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+		return slices.Concat(
+			querygen.StandardCRUD(validMeasurementUnitsTableName, validMeasurementUnitsColumns,
+				querygen.WithEntity("ValidMeasurementUnit", "ValidMeasurementUnits"),
+				querygen.WithOmitted(querygen.ListQuery),
+			),
+			[]*Query{
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetValidMeasurementUnits",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s
@@ -104,29 +62,29 @@ WHERE
 	%s
 GROUP BY %s.%s
 %s;`,
-					strings.Join(applyToEach(validMeasurementUnitsColumns, func(i int, s string) string {
-						return fmt.Sprintf("%s.%s", validMeasurementUnitsTableName, s)
-					}), ",\n\t"),
-					buildFilterCountSelect(validMeasurementUnitsTableName, true, true, []string{}),
-					buildTotalCountSelect(validMeasurementUnitsTableName, true, []string{}),
-					validMeasurementUnitsTableName,
-					validMeasurementUnitsTableName,
-					archivedAtColumn,
-					buildFilterConditions(
+						strings.Join(applyToEach(validMeasurementUnitsColumns, func(i int, s string) string {
+							return fmt.Sprintf("%s.%s", validMeasurementUnitsTableName, s)
+						}), ",\n\t"),
+						buildFilterCountSelect(validMeasurementUnitsTableName, true, true, []string{}),
+						buildTotalCountSelect(validMeasurementUnitsTableName, true, []string{}),
 						validMeasurementUnitsTableName,
-						true,
-						true,
-					),
-					validMeasurementUnitsTableName, idColumn,
-					buildCursorLimitClause(validMeasurementUnitsTableName),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetUniversalValidMeasurementUnits",
-					Type: ManyType,
+						validMeasurementUnitsTableName,
+						archivedAtColumn,
+						buildFilterConditions(
+							validMeasurementUnitsTableName,
+							true,
+							true,
+						),
+						validMeasurementUnitsTableName, idColumn,
+						buildCursorLimitClause(validMeasurementUnitsTableName),
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetUniversalValidMeasurementUnits",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s
@@ -137,120 +95,92 @@ WHERE
 	%s
 GROUP BY %s.%s
 %s;`,
-					strings.Join(applyToEach(validMeasurementUnitsColumns, func(i int, s string) string {
-						return fmt.Sprintf("%s.%s", validMeasurementUnitsTableName, s)
-					}), ",\n\t"),
-					buildFilterCountSelect(validMeasurementUnitsTableName, true, true, []string{}),
-					buildTotalCountSelect(validMeasurementUnitsTableName, true, []string{}),
-					validMeasurementUnitsTableName,
-					validMeasurementUnitsTableName, validMeasurementUnitsUniversalColumn,
-					validMeasurementUnitsTableName,
-					archivedAtColumn,
-					buildFilterConditions(
+						strings.Join(applyToEach(validMeasurementUnitsColumns, func(i int, s string) string {
+							return fmt.Sprintf("%s.%s", validMeasurementUnitsTableName, s)
+						}), ",\n\t"),
+						buildFilterCountSelect(validMeasurementUnitsTableName, true, true, []string{}),
+						buildTotalCountSelect(validMeasurementUnitsTableName, true, []string{}),
 						validMeasurementUnitsTableName,
-						true,
-						true,
-					),
-					validMeasurementUnitsTableName, idColumn,
-					buildCursorLimitClause(validMeasurementUnitsTableName),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "ScanValidMeasurementUnitIDsForReindex",
-					Type: ManyType,
+						validMeasurementUnitsTableName, validMeasurementUnitsUniversalColumn,
+						validMeasurementUnitsTableName,
+						archivedAtColumn,
+						buildFilterConditions(
+							validMeasurementUnitsTableName,
+							true,
+							true,
+						),
+						validMeasurementUnitsTableName, idColumn,
+						buildCursorLimitClause(validMeasurementUnitsTableName),
+					)),
 				},
-				Content: buildReindexScanQuery(validMeasurementUnitsTableName),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetValidMeasurementUnitsNeedingIndexing",
-					Type: ManyType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT %s.%s
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetValidMeasurementUnitsNeedingIndexing",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT %s.%s
 FROM %s
 WHERE %s.%s IS NULL
 	AND (
 	%s.%s IS NULL
 	OR %s.%s < %s - '24 hours'::INTERVAL
 );`,
-					validMeasurementUnitsTableName,
-					idColumn,
-					validMeasurementUnitsTableName,
-					validMeasurementUnitsTableName,
-					archivedAtColumn,
-					validMeasurementUnitsTableName,
-					lastIndexedAtColumn,
-					validMeasurementUnitsTableName,
-					lastIndexedAtColumn,
-					currentTimeExpression,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetValidMeasurementUnit",
-					Type: OneType,
+						validMeasurementUnitsTableName,
+						idColumn,
+						validMeasurementUnitsTableName,
+						validMeasurementUnitsTableName,
+						archivedAtColumn,
+						validMeasurementUnitsTableName,
+						lastIndexedAtColumn,
+						validMeasurementUnitsTableName,
+						lastIndexedAtColumn,
+						currentTimeExpression,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
-	%s
-FROM %s
-WHERE %s.%s IS NULL
-AND %s.%s = sqlc.arg(%s);`,
-					strings.Join(applyToEach(validMeasurementUnitsColumns, func(i int, s string) string {
-						return fmt.Sprintf("%s.%s", validMeasurementUnitsTableName, s)
-					}), ",\n\t"),
-					validMeasurementUnitsTableName,
-					validMeasurementUnitsTableName,
-					archivedAtColumn,
-					validMeasurementUnitsTableName,
-					idColumn,
-					idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetRandomValidMeasurementUnit",
-					Type: OneType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetRandomValidMeasurementUnit",
+						Type: OneType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s
 FROM %s
 WHERE %s.%s IS NULL
 ORDER BY RANDOM() LIMIT 1;`,
-					strings.Join(applyToEach(validMeasurementUnitsColumns, func(i int, s string) string {
-						return fmt.Sprintf("%s.%s", validMeasurementUnitsTableName, s)
-					}), ",\n\t"),
-					validMeasurementUnitsTableName,
-					validMeasurementUnitsTableName,
-					archivedAtColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetValidMeasurementUnitsWithIDs",
-					Type: ManyType,
+						strings.Join(applyToEach(validMeasurementUnitsColumns, func(i int, s string) string {
+							return fmt.Sprintf("%s.%s", validMeasurementUnitsTableName, s)
+						}), ",\n\t"),
+						validMeasurementUnitsTableName,
+						validMeasurementUnitsTableName,
+						archivedAtColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetValidMeasurementUnitsWithIDs",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s
 FROM %s
 WHERE %s.%s IS NULL
 	AND %s.%s = ANY(sqlc.arg(ids)::text[]);`,
-					strings.Join(applyToEach(validMeasurementUnitsColumns, func(i int, s string) string {
-						return fmt.Sprintf("%s.%s", validMeasurementUnitsTableName, s)
-					}), ",\n\t"),
-					validMeasurementUnitsTableName,
-					validMeasurementUnitsTableName,
-					archivedAtColumn,
-					validMeasurementUnitsTableName,
-					idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "SearchForValidMeasurementUnits",
-					Type: ManyType,
+						strings.Join(applyToEach(validMeasurementUnitsColumns, func(i int, s string) string {
+							return fmt.Sprintf("%s.%s", validMeasurementUnitsTableName, s)
+						}), ",\n\t"),
+						validMeasurementUnitsTableName,
+						validMeasurementUnitsTableName,
+						archivedAtColumn,
+						validMeasurementUnitsTableName,
+						idColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "SearchForValidMeasurementUnits",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s
@@ -259,31 +189,31 @@ WHERE %s.%s IS NULL
 	AND %s.%s %s
 	%s
 %s;`,
-					strings.Join(applyToEach(validMeasurementUnitsColumns, func(i int, s string) string {
-						return fmt.Sprintf("%s.%s", validMeasurementUnitsTableName, s)
-					}), ",\n\t"),
-					buildFilterCountSelect(validMeasurementUnitsTableName, true, true, []string{}),
-					buildTotalCountSelect(validMeasurementUnitsTableName, true, []string{}),
-					validMeasurementUnitsTableName,
-					validMeasurementUnitsTableName,
-					archivedAtColumn,
-					validMeasurementUnitsTableName,
-					nameColumn,
-					buildILIKEForArgument("name_query"),
-					buildFilterConditions(
+						strings.Join(applyToEach(validMeasurementUnitsColumns, func(i int, s string) string {
+							return fmt.Sprintf("%s.%s", validMeasurementUnitsTableName, s)
+						}), ",\n\t"),
+						buildFilterCountSelect(validMeasurementUnitsTableName, true, true, []string{}),
+						buildTotalCountSelect(validMeasurementUnitsTableName, true, []string{}),
 						validMeasurementUnitsTableName,
-						true,
-						true,
-					),
-					buildCursorLimitClause(validMeasurementUnitsTableName),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "SearchValidMeasurementUnitsByIngredientID",
-					Type: ManyType,
+						validMeasurementUnitsTableName,
+						archivedAtColumn,
+						validMeasurementUnitsTableName,
+						nameColumn,
+						buildILIKEForArgument("name_query"),
+						buildFilterConditions(
+							validMeasurementUnitsTableName,
+							true,
+							true,
+						),
+						buildCursorLimitClause(validMeasurementUnitsTableName),
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "SearchValidMeasurementUnitsByIngredientID",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s
@@ -300,65 +230,45 @@ WHERE
 	AND %s.%s IS NULL
 	%s
 %s;`,
-					strings.Join(applyToEach(validMeasurementUnitsColumns, func(i int, s string) string {
-						if i == 0 {
-							return fmt.Sprintf("DISTINCT(%s.%s)", validMeasurementUnitsTableName, s)
-						}
-						return fmt.Sprintf("%s.%s", validMeasurementUnitsTableName, s)
-					}), ",\n\t"),
-					buildFilterCountSelect(validMeasurementUnitsTableName, true, true, []string{}, ` (
+						strings.Join(applyToEach(validMeasurementUnitsColumns, func(i int, s string) string {
+							if i == 0 {
+								return fmt.Sprintf("DISTINCT(%s.%s)", validMeasurementUnitsTableName, s)
+							}
+							return fmt.Sprintf("%s.%s", validMeasurementUnitsTableName, s)
+						}), ",\n\t"),
+						buildFilterCountSelect(validMeasurementUnitsTableName, true, true, []string{}, ` (
 				valid_ingredient_measurement_units.valid_ingredient_id = sqlc.arg(valid_ingredient_id)
 				OR valid_measurement_units.universal = true
 			)`),
-					buildTotalCountSelect(validMeasurementUnitsTableName, true, []string{}),
-					validMeasurementUnitsTableName,
-					validIngredientMeasurementUnitsTableName, validIngredientMeasurementUnitsTableName, validMeasurementUnitIDColumn, validMeasurementUnitsTableName, idColumn,
-					validIngredientsTableName, validIngredientMeasurementUnitsTableName, validIngredientIDColumn, validIngredientsTableName, idColumn,
-					validIngredientMeasurementUnitsTableName, validIngredientIDColumn, validIngredientIDColumn,
-					validMeasurementUnitsTableName, validMeasurementUnitsUniversalColumn,
-					validMeasurementUnitsTableName, archivedAtColumn,
-					validIngredientsTableName, archivedAtColumn,
-					validIngredientMeasurementUnitsTableName, archivedAtColumn,
-					buildFilterConditions(validMeasurementUnitsTableName, true, false),
-					buildCursorLimitClause(validMeasurementUnitsTableName),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "UpdateValidMeasurementUnit",
-					Type: ExecRowsType,
+						buildTotalCountSelect(validMeasurementUnitsTableName, true, []string{}),
+						validMeasurementUnitsTableName,
+						validIngredientMeasurementUnitsTableName, validIngredientMeasurementUnitsTableName, validMeasurementUnitIDColumn, validMeasurementUnitsTableName, idColumn,
+						validIngredientsTableName, validIngredientMeasurementUnitsTableName, validIngredientIDColumn, validIngredientsTableName, idColumn,
+						validIngredientMeasurementUnitsTableName, validIngredientIDColumn, validIngredientIDColumn,
+						validMeasurementUnitsTableName, validMeasurementUnitsUniversalColumn,
+						validMeasurementUnitsTableName, archivedAtColumn,
+						validIngredientsTableName, archivedAtColumn,
+						validIngredientMeasurementUnitsTableName, archivedAtColumn,
+						buildFilterConditions(validMeasurementUnitsTableName, true, false),
+						buildCursorLimitClause(validMeasurementUnitsTableName),
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
-	%s,
-	%s = %s
-WHERE %s IS NULL
-	AND %s = sqlc.arg(%s);`,
-					validMeasurementUnitsTableName,
-					strings.Join(applyToEach(filterForUpdate(validMeasurementUnitsColumns), func(i int, s string) string {
-						return fmt.Sprintf("%s = sqlc.arg(%s)", s, s)
-					}), ",\n\t"),
-					lastUpdatedAtColumn,
-					currentTimeExpression,
-					archivedAtColumn,
-					idColumn,
-					idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "UpdateValidMeasurementUnitLastIndexedAt",
-					Type: ExecRowsType,
+				{
+					Annotation: QueryAnnotation{
+						Name: "UpdateValidMeasurementUnitLastIndexedAt",
+						Type: ExecRowsType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET %s = %s WHERE %s = sqlc.arg(%s) AND %s IS NULL;`,
+						validMeasurementUnitsTableName,
+						lastIndexedAtColumn,
+						currentTimeExpression,
+						idColumn,
+						idColumn,
+						archivedAtColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET %s = %s WHERE %s = sqlc.arg(%s) AND %s IS NULL;`,
-					validMeasurementUnitsTableName,
-					lastIndexedAtColumn,
-					currentTimeExpression,
-					idColumn,
-					idColumn,
-					archivedAtColumn,
-				)),
 			},
-		}
+		)
 	default:
 		return nil
 	}

--- a/backend/cmd/tools/codegen/queries/mealplanning_valid_preparations.go
+++ b/backend/cmd/tools/codegen/queries/mealplanning_valid_preparations.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"fmt"
+	"slices"
 	"strings"
+
+	"github.com/primandproper/platform-go/v11/database/querygen"
 
 	"github.com/cristalhq/builq"
 )
@@ -48,63 +51,18 @@ func buildValidPreparationsQueries(database string) []*Query {
 	switch database {
 	case postgres:
 
-		insertColumns := filterForInsert(validPreparationsColumns)
-
-		return []*Query{
-			{
-				Annotation: QueryAnnotation{
-					Name: "ArchiveValidPreparation",
-					Type: ExecRowsType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET %s = %s WHERE %s IS NULL AND %s = sqlc.arg(%s);`,
-					validPreparationsTableName,
-					archivedAtColumn,
-					currentTimeExpression,
-					archivedAtColumn,
-					idColumn,
-					idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CreateValidPreparation",
-					Type: ExecType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`INSERT INTO %s (
-	%s
-) VALUES (
-	%s
-);`,
-					validPreparationsTableName,
-					strings.Join(insertColumns, ",\n\t"),
-					strings.Join(applyToEach(insertColumns, func(i int, s string) string {
-						return fmt.Sprintf("sqlc.arg(%s)", s)
-					}), ",\n\t"),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CheckValidPreparationExistence",
-					Type: OneType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT EXISTS (
-	SELECT %s.%s
-	FROM %s
-	WHERE %s.%s IS NULL
-		AND %s.%s = sqlc.arg(%s)
-);`,
-					validPreparationsTableName, idColumn,
-					validPreparationsTableName,
-					validPreparationsTableName, archivedAtColumn,
-					validPreparationsTableName, idColumn, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetValidPreparations",
-					Type: ManyType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+		return slices.Concat(
+			querygen.StandardCRUD(validPreparationsTableName, validPreparationsColumns,
+				querygen.WithEntity("ValidPreparation", "ValidPreparations"),
+				querygen.WithOmitted(querygen.ListQuery),
+			),
+			[]*Query{
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetValidPreparations",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s
@@ -114,106 +72,81 @@ WHERE
 	%s
 GROUP BY %s.%s
 %s;`,
-					strings.Join(applyToEach(validPreparationsColumns, func(i int, s string) string {
-						return fmt.Sprintf("%s.%s", validPreparationsTableName, s)
-					}), ",\n\t"),
-					buildFilterCountSelect(validPreparationsTableName, true, true, []string{}),
-					buildTotalCountSelect(validPreparationsTableName, true, []string{}),
-					validPreparationsTableName,
-					validPreparationsTableName, archivedAtColumn,
-					buildFilterConditions(
+						strings.Join(applyToEach(validPreparationsColumns, func(i int, s string) string {
+							return fmt.Sprintf("%s.%s", validPreparationsTableName, s)
+						}), ",\n\t"),
+						buildFilterCountSelect(validPreparationsTableName, true, true, []string{}),
+						buildTotalCountSelect(validPreparationsTableName, true, []string{}),
 						validPreparationsTableName,
-						true,
-						true,
-					),
-					validPreparationsTableName, idColumn, buildCursorLimitClause(validPreparationsTableName),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "ScanValidPreparationIDsForReindex",
-					Type: ManyType,
+						validPreparationsTableName, archivedAtColumn,
+						buildFilterConditions(
+							validPreparationsTableName,
+							true,
+							true,
+						),
+						validPreparationsTableName, idColumn, buildCursorLimitClause(validPreparationsTableName),
+					)),
 				},
-				Content: buildReindexScanQuery(validPreparationsTableName),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetValidPreparationsNeedingIndexing",
-					Type: ManyType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT %s.%s
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetValidPreparationsNeedingIndexing",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT %s.%s
 FROM %s
 WHERE %s.%s IS NULL
 	AND (
 	%s.%s IS NULL
 	OR %s.%s < %s - '24 hours'::INTERVAL
 );`,
-					validPreparationsTableName, idColumn,
-					validPreparationsTableName,
-					validPreparationsTableName, archivedAtColumn,
-					validPreparationsTableName, lastIndexedAtColumn,
-					validPreparationsTableName, lastIndexedAtColumn, currentTimeExpression,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetValidPreparation",
-					Type: OneType,
+						validPreparationsTableName, idColumn,
+						validPreparationsTableName,
+						validPreparationsTableName, archivedAtColumn,
+						validPreparationsTableName, lastIndexedAtColumn,
+						validPreparationsTableName, lastIndexedAtColumn, currentTimeExpression,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
-	%s
-FROM %s
-WHERE %s.%s IS NULL
-	AND %s.%s = sqlc.arg(%s);`,
-					strings.Join(applyToEach(validPreparationsColumns, func(i int, s string) string {
-						return fmt.Sprintf("%s.%s", validPreparationsTableName, s)
-					}), ",\n\t"),
-					validPreparationsTableName,
-					validPreparationsTableName, archivedAtColumn,
-					validPreparationsTableName, idColumn, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetRandomValidPreparation",
-					Type: OneType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetRandomValidPreparation",
+						Type: OneType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s
 FROM %s
 WHERE %s.%s IS NULL
 ORDER BY RANDOM() LIMIT 1;`,
-					strings.Join(applyToEach(validPreparationsColumns, func(i int, s string) string {
-						return fmt.Sprintf("%s.%s", validPreparationsTableName, s)
-					}), ",\n\t"),
-					validPreparationsTableName,
-					validPreparationsTableName, archivedAtColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetValidPreparationsWithIDs",
-					Type: ManyType,
+						strings.Join(applyToEach(validPreparationsColumns, func(i int, s string) string {
+							return fmt.Sprintf("%s.%s", validPreparationsTableName, s)
+						}), ",\n\t"),
+						validPreparationsTableName,
+						validPreparationsTableName, archivedAtColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetValidPreparationsWithIDs",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s
 FROM %s
 WHERE %s.%s IS NULL
 	AND %s.%s = ANY(sqlc.arg(ids)::text[]);`,
-					strings.Join(applyToEach(validPreparationsColumns, func(i int, s string) string {
-						return fmt.Sprintf("%s.%s", validPreparationsTableName, s)
-					}), ",\n\t"),
-					validPreparationsTableName,
-					validPreparationsTableName, archivedAtColumn,
-					validPreparationsTableName, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "SearchForValidPreparations",
-					Type: ManyType,
+						strings.Join(applyToEach(validPreparationsColumns, func(i int, s string) string {
+							return fmt.Sprintf("%s.%s", validPreparationsTableName, s)
+						}), ",\n\t"),
+						validPreparationsTableName,
+						validPreparationsTableName, archivedAtColumn,
+						validPreparationsTableName, idColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "SearchForValidPreparations",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s
@@ -222,59 +155,41 @@ WHERE %s.%s IS NULL
 	AND %s.%s %s
 	%s
 %s;`,
-					strings.Join(applyToEach(validPreparationsColumns, func(i int, s string) string {
-						return fmt.Sprintf("%s.%s", validPreparationsTableName, s)
-					}), ",\n\t"),
-					buildFilterCountSelect(validPreparationsTableName, true, true, []string{}),
-					buildTotalCountSelect(validPreparationsTableName, true, []string{}),
-					validPreparationsTableName,
-					validPreparationsTableName,
-					archivedAtColumn,
-					validPreparationsTableName,
-					nameColumn,
-					buildILIKEForArgument("name_query"),
-					buildFilterConditions(
+						strings.Join(applyToEach(validPreparationsColumns, func(i int, s string) string {
+							return fmt.Sprintf("%s.%s", validPreparationsTableName, s)
+						}), ",\n\t"),
+						buildFilterCountSelect(validPreparationsTableName, true, true, []string{}),
+						buildTotalCountSelect(validPreparationsTableName, true, []string{}),
 						validPreparationsTableName,
-						true,
-						true,
-					),
-					buildCursorLimitClause(validPreparationsTableName),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "UpdateValidPreparation",
-					Type: ExecRowsType,
+						validPreparationsTableName,
+						archivedAtColumn,
+						validPreparationsTableName,
+						nameColumn,
+						buildILIKEForArgument("name_query"),
+						buildFilterConditions(
+							validPreparationsTableName,
+							true,
+							true,
+						),
+						buildCursorLimitClause(validPreparationsTableName),
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
-	%s,
-	%s = %s
-WHERE %s IS NULL
-	AND %s = sqlc.arg(%s);`,
-					validPreparationsTableName,
-					strings.Join(applyToEach(filterForUpdate(validPreparationsColumns), func(i int, s string) string {
-						return fmt.Sprintf("%s = sqlc.arg(%s)", s, s)
-					}), ",\n\t"),
-					lastUpdatedAtColumn, currentTimeExpression,
-					archivedAtColumn,
-					idColumn, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "UpdateValidPreparationLastIndexedAt",
-					Type: ExecRowsType,
+				{
+					Annotation: QueryAnnotation{
+						Name: "UpdateValidPreparationLastIndexedAt",
+						Type: ExecRowsType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET %s = %s WHERE %s = sqlc.arg(%s) AND %s IS NULL;`,
+						validPreparationsTableName,
+						lastIndexedAtColumn,
+						currentTimeExpression,
+						idColumn,
+						idColumn,
+						archivedAtColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET %s = %s WHERE %s = sqlc.arg(%s) AND %s IS NULL;`,
-					validPreparationsTableName,
-					lastIndexedAtColumn,
-					currentTimeExpression,
-					idColumn,
-					idColumn,
-					archivedAtColumn,
-				)),
 			},
-		}
+		)
 	default:
 		return nil
 	}

--- a/backend/cmd/tools/codegen/queries/mealplanning_valid_vessels.go
+++ b/backend/cmd/tools/codegen/queries/mealplanning_valid_vessels.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"fmt"
+	"slices"
 	"strings"
+
+	"github.com/primandproper/platform-go/v11/database/querygen"
 
 	"github.com/cristalhq/builq"
 )
@@ -43,8 +46,6 @@ func buildValidVesselsQueries(database string) []*Query {
 	switch database {
 	case postgres:
 
-		insertColumns := filterForInsert(validVesselsColumns)
-
 		fullSelectColumns := mergeColumns(
 			applyToEach(filterFromSlice(validVesselsColumns, "capacity_unit"), func(i int, s string) string {
 				return fmt.Sprintf("%s.%s", validVesselsTableName, s)
@@ -55,64 +56,20 @@ func buildValidVesselsQueries(database string) []*Query {
 			10,
 		)
 
-		return []*Query{
-			{
-				Annotation: QueryAnnotation{
-					Name: "ArchiveValidVessel",
-					Type: ExecRowsType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET %s = %s WHERE %s IS NULL AND %s = sqlc.arg(%s);`,
-					validVesselsTableName,
-					archivedAtColumn,
-					currentTimeExpression,
-					archivedAtColumn,
-					idColumn,
-					idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CreateValidVessel",
-					Type: ExecType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`INSERT INTO %s (
-	%s
-) VALUES (
-	%s
-);`,
-					validVesselsTableName,
-					strings.Join(insertColumns, ",\n\t"),
-					strings.Join(applyToEach(insertColumns, func(i int, s string) string {
-						return fmt.Sprintf("sqlc.arg(%s)", s)
-					}), ",\n\t"),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CheckValidVesselExistence",
-					Type: OneType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT EXISTS (
-	SELECT %s.id
-	FROM %s
-	WHERE %s.%s IS NULL
-		AND %s.%s = sqlc.arg(%s)
-);`,
-					validVesselsTableName,
-					validVesselsTableName,
-					validVesselsTableName,
-					archivedAtColumn,
-					validVesselsTableName,
-					idColumn,
-					idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetValidVessels",
-					Type: ManyType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+		return slices.Concat(
+			// GetValidVessel joins valid_measurement_units for the capacity unit, so it
+			// is not the standard single-row read and stays below.
+			querygen.StandardCRUD(validVesselsTableName, validVesselsColumns,
+				querygen.WithEntity("ValidVessel", "ValidVessels"),
+				querygen.WithOmitted(querygen.GetQuery, querygen.ListQuery),
+			),
+			[]*Query{
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetValidVessels",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s
@@ -122,139 +79,132 @@ WHERE
 	%s
 GROUP BY %s.%s
 %s;`,
-					strings.Join(applyToEach(validVesselsColumns, func(i int, s string) string {
-						return fmt.Sprintf("%s.%s", validVesselsTableName, s)
-					}), ",\n\t"),
-					buildFilterCountSelect(validVesselsTableName, true, true, []string{}),
-					buildTotalCountSelect(validVesselsTableName, true, []string{}),
-					validVesselsTableName,
-					validVesselsTableName,
-					archivedAtColumn,
-					buildFilterConditions(
+						strings.Join(applyToEach(validVesselsColumns, func(i int, s string) string {
+							return fmt.Sprintf("%s.%s", validVesselsTableName, s)
+						}), ",\n\t"),
+						buildFilterCountSelect(validVesselsTableName, true, true, []string{}),
+						buildTotalCountSelect(validVesselsTableName, true, []string{}),
 						validVesselsTableName,
-						true,
-						true,
-					),
-					validVesselsTableName, idColumn,
-					buildCursorLimitClause(validVesselsTableName),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "ScanValidVesselIDsForReindex",
-					Type: ManyType,
+						validVesselsTableName,
+						archivedAtColumn,
+						buildFilterConditions(
+							validVesselsTableName,
+							true,
+							true,
+						),
+						validVesselsTableName, idColumn,
+						buildCursorLimitClause(validVesselsTableName),
+					)),
 				},
-				Content: buildReindexScanQuery(validVesselsTableName),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetValidVesselIDsNeedingIndexing",
-					Type: ManyType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT %s.%s
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetValidVesselIDsNeedingIndexing",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT %s.%s
 FROM %s
 WHERE %s.%s IS NULL
 	AND (
 	%s.%s IS NULL
 	OR %s.%s < %s - '24 hours'::INTERVAL
 );`,
-					validVesselsTableName,
-					idColumn,
-					validVesselsTableName,
-					validVesselsTableName,
-					archivedAtColumn,
-					validVesselsTableName,
-					lastIndexedAtColumn,
-					validVesselsTableName,
-					lastIndexedAtColumn,
-					currentTimeExpression,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetValidVessel",
-					Type: OneType,
+						validVesselsTableName,
+						idColumn,
+						validVesselsTableName,
+						validVesselsTableName,
+						archivedAtColumn,
+						validVesselsTableName,
+						lastIndexedAtColumn,
+						validVesselsTableName,
+						lastIndexedAtColumn,
+						currentTimeExpression,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetValidVessel",
+						Type: OneType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s
 FROM %s
 	LEFT JOIN %s ON %s.%s=%s.id
 WHERE %s.%s IS NULL
 	AND %s.%s IS NULL
 	AND %s.%s = sqlc.arg(%s);`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					validVesselsTableName,
-					validMeasurementUnitsTableName,
-					validVesselsTableName,
-					capacityUnitColumn,
-					validMeasurementUnitsTableName,
-					validVesselsTableName,
-					archivedAtColumn,
-					validMeasurementUnitsTableName,
-					archivedAtColumn,
-					validVesselsTableName,
-					idColumn,
-					idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetRandomValidVessel",
-					Type: OneType,
+						strings.Join(fullSelectColumns, ",\n\t"),
+						validVesselsTableName,
+						validMeasurementUnitsTableName,
+						validVesselsTableName,
+						capacityUnitColumn,
+						validMeasurementUnitsTableName,
+						validVesselsTableName,
+						archivedAtColumn,
+						validMeasurementUnitsTableName,
+						archivedAtColumn,
+						validVesselsTableName,
+						idColumn,
+						idColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetRandomValidVessel",
+						Type: OneType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s
 FROM %s
 	JOIN %s ON %s.%s=%s.%s
 WHERE %s.%s IS NULL
 	AND %s.%s IS NULL
 ORDER BY RANDOM() LIMIT 1;`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					validVesselsTableName,
-					validMeasurementUnitsTableName,
-					validVesselsTableName,
-					capacityUnitColumn,
-					validMeasurementUnitsTableName,
-					idColumn,
-					validVesselsTableName,
-					archivedAtColumn,
-					validMeasurementUnitsTableName,
-					archivedAtColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetValidVesselsWithIDs",
-					Type: ManyType,
+						strings.Join(fullSelectColumns, ",\n\t"),
+						validVesselsTableName,
+						validMeasurementUnitsTableName,
+						validVesselsTableName,
+						capacityUnitColumn,
+						validMeasurementUnitsTableName,
+						idColumn,
+						validVesselsTableName,
+						archivedAtColumn,
+						validMeasurementUnitsTableName,
+						archivedAtColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetValidVesselsWithIDs",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s
 FROM %s
 	JOIN %s ON %s.%s=%s.%s
 WHERE %s.%s IS NULL
 	AND %s.%s IS NULL
 	AND %s.%s = ANY(sqlc.arg(ids)::text[]);`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					validVesselsTableName,
-					validMeasurementUnitsTableName,
-					validVesselsTableName,
-					capacityUnitColumn,
-					validMeasurementUnitsTableName,
-					idColumn,
-					validVesselsTableName,
-					archivedAtColumn,
-					validMeasurementUnitsTableName,
-					archivedAtColumn,
-					validVesselsTableName,
-					idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "SearchForValidVessels",
-					Type: ManyType,
+						strings.Join(fullSelectColumns, ",\n\t"),
+						validVesselsTableName,
+						validMeasurementUnitsTableName,
+						validVesselsTableName,
+						capacityUnitColumn,
+						validMeasurementUnitsTableName,
+						idColumn,
+						validVesselsTableName,
+						archivedAtColumn,
+						validMeasurementUnitsTableName,
+						archivedAtColumn,
+						validVesselsTableName,
+						idColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "SearchForValidVessels",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s
@@ -263,61 +213,41 @@ WHERE %s.%s IS NULL
 	AND %s.%s %s
 	%s
 %s;`,
-					strings.Join(applyToEach(validVesselsColumns, func(i int, s string) string {
-						return fmt.Sprintf("%s.%s", validVesselsTableName, s)
-					}), ",\n\t"),
-					buildFilterCountSelect(validVesselsTableName, true, true, []string{}),
-					buildTotalCountSelect(validVesselsTableName, true, []string{}),
-					validVesselsTableName,
-					validVesselsTableName,
-					archivedAtColumn,
-					validVesselsTableName,
-					nameColumn,
-					buildILIKEForArgument("name_query"),
-					buildFilterConditions(
+						strings.Join(applyToEach(validVesselsColumns, func(i int, s string) string {
+							return fmt.Sprintf("%s.%s", validVesselsTableName, s)
+						}), ",\n\t"),
+						buildFilterCountSelect(validVesselsTableName, true, true, []string{}),
+						buildTotalCountSelect(validVesselsTableName, true, []string{}),
 						validVesselsTableName,
-						true,
-						true,
-					),
-					buildCursorLimitClause(validVesselsTableName),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "UpdateValidVessel",
-					Type: ExecRowsType,
+						validVesselsTableName,
+						archivedAtColumn,
+						validVesselsTableName,
+						nameColumn,
+						buildILIKEForArgument("name_query"),
+						buildFilterConditions(
+							validVesselsTableName,
+							true,
+							true,
+						),
+						buildCursorLimitClause(validVesselsTableName),
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
-	%s,
-	%s = %s
-WHERE %s IS NULL
-	AND %s = sqlc.arg(%s);`,
-					validVesselsTableName,
-					strings.Join(applyToEach(filterForUpdate(validVesselsColumns), func(i int, s string) string {
-						return fmt.Sprintf("%s = sqlc.arg(%s)", s, s)
-					}), ",\n\t"),
-					lastUpdatedAtColumn,
-					currentTimeExpression,
-					archivedAtColumn,
-					idColumn,
-					idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "UpdateValidVesselLastIndexedAt",
-					Type: ExecRowsType,
+				{
+					Annotation: QueryAnnotation{
+						Name: "UpdateValidVesselLastIndexedAt",
+						Type: ExecRowsType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET %s = %s WHERE %s = sqlc.arg(%s) AND %s IS NULL;`,
+						validVesselsTableName,
+						lastIndexedAtColumn,
+						currentTimeExpression,
+						idColumn,
+						idColumn,
+						archivedAtColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET %s = %s WHERE %s = sqlc.arg(%s) AND %s IS NULL;`,
-					validVesselsTableName,
-					lastIndexedAtColumn,
-					currentTimeExpression,
-					idColumn,
-					idColumn,
-					archivedAtColumn,
-				)),
 			},
-		}
+		)
 	default:
 		return nil
 	}

--- a/backend/cmd/tools/codegen/queries/sqlc.go
+++ b/backend/cmd/tools/codegen/queries/sqlc.go
@@ -1,34 +1,24 @@
 package main
 
 import (
-	"fmt"
-	"strings"
+	"github.com/primandproper/platform-go/v11/database/querygen"
 )
 
-type QueryType string
+// The sqlc input types live in platform's querygen, which emits the standard
+// queries as values of them. Aliasing rather than converting is what lets a
+// table's bespoke queries and its StandardCRUD call go into the same slice.
+type (
+	// QueryType is the sqlc annotation suffix declaring what a query returns.
+	QueryType = querygen.QueryType
+	// QueryAnnotation is the `-- name: X :one` line sqlc reads above a query.
+	QueryAnnotation = querygen.QueryAnnotation
+	// Query is one annotated statement.
+	Query = querygen.Query
+)
 
 const (
-	ExecType     QueryType = ":exec"
-	ExecRowsType QueryType = ":execrows"
-	ManyType     QueryType = ":many"
-	OneType      QueryType = ":one"
+	ExecType     = querygen.ExecType
+	ExecRowsType = querygen.ExecRowsType
+	ManyType     = querygen.ManyType
+	OneType      = querygen.OneType
 )
-
-type QueryAnnotation struct {
-	Name string
-	Type QueryType
-}
-
-type Query struct {
-	Content    string
-	Annotation QueryAnnotation
-}
-
-func (q *Query) Render() string {
-	content := q.Content
-	if !strings.HasSuffix(content, ";") {
-		content += ";"
-	}
-
-	return fmt.Sprintf("-- name: %s %s\n%s\n", q.Annotation.Name, q.Annotation.Type, content)
-}

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -384,7 +384,7 @@ require (
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
-	github.com/primandproper/platform-go/v11 v11.0.0
+	github.com/primandproper/platform-go/v11 v11.1.0
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/samber/lo v1.53.0 // indirect
 	github.com/segmentio/backo-go v1.1.0 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -793,8 +793,8 @@ github.com/prashantv/gostub v1.1.0 h1:BTyx3RfQjRHnUWaGF9oQos79AlQ5k8WNktv7VGvVH4
 github.com/prashantv/gostub v1.1.0/go.mod h1:A5zLQHz7ieHGG7is6LLXLz7I8+3LZzsrV0P1IAHhP5U=
 github.com/pressly/goose/v3 v3.27.3 h1:pIglVHjw99r4e/hDHHwbl9vfOsDMqUokfkXo6+n/RxA=
 github.com/pressly/goose/v3 v3.27.3/go.mod h1:Dag+xpV6o20HR2LFY1j0q6MDwc3f7vPUFDA77R+0yGY=
-github.com/primandproper/platform-go/v11 v11.0.0 h1:vCQ4FAMpF7ir530GxMIvxvW9+F7wPCeNAzbiMHhI+vA=
-github.com/primandproper/platform-go/v11 v11.0.0/go.mod h1:F+JIp4sO67E6l8cRY/mr5QNr6No5lOcTem124VdpEDE=
+github.com/primandproper/platform-go/v11 v11.1.0 h1:APWpVsKQ2qD5Q3pajkshOM1OkjIyF1jYRS0t8F6XCvc=
+github.com/primandproper/platform-go/v11 v11.1.0/go.mod h1:F+JIp4sO67E6l8cRY/mr5QNr6No5lOcTem124VdpEDE=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/pusher/pusher-http-go/v5 v5.1.1 h1:ZLUGdLA8yXMvByafIkS47nvuXOHrYmlh4bsQvuZnYVQ=
 github.com/pusher/pusher-http-go/v5 v5.1.1/go.mod h1:Ibji4SGoUDtOy7CVRhCiEpgy+n5Xv6hSL/QqYOhmWW8=

--- a/backend/internal/repositories/postgres/mealplanning/generated/valid_ingredient_groups.generated.sql_generated.go
+++ b/backend/internal/repositories/postgres/mealplanning/generated/valid_ingredient_groups.generated.sql_generated.go
@@ -14,7 +14,10 @@ import (
 )
 
 const archiveValidIngredientGroup = `-- name: ArchiveValidIngredientGroup :execrows
-UPDATE valid_ingredient_groups SET archived_at = NOW() WHERE archived_at IS NULL AND id = $1
+UPDATE valid_ingredient_groups SET
+	archived_at = NOW()
+WHERE archived_at IS NULL
+	AND id = $1
 `
 
 func (q *Queries) ArchiveValidIngredientGroup(ctx context.Context, db DBTX, id string) (int64, error) {
@@ -127,7 +130,7 @@ SELECT
 	valid_ingredient_groups.archived_at
 FROM valid_ingredient_groups
 WHERE valid_ingredient_groups.archived_at IS NULL
-AND valid_ingredient_groups.id = $1
+	AND valid_ingredient_groups.id = $1
 `
 
 type GetValidIngredientGroupRow struct {

--- a/backend/internal/repositories/postgres/mealplanning/generated/valid_ingredient_states.generated.sql_generated.go
+++ b/backend/internal/repositories/postgres/mealplanning/generated/valid_ingredient_states.generated.sql_generated.go
@@ -14,7 +14,10 @@ import (
 )
 
 const archiveValidIngredientState = `-- name: ArchiveValidIngredientState :execrows
-UPDATE valid_ingredient_states SET archived_at = NOW() WHERE archived_at IS NULL AND id = $1
+UPDATE valid_ingredient_states SET
+	archived_at = NOW()
+WHERE archived_at IS NULL
+	AND id = $1
 `
 
 func (q *Queries) ArchiveValidIngredientState(ctx context.Context, db DBTX, id string) (int64, error) {
@@ -99,7 +102,7 @@ SELECT
 	valid_ingredient_states.archived_at
 FROM valid_ingredient_states
 WHERE valid_ingredient_states.archived_at IS NULL
-AND valid_ingredient_states.id = $1
+	AND valid_ingredient_states.id = $1
 `
 
 type GetValidIngredientStateRow struct {

--- a/backend/internal/repositories/postgres/mealplanning/generated/valid_ingredients.generated.sql_generated.go
+++ b/backend/internal/repositories/postgres/mealplanning/generated/valid_ingredients.generated.sql_generated.go
@@ -14,7 +14,10 @@ import (
 )
 
 const archiveValidIngredient = `-- name: ArchiveValidIngredient :execrows
-UPDATE valid_ingredients SET archived_at = NOW() WHERE archived_at IS NULL AND id = $1
+UPDATE valid_ingredients SET
+	archived_at = NOW()
+WHERE archived_at IS NULL
+	AND id = $1
 `
 
 func (q *Queries) ArchiveValidIngredient(ctx context.Context, db DBTX, id string) (int64, error) {
@@ -374,7 +377,7 @@ SELECT
 	valid_ingredients.archived_at
 FROM valid_ingredients
 WHERE valid_ingredients.archived_at IS NULL
-AND valid_ingredients.id = $1
+	AND valid_ingredients.id = $1
 `
 
 type GetValidIngredientRow struct {

--- a/backend/internal/repositories/postgres/mealplanning/generated/valid_instruments.generated.sql_generated.go
+++ b/backend/internal/repositories/postgres/mealplanning/generated/valid_instruments.generated.sql_generated.go
@@ -14,7 +14,10 @@ import (
 )
 
 const archiveValidInstrument = `-- name: ArchiveValidInstrument :execrows
-UPDATE valid_instruments SET archived_at = NOW() WHERE archived_at IS NULL AND id = $1
+UPDATE valid_instruments SET
+	archived_at = NOW()
+WHERE archived_at IS NULL
+	AND id = $1
 `
 
 func (q *Queries) ArchiveValidInstrument(ctx context.Context, db DBTX, id string) (int64, error) {
@@ -166,7 +169,7 @@ SELECT
 	valid_instruments.archived_at
 FROM valid_instruments
 WHERE valid_instruments.archived_at IS NULL
-AND valid_instruments.id = $1
+	AND valid_instruments.id = $1
 `
 
 type GetValidInstrumentRow struct {

--- a/backend/internal/repositories/postgres/mealplanning/generated/valid_measurement_units.generated.sql_generated.go
+++ b/backend/internal/repositories/postgres/mealplanning/generated/valid_measurement_units.generated.sql_generated.go
@@ -14,7 +14,10 @@ import (
 )
 
 const archiveValidMeasurementUnit = `-- name: ArchiveValidMeasurementUnit :execrows
-UPDATE valid_measurement_units SET archived_at = NOW() WHERE archived_at IS NULL AND id = $1
+UPDATE valid_measurement_units SET
+	archived_at = NOW()
+WHERE archived_at IS NULL
+	AND id = $1
 `
 
 func (q *Queries) ArchiveValidMeasurementUnit(ctx context.Context, db DBTX, id string) (int64, error) {
@@ -310,7 +313,7 @@ SELECT
 	valid_measurement_units.archived_at
 FROM valid_measurement_units
 WHERE valid_measurement_units.archived_at IS NULL
-AND valid_measurement_units.id = $1
+	AND valid_measurement_units.id = $1
 `
 
 type GetValidMeasurementUnitRow struct {

--- a/backend/internal/repositories/postgres/mealplanning/generated/valid_preparations.generated.sql_generated.go
+++ b/backend/internal/repositories/postgres/mealplanning/generated/valid_preparations.generated.sql_generated.go
@@ -14,7 +14,10 @@ import (
 )
 
 const archiveValidPreparation = `-- name: ArchiveValidPreparation :execrows
-UPDATE valid_preparations SET archived_at = NOW() WHERE archived_at IS NULL AND id = $1
+UPDATE valid_preparations SET
+	archived_at = NOW()
+WHERE archived_at IS NULL
+	AND id = $1
 `
 
 func (q *Queries) ArchiveValidPreparation(ctx context.Context, db DBTX, id string) (int64, error) {

--- a/backend/internal/repositories/postgres/mealplanning/generated/valid_vessels.generated.sql_generated.go
+++ b/backend/internal/repositories/postgres/mealplanning/generated/valid_vessels.generated.sql_generated.go
@@ -14,7 +14,10 @@ import (
 )
 
 const archiveValidVessel = `-- name: ArchiveValidVessel :execrows
-UPDATE valid_vessels SET archived_at = NOW() WHERE archived_at IS NULL AND id = $1
+UPDATE valid_vessels SET
+	archived_at = NOW()
+WHERE archived_at IS NULL
+	AND id = $1
 `
 
 func (q *Queries) ArchiveValidVessel(ctx context.Context, db DBTX, id string) (int64, error) {

--- a/backend/internal/repositories/postgres/mealplanning/sqlc_queries/valid_ingredient_groups.generated.sql
+++ b/backend/internal/repositories/postgres/mealplanning/sqlc_queries/valid_ingredient_groups.generated.sql
@@ -1,13 +1,3 @@
--- name: ArchiveValidIngredientGroup :execrows
-UPDATE valid_ingredient_groups SET archived_at = NOW() WHERE archived_at IS NULL AND id = sqlc.arg(id);
-
--- name: ArchiveValidIngredientGroupMember :execrows
-UPDATE valid_ingredient_group_members SET
-	archived_at = NOW()
-WHERE archived_at IS NULL
-	AND id = sqlc.arg(id)
-	AND belongs_to_group = sqlc.arg(belongs_to_group);
-
 -- name: CreateValidIngredientGroup :exec
 INSERT INTO valid_ingredient_groups (
 	id,
@@ -21,6 +11,49 @@ INSERT INTO valid_ingredient_groups (
 	sqlc.arg(slug)
 );
 
+-- name: GetValidIngredientGroup :one
+SELECT
+	valid_ingredient_groups.id,
+	valid_ingredient_groups.name,
+	valid_ingredient_groups.description,
+	valid_ingredient_groups.slug,
+	valid_ingredient_groups.created_at,
+	valid_ingredient_groups.last_updated_at,
+	valid_ingredient_groups.archived_at
+FROM valid_ingredient_groups
+WHERE valid_ingredient_groups.archived_at IS NULL
+	AND valid_ingredient_groups.id = sqlc.arg(id);
+
+-- name: CheckValidIngredientGroupExistence :one
+SELECT EXISTS (
+	SELECT valid_ingredient_groups.id
+	FROM valid_ingredient_groups
+	WHERE valid_ingredient_groups.archived_at IS NULL
+		AND valid_ingredient_groups.id = sqlc.arg(id)
+);
+
+-- name: UpdateValidIngredientGroup :execrows
+UPDATE valid_ingredient_groups SET
+	name = sqlc.arg(name),
+	description = sqlc.arg(description),
+	slug = sqlc.arg(slug),
+	last_updated_at = NOW()
+WHERE archived_at IS NULL
+	AND id = sqlc.arg(id);
+
+-- name: ArchiveValidIngredientGroup :execrows
+UPDATE valid_ingredient_groups SET
+	archived_at = NOW()
+WHERE archived_at IS NULL
+	AND id = sqlc.arg(id);
+
+-- name: ArchiveValidIngredientGroupMember :execrows
+UPDATE valid_ingredient_group_members SET
+	archived_at = NOW()
+WHERE archived_at IS NULL
+	AND id = sqlc.arg(id)
+	AND belongs_to_group = sqlc.arg(belongs_to_group);
+
 -- name: CreateValidIngredientGroupMember :exec
 INSERT INTO valid_ingredient_group_members (
 	id,
@@ -30,14 +63,6 @@ INSERT INTO valid_ingredient_group_members (
 	sqlc.arg(id),
 	sqlc.arg(belongs_to_group),
 	sqlc.arg(valid_ingredient)
-);
-
--- name: CheckValidIngredientGroupExistence :one
-SELECT EXISTS (
-	SELECT valid_ingredient_groups.id
-	FROM valid_ingredient_groups
-	WHERE valid_ingredient_groups.archived_at IS NULL
-		AND valid_ingredient_groups.id = sqlc.arg(id)
 );
 
 -- name: GetValidIngredientGroups :many
@@ -143,19 +168,6 @@ WHERE
 	AND valid_ingredient_group_members.archived_at IS NULL
 	AND valid_ingredient_group_members.belongs_to_group = sqlc.arg(belongs_to_group);
 
--- name: GetValidIngredientGroup :one
-SELECT
-	valid_ingredient_groups.id,
-	valid_ingredient_groups.name,
-	valid_ingredient_groups.description,
-	valid_ingredient_groups.slug,
-	valid_ingredient_groups.created_at,
-	valid_ingredient_groups.last_updated_at,
-	valid_ingredient_groups.archived_at
-FROM valid_ingredient_groups
-WHERE valid_ingredient_groups.archived_at IS NULL
-AND valid_ingredient_groups.id = sqlc.arg(id);
-
 -- name: SearchForValidIngredientGroups :many
 SELECT
 	valid_ingredient_groups.id,
@@ -220,12 +232,3 @@ SELECT
 FROM valid_ingredient_groups
 WHERE valid_ingredient_groups.archived_at IS NULL
 	AND valid_ingredient_groups.id = ANY(sqlc.arg(ids)::text[]);
-
--- name: UpdateValidIngredientGroup :execrows
-UPDATE valid_ingredient_groups SET
-	name = sqlc.arg(name),
-	description = sqlc.arg(description),
-	slug = sqlc.arg(slug),
-	last_updated_at = NOW()
-WHERE archived_at IS NULL
-	AND id = sqlc.arg(id);

--- a/backend/internal/repositories/postgres/mealplanning/sqlc_queries/valid_ingredient_states.generated.sql
+++ b/backend/internal/repositories/postgres/mealplanning/sqlc_queries/valid_ingredient_states.generated.sql
@@ -1,6 +1,3 @@
--- name: ArchiveValidIngredientState :execrows
-UPDATE valid_ingredient_states SET archived_at = NOW() WHERE archived_at IS NULL AND id = sqlc.arg(id);
-
 -- name: CreateValidIngredientState :exec
 INSERT INTO valid_ingredient_states (
 	id,
@@ -20,6 +17,23 @@ INSERT INTO valid_ingredient_states (
 	sqlc.arg(attribute_type)
 );
 
+-- name: GetValidIngredientState :one
+SELECT
+	valid_ingredient_states.id,
+	valid_ingredient_states.name,
+	valid_ingredient_states.past_tense,
+	valid_ingredient_states.slug,
+	valid_ingredient_states.description,
+	valid_ingredient_states.icon_path,
+	valid_ingredient_states.attribute_type,
+	valid_ingredient_states.last_indexed_at,
+	valid_ingredient_states.created_at,
+	valid_ingredient_states.last_updated_at,
+	valid_ingredient_states.archived_at
+FROM valid_ingredient_states
+WHERE valid_ingredient_states.archived_at IS NULL
+	AND valid_ingredient_states.id = sqlc.arg(id);
+
 -- name: CheckValidIngredientStateExistence :one
 SELECT EXISTS (
 	SELECT valid_ingredient_states.id
@@ -27,6 +41,32 @@ SELECT EXISTS (
 	WHERE valid_ingredient_states.archived_at IS NULL
 		AND valid_ingredient_states.id = sqlc.arg(id)
 );
+
+-- name: UpdateValidIngredientState :execrows
+UPDATE valid_ingredient_states SET
+	name = sqlc.arg(name),
+	past_tense = sqlc.arg(past_tense),
+	slug = sqlc.arg(slug),
+	description = sqlc.arg(description),
+	icon_path = sqlc.arg(icon_path),
+	attribute_type = sqlc.arg(attribute_type),
+	last_updated_at = NOW()
+WHERE archived_at IS NULL
+	AND id = sqlc.arg(id);
+
+-- name: ArchiveValidIngredientState :execrows
+UPDATE valid_ingredient_states SET
+	archived_at = NOW()
+WHERE archived_at IS NULL
+	AND id = sqlc.arg(id);
+
+-- name: ScanValidIngredientStateIDsForReindex :many
+SELECT valid_ingredient_states.id
+FROM valid_ingredient_states
+WHERE valid_ingredient_states.archived_at IS NULL
+	AND valid_ingredient_states.id COLLATE "C" > sqlc.arg(cursor)
+ORDER BY valid_ingredient_states.id COLLATE "C"
+LIMIT COALESCE(sqlc.narg(result_limit), 50);
 
 -- name: GetValidIngredientStates :many
 SELECT
@@ -82,14 +122,6 @@ GROUP BY valid_ingredient_states.id
 ORDER BY valid_ingredient_states.id ASC
 LIMIT COALESCE(sqlc.narg(result_limit), 50);
 
--- name: ScanValidIngredientStateIDsForReindex :many
-SELECT valid_ingredient_states.id
-FROM valid_ingredient_states
-WHERE valid_ingredient_states.archived_at IS NULL
-	AND valid_ingredient_states.id COLLATE "C" > sqlc.arg(cursor)
-ORDER BY valid_ingredient_states.id COLLATE "C"
-LIMIT COALESCE(sqlc.narg(result_limit), 50);
-
 -- name: GetValidIngredientStatesNeedingIndexing :many
 SELECT valid_ingredient_states.id
 FROM valid_ingredient_states
@@ -98,23 +130,6 @@ WHERE valid_ingredient_states.archived_at IS NULL
 	valid_ingredient_states.last_indexed_at IS NULL
 	OR valid_ingredient_states.last_indexed_at < NOW() - '24 hours'::INTERVAL
 );
-
--- name: GetValidIngredientState :one
-SELECT
-	valid_ingredient_states.id,
-	valid_ingredient_states.name,
-	valid_ingredient_states.past_tense,
-	valid_ingredient_states.slug,
-	valid_ingredient_states.description,
-	valid_ingredient_states.icon_path,
-	valid_ingredient_states.attribute_type,
-	valid_ingredient_states.last_indexed_at,
-	valid_ingredient_states.created_at,
-	valid_ingredient_states.last_updated_at,
-	valid_ingredient_states.archived_at
-FROM valid_ingredient_states
-WHERE valid_ingredient_states.archived_at IS NULL
-AND valid_ingredient_states.id = sqlc.arg(id);
 
 -- name: GetValidIngredientStatesWithIDs :many
 SELECT
@@ -185,18 +200,6 @@ WHERE valid_ingredient_states.archived_at IS NULL
 	AND valid_ingredient_states.id > COALESCE(sqlc.narg(cursor), '')
 ORDER BY valid_ingredient_states.id ASC
 LIMIT COALESCE(sqlc.narg(result_limit), 50);
-
--- name: UpdateValidIngredientState :execrows
-UPDATE valid_ingredient_states SET
-	name = sqlc.arg(name),
-	past_tense = sqlc.arg(past_tense),
-	slug = sqlc.arg(slug),
-	description = sqlc.arg(description),
-	icon_path = sqlc.arg(icon_path),
-	attribute_type = sqlc.arg(attribute_type),
-	last_updated_at = NOW()
-WHERE archived_at IS NULL
-	AND id = sqlc.arg(id);
 
 -- name: UpdateValidIngredientStateLastIndexedAt :execrows
 UPDATE valid_ingredient_states SET last_indexed_at = NOW() WHERE id = sqlc.arg(id) AND archived_at IS NULL;

--- a/backend/internal/repositories/postgres/mealplanning/sqlc_queries/valid_ingredients.generated.sql
+++ b/backend/internal/repositories/postgres/mealplanning/sqlc_queries/valid_ingredients.generated.sql
@@ -1,6 +1,3 @@
--- name: ArchiveValidIngredient :execrows
-UPDATE valid_ingredients SET archived_at = NOW() WHERE archived_at IS NULL AND id = sqlc.arg(id);
-
 -- name: CreateValidIngredient :exec
 INSERT INTO valid_ingredients (
 	id,
@@ -76,6 +73,51 @@ INSERT INTO valid_ingredients (
 	sqlc.arg(is_heat)
 );
 
+-- name: GetValidIngredient :one
+SELECT
+	valid_ingredients.id,
+	valid_ingredients.name,
+	valid_ingredients.description,
+	valid_ingredients.warning,
+	valid_ingredients.contains_egg,
+	valid_ingredients.contains_dairy,
+	valid_ingredients.contains_peanut,
+	valid_ingredients.contains_tree_nut,
+	valid_ingredients.contains_soy,
+	valid_ingredients.contains_wheat,
+	valid_ingredients.contains_shellfish,
+	valid_ingredients.contains_sesame,
+	valid_ingredients.contains_fish,
+	valid_ingredients.contains_gluten,
+	valid_ingredients.animal_flesh,
+	valid_ingredients.is_liquid,
+	valid_ingredients.icon_path,
+	valid_ingredients.animal_derived,
+	valid_ingredients.plural_name,
+	valid_ingredients.restrict_to_preparations,
+	valid_ingredients.contaminates_equipment,
+	valid_ingredients.minimum_ideal_storage_temperature_in_celsius,
+	valid_ingredients.maximum_ideal_storage_temperature_in_celsius,
+	valid_ingredients.storage_instructions,
+	valid_ingredients.slug,
+	valid_ingredients.contains_alcohol,
+	valid_ingredients.shopping_suggestions,
+	valid_ingredients.is_starch,
+	valid_ingredients.is_protein,
+	valid_ingredients.is_grain,
+	valid_ingredients.is_fruit,
+	valid_ingredients.is_salt,
+	valid_ingredients.is_fat,
+	valid_ingredients.is_acid,
+	valid_ingredients.is_heat,
+	valid_ingredients.last_indexed_at,
+	valid_ingredients.created_at,
+	valid_ingredients.last_updated_at,
+	valid_ingredients.archived_at
+FROM valid_ingredients
+WHERE valid_ingredients.archived_at IS NULL
+	AND valid_ingredients.id = sqlc.arg(id);
+
 -- name: CheckValidIngredientExistence :one
 SELECT EXISTS (
 	SELECT valid_ingredients.id
@@ -83,6 +125,60 @@ SELECT EXISTS (
 	WHERE valid_ingredients.archived_at IS NULL
 		AND valid_ingredients.id = sqlc.arg(id)
 );
+
+-- name: UpdateValidIngredient :execrows
+UPDATE valid_ingredients SET
+	name = sqlc.arg(name),
+	description = sqlc.arg(description),
+	warning = sqlc.arg(warning),
+	contains_egg = sqlc.arg(contains_egg),
+	contains_dairy = sqlc.arg(contains_dairy),
+	contains_peanut = sqlc.arg(contains_peanut),
+	contains_tree_nut = sqlc.arg(contains_tree_nut),
+	contains_soy = sqlc.arg(contains_soy),
+	contains_wheat = sqlc.arg(contains_wheat),
+	contains_shellfish = sqlc.arg(contains_shellfish),
+	contains_sesame = sqlc.arg(contains_sesame),
+	contains_fish = sqlc.arg(contains_fish),
+	contains_gluten = sqlc.arg(contains_gluten),
+	animal_flesh = sqlc.arg(animal_flesh),
+	is_liquid = sqlc.arg(is_liquid),
+	icon_path = sqlc.arg(icon_path),
+	animal_derived = sqlc.arg(animal_derived),
+	plural_name = sqlc.arg(plural_name),
+	restrict_to_preparations = sqlc.arg(restrict_to_preparations),
+	contaminates_equipment = sqlc.arg(contaminates_equipment),
+	minimum_ideal_storage_temperature_in_celsius = sqlc.narg(minimum_ideal_storage_temperature_in_celsius),
+	maximum_ideal_storage_temperature_in_celsius = sqlc.narg(maximum_ideal_storage_temperature_in_celsius),
+	storage_instructions = sqlc.arg(storage_instructions),
+	slug = sqlc.arg(slug),
+	contains_alcohol = sqlc.arg(contains_alcohol),
+	shopping_suggestions = sqlc.arg(shopping_suggestions),
+	is_starch = sqlc.arg(is_starch),
+	is_protein = sqlc.arg(is_protein),
+	is_grain = sqlc.arg(is_grain),
+	is_fruit = sqlc.arg(is_fruit),
+	is_salt = sqlc.arg(is_salt),
+	is_fat = sqlc.arg(is_fat),
+	is_acid = sqlc.arg(is_acid),
+	is_heat = sqlc.arg(is_heat),
+	last_updated_at = NOW()
+WHERE archived_at IS NULL
+	AND id = sqlc.arg(id);
+
+-- name: ArchiveValidIngredient :execrows
+UPDATE valid_ingredients SET
+	archived_at = NOW()
+WHERE archived_at IS NULL
+	AND id = sqlc.arg(id);
+
+-- name: ScanValidIngredientIDsForReindex :many
+SELECT valid_ingredients.id
+FROM valid_ingredients
+WHERE valid_ingredients.archived_at IS NULL
+	AND valid_ingredients.id COLLATE "C" > sqlc.arg(cursor)
+ORDER BY valid_ingredients.id COLLATE "C"
+LIMIT COALESCE(sqlc.narg(result_limit), 50);
 
 -- name: GetValidIngredients :many
 SELECT
@@ -166,14 +262,6 @@ GROUP BY valid_ingredients.id
 ORDER BY valid_ingredients.id ASC
 LIMIT COALESCE(sqlc.narg(result_limit), 50);
 
--- name: ScanValidIngredientIDsForReindex :many
-SELECT valid_ingredients.id
-FROM valid_ingredients
-WHERE valid_ingredients.archived_at IS NULL
-	AND valid_ingredients.id COLLATE "C" > sqlc.arg(cursor)
-ORDER BY valid_ingredients.id COLLATE "C"
-LIMIT COALESCE(sqlc.narg(result_limit), 50);
-
 -- name: GetValidIngredientsNeedingIndexing :many
 SELECT valid_ingredients.id
 FROM valid_ingredients
@@ -182,51 +270,6 @@ WHERE valid_ingredients.archived_at IS NULL
 	valid_ingredients.last_indexed_at IS NULL
 	OR valid_ingredients.last_indexed_at < NOW() - '24 hours'::INTERVAL
 );
-
--- name: GetValidIngredient :one
-SELECT
-	valid_ingredients.id,
-	valid_ingredients.name,
-	valid_ingredients.description,
-	valid_ingredients.warning,
-	valid_ingredients.contains_egg,
-	valid_ingredients.contains_dairy,
-	valid_ingredients.contains_peanut,
-	valid_ingredients.contains_tree_nut,
-	valid_ingredients.contains_soy,
-	valid_ingredients.contains_wheat,
-	valid_ingredients.contains_shellfish,
-	valid_ingredients.contains_sesame,
-	valid_ingredients.contains_fish,
-	valid_ingredients.contains_gluten,
-	valid_ingredients.animal_flesh,
-	valid_ingredients.is_liquid,
-	valid_ingredients.icon_path,
-	valid_ingredients.animal_derived,
-	valid_ingredients.plural_name,
-	valid_ingredients.restrict_to_preparations,
-	valid_ingredients.contaminates_equipment,
-	valid_ingredients.minimum_ideal_storage_temperature_in_celsius,
-	valid_ingredients.maximum_ideal_storage_temperature_in_celsius,
-	valid_ingredients.storage_instructions,
-	valid_ingredients.slug,
-	valid_ingredients.contains_alcohol,
-	valid_ingredients.shopping_suggestions,
-	valid_ingredients.is_starch,
-	valid_ingredients.is_protein,
-	valid_ingredients.is_grain,
-	valid_ingredients.is_fruit,
-	valid_ingredients.is_salt,
-	valid_ingredients.is_fat,
-	valid_ingredients.is_acid,
-	valid_ingredients.is_heat,
-	valid_ingredients.last_indexed_at,
-	valid_ingredients.created_at,
-	valid_ingredients.last_updated_at,
-	valid_ingredients.archived_at
-FROM valid_ingredients
-WHERE valid_ingredients.archived_at IS NULL
-AND valid_ingredients.id = sqlc.arg(id);
 
 -- name: GetRandomValidIngredient :one
 SELECT
@@ -448,46 +491,6 @@ WHERE valid_ingredient_preparations.archived_at IS NULL
 	AND valid_preparations.archived_at IS NULL
 	AND valid_ingredient_preparations.valid_preparation_id = sqlc.arg(valid_preparation_id)
 	AND valid_ingredients.name ILIKE '%' || sqlc.arg(name_query)::text || '%';
-
--- name: UpdateValidIngredient :execrows
-UPDATE valid_ingredients SET
-	name = sqlc.arg(name),
-	description = sqlc.arg(description),
-	warning = sqlc.arg(warning),
-	contains_egg = sqlc.arg(contains_egg),
-	contains_dairy = sqlc.arg(contains_dairy),
-	contains_peanut = sqlc.arg(contains_peanut),
-	contains_tree_nut = sqlc.arg(contains_tree_nut),
-	contains_soy = sqlc.arg(contains_soy),
-	contains_wheat = sqlc.arg(contains_wheat),
-	contains_shellfish = sqlc.arg(contains_shellfish),
-	contains_sesame = sqlc.arg(contains_sesame),
-	contains_fish = sqlc.arg(contains_fish),
-	contains_gluten = sqlc.arg(contains_gluten),
-	animal_flesh = sqlc.arg(animal_flesh),
-	is_liquid = sqlc.arg(is_liquid),
-	icon_path = sqlc.arg(icon_path),
-	animal_derived = sqlc.arg(animal_derived),
-	plural_name = sqlc.arg(plural_name),
-	restrict_to_preparations = sqlc.arg(restrict_to_preparations),
-	contaminates_equipment = sqlc.arg(contaminates_equipment),
-	minimum_ideal_storage_temperature_in_celsius = sqlc.narg(minimum_ideal_storage_temperature_in_celsius),
-	maximum_ideal_storage_temperature_in_celsius = sqlc.narg(maximum_ideal_storage_temperature_in_celsius),
-	storage_instructions = sqlc.arg(storage_instructions),
-	slug = sqlc.arg(slug),
-	contains_alcohol = sqlc.arg(contains_alcohol),
-	shopping_suggestions = sqlc.arg(shopping_suggestions),
-	is_starch = sqlc.arg(is_starch),
-	is_protein = sqlc.arg(is_protein),
-	is_grain = sqlc.arg(is_grain),
-	is_fruit = sqlc.arg(is_fruit),
-	is_salt = sqlc.arg(is_salt),
-	is_fat = sqlc.arg(is_fat),
-	is_acid = sqlc.arg(is_acid),
-	is_heat = sqlc.arg(is_heat),
-	last_updated_at = NOW()
-WHERE archived_at IS NULL
-	AND id = sqlc.arg(id);
 
 -- name: UpdateValidIngredientLastIndexedAt :execrows
 UPDATE valid_ingredients SET last_indexed_at = NOW() WHERE id = sqlc.arg(id) AND archived_at IS NULL;

--- a/backend/internal/repositories/postgres/mealplanning/sqlc_queries/valid_instruments.generated.sql
+++ b/backend/internal/repositories/postgres/mealplanning/sqlc_queries/valid_instruments.generated.sql
@@ -1,6 +1,3 @@
--- name: ArchiveValidInstrument :execrows
-UPDATE valid_instruments SET archived_at = NOW() WHERE archived_at IS NULL AND id = sqlc.arg(id);
-
 -- name: CreateValidInstrument :exec
 INSERT INTO valid_instruments (
 	id,
@@ -24,6 +21,25 @@ INSERT INTO valid_instruments (
 	sqlc.arg(include_in_generated_instructions)
 );
 
+-- name: GetValidInstrument :one
+SELECT
+	valid_instruments.id,
+	valid_instruments.name,
+	valid_instruments.description,
+	valid_instruments.icon_path,
+	valid_instruments.plural_name,
+	valid_instruments.usable_for_storage,
+	valid_instruments.slug,
+	valid_instruments.display_in_summary_lists,
+	valid_instruments.include_in_generated_instructions,
+	valid_instruments.last_indexed_at,
+	valid_instruments.created_at,
+	valid_instruments.last_updated_at,
+	valid_instruments.archived_at
+FROM valid_instruments
+WHERE valid_instruments.archived_at IS NULL
+	AND valid_instruments.id = sqlc.arg(id);
+
 -- name: CheckValidInstrumentExistence :one
 SELECT EXISTS (
 	SELECT valid_instruments.id
@@ -31,6 +47,34 @@ SELECT EXISTS (
 	WHERE valid_instruments.archived_at IS NULL
 		AND valid_instruments.id = sqlc.arg(id)
 );
+
+-- name: UpdateValidInstrument :execrows
+UPDATE valid_instruments SET
+	name = sqlc.arg(name),
+	description = sqlc.arg(description),
+	icon_path = sqlc.arg(icon_path),
+	plural_name = sqlc.arg(plural_name),
+	usable_for_storage = sqlc.arg(usable_for_storage),
+	slug = sqlc.arg(slug),
+	display_in_summary_lists = sqlc.arg(display_in_summary_lists),
+	include_in_generated_instructions = sqlc.arg(include_in_generated_instructions),
+	last_updated_at = NOW()
+WHERE archived_at IS NULL
+	AND id = sqlc.arg(id);
+
+-- name: ArchiveValidInstrument :execrows
+UPDATE valid_instruments SET
+	archived_at = NOW()
+WHERE archived_at IS NULL
+	AND id = sqlc.arg(id);
+
+-- name: ScanValidInstrumentIDsForReindex :many
+SELECT valid_instruments.id
+FROM valid_instruments
+WHERE valid_instruments.archived_at IS NULL
+	AND valid_instruments.id COLLATE "C" > sqlc.arg(cursor)
+ORDER BY valid_instruments.id COLLATE "C"
+LIMIT COALESCE(sqlc.narg(result_limit), 50);
 
 -- name: GetValidInstruments :many
 SELECT
@@ -88,14 +132,6 @@ GROUP BY valid_instruments.id
 ORDER BY valid_instruments.id ASC
 LIMIT COALESCE(sqlc.narg(result_limit), 50);
 
--- name: ScanValidInstrumentIDsForReindex :many
-SELECT valid_instruments.id
-FROM valid_instruments
-WHERE valid_instruments.archived_at IS NULL
-	AND valid_instruments.id COLLATE "C" > sqlc.arg(cursor)
-ORDER BY valid_instruments.id COLLATE "C"
-LIMIT COALESCE(sqlc.narg(result_limit), 50);
-
 -- name: GetValidInstrumentsNeedingIndexing :many
 SELECT valid_instruments.id
 FROM valid_instruments
@@ -104,25 +140,6 @@ WHERE valid_instruments.archived_at IS NULL
 	valid_instruments.last_indexed_at IS NULL
 	OR valid_instruments.last_indexed_at < NOW() - '24 hours'::INTERVAL
 );
-
--- name: GetValidInstrument :one
-SELECT
-	valid_instruments.id,
-	valid_instruments.name,
-	valid_instruments.description,
-	valid_instruments.icon_path,
-	valid_instruments.plural_name,
-	valid_instruments.usable_for_storage,
-	valid_instruments.slug,
-	valid_instruments.display_in_summary_lists,
-	valid_instruments.include_in_generated_instructions,
-	valid_instruments.last_indexed_at,
-	valid_instruments.created_at,
-	valid_instruments.last_updated_at,
-	valid_instruments.archived_at
-FROM valid_instruments
-WHERE valid_instruments.archived_at IS NULL
-AND valid_instruments.id = sqlc.arg(id);
 
 -- name: GetRandomValidInstrument :one
 SELECT
@@ -274,20 +291,6 @@ WHERE valid_instruments.archived_at IS NULL
 	AND valid_instruments.id > COALESCE(sqlc.narg(cursor), '')
 ORDER BY valid_instruments.id ASC
 LIMIT COALESCE(sqlc.narg(result_limit), 50);
-
--- name: UpdateValidInstrument :execrows
-UPDATE valid_instruments SET
-	name = sqlc.arg(name),
-	description = sqlc.arg(description),
-	icon_path = sqlc.arg(icon_path),
-	plural_name = sqlc.arg(plural_name),
-	usable_for_storage = sqlc.arg(usable_for_storage),
-	slug = sqlc.arg(slug),
-	display_in_summary_lists = sqlc.arg(display_in_summary_lists),
-	include_in_generated_instructions = sqlc.arg(include_in_generated_instructions),
-	last_updated_at = NOW()
-WHERE archived_at IS NULL
-	AND id = sqlc.arg(id);
 
 -- name: UpdateValidInstrumentLastIndexedAt :execrows
 UPDATE valid_instruments SET last_indexed_at = NOW() WHERE id = sqlc.arg(id) AND archived_at IS NULL;

--- a/backend/internal/repositories/postgres/mealplanning/sqlc_queries/valid_measurement_units.generated.sql
+++ b/backend/internal/repositories/postgres/mealplanning/sqlc_queries/valid_measurement_units.generated.sql
@@ -1,6 +1,3 @@
--- name: ArchiveValidMeasurementUnit :execrows
-UPDATE valid_measurement_units SET archived_at = NOW() WHERE archived_at IS NULL AND id = sqlc.arg(id);
-
 -- name: CreateValidMeasurementUnit :exec
 INSERT INTO valid_measurement_units (
 	id,
@@ -26,6 +23,26 @@ INSERT INTO valid_measurement_units (
 	sqlc.arg(plural_name)
 );
 
+-- name: GetValidMeasurementUnit :one
+SELECT
+	valid_measurement_units.id,
+	valid_measurement_units.name,
+	valid_measurement_units.description,
+	valid_measurement_units.volumetric,
+	valid_measurement_units.icon_path,
+	valid_measurement_units.universal,
+	valid_measurement_units.metric,
+	valid_measurement_units.imperial,
+	valid_measurement_units.slug,
+	valid_measurement_units.plural_name,
+	valid_measurement_units.last_indexed_at,
+	valid_measurement_units.created_at,
+	valid_measurement_units.last_updated_at,
+	valid_measurement_units.archived_at
+FROM valid_measurement_units
+WHERE valid_measurement_units.archived_at IS NULL
+	AND valid_measurement_units.id = sqlc.arg(id);
+
 -- name: CheckValidMeasurementUnitExistence :one
 SELECT EXISTS (
 	SELECT valid_measurement_units.id
@@ -33,6 +50,35 @@ SELECT EXISTS (
 	WHERE valid_measurement_units.archived_at IS NULL
 		AND valid_measurement_units.id = sqlc.arg(id)
 );
+
+-- name: UpdateValidMeasurementUnit :execrows
+UPDATE valid_measurement_units SET
+	name = sqlc.arg(name),
+	description = sqlc.arg(description),
+	volumetric = sqlc.arg(volumetric),
+	icon_path = sqlc.arg(icon_path),
+	universal = sqlc.arg(universal),
+	metric = sqlc.arg(metric),
+	imperial = sqlc.arg(imperial),
+	slug = sqlc.arg(slug),
+	plural_name = sqlc.arg(plural_name),
+	last_updated_at = NOW()
+WHERE archived_at IS NULL
+	AND id = sqlc.arg(id);
+
+-- name: ArchiveValidMeasurementUnit :execrows
+UPDATE valid_measurement_units SET
+	archived_at = NOW()
+WHERE archived_at IS NULL
+	AND id = sqlc.arg(id);
+
+-- name: ScanValidMeasurementUnitIDsForReindex :many
+SELECT valid_measurement_units.id
+FROM valid_measurement_units
+WHERE valid_measurement_units.archived_at IS NULL
+	AND valid_measurement_units.id COLLATE "C" > sqlc.arg(cursor)
+ORDER BY valid_measurement_units.id COLLATE "C"
+LIMIT COALESCE(sqlc.narg(result_limit), 50);
 
 -- name: GetValidMeasurementUnits :many
 SELECT
@@ -149,14 +195,6 @@ GROUP BY valid_measurement_units.id
 ORDER BY valid_measurement_units.id ASC
 LIMIT COALESCE(sqlc.narg(result_limit), 50);
 
--- name: ScanValidMeasurementUnitIDsForReindex :many
-SELECT valid_measurement_units.id
-FROM valid_measurement_units
-WHERE valid_measurement_units.archived_at IS NULL
-	AND valid_measurement_units.id COLLATE "C" > sqlc.arg(cursor)
-ORDER BY valid_measurement_units.id COLLATE "C"
-LIMIT COALESCE(sqlc.narg(result_limit), 50);
-
 -- name: GetValidMeasurementUnitsNeedingIndexing :many
 SELECT valid_measurement_units.id
 FROM valid_measurement_units
@@ -165,26 +203,6 @@ WHERE valid_measurement_units.archived_at IS NULL
 	valid_measurement_units.last_indexed_at IS NULL
 	OR valid_measurement_units.last_indexed_at < NOW() - '24 hours'::INTERVAL
 );
-
--- name: GetValidMeasurementUnit :one
-SELECT
-	valid_measurement_units.id,
-	valid_measurement_units.name,
-	valid_measurement_units.description,
-	valid_measurement_units.volumetric,
-	valid_measurement_units.icon_path,
-	valid_measurement_units.universal,
-	valid_measurement_units.metric,
-	valid_measurement_units.imperial,
-	valid_measurement_units.slug,
-	valid_measurement_units.plural_name,
-	valid_measurement_units.last_indexed_at,
-	valid_measurement_units.created_at,
-	valid_measurement_units.last_updated_at,
-	valid_measurement_units.archived_at
-FROM valid_measurement_units
-WHERE valid_measurement_units.archived_at IS NULL
-AND valid_measurement_units.id = sqlc.arg(id);
 
 -- name: GetRandomValidMeasurementUnit :one
 SELECT
@@ -348,21 +366,6 @@ WHERE
 	AND valid_measurement_units.id > COALESCE(sqlc.narg(cursor), '')
 ORDER BY valid_measurement_units.id ASC
 LIMIT COALESCE(sqlc.narg(result_limit), 50);
-
--- name: UpdateValidMeasurementUnit :execrows
-UPDATE valid_measurement_units SET
-	name = sqlc.arg(name),
-	description = sqlc.arg(description),
-	volumetric = sqlc.arg(volumetric),
-	icon_path = sqlc.arg(icon_path),
-	universal = sqlc.arg(universal),
-	metric = sqlc.arg(metric),
-	imperial = sqlc.arg(imperial),
-	slug = sqlc.arg(slug),
-	plural_name = sqlc.arg(plural_name),
-	last_updated_at = NOW()
-WHERE archived_at IS NULL
-	AND id = sqlc.arg(id);
 
 -- name: UpdateValidMeasurementUnitLastIndexedAt :execrows
 UPDATE valid_measurement_units SET last_indexed_at = NOW() WHERE id = sqlc.arg(id) AND archived_at IS NULL;

--- a/backend/internal/repositories/postgres/mealplanning/sqlc_queries/valid_preparations.generated.sql
+++ b/backend/internal/repositories/postgres/mealplanning/sqlc_queries/valid_preparations.generated.sql
@@ -1,6 +1,3 @@
--- name: ArchiveValidPreparation :execrows
-UPDATE valid_preparations SET archived_at = NOW() WHERE archived_at IS NULL AND id = sqlc.arg(id);
-
 -- name: CreateValidPreparation :exec
 INSERT INTO valid_preparations (
 	id,
@@ -44,6 +41,35 @@ INSERT INTO valid_preparations (
 	sqlc.arg(maximum_vessel_count)
 );
 
+-- name: GetValidPreparation :one
+SELECT
+	valid_preparations.id,
+	valid_preparations.name,
+	valid_preparations.description,
+	valid_preparations.icon_path,
+	valid_preparations.yields_nothing,
+	valid_preparations.restrict_to_ingredients,
+	valid_preparations.past_tense,
+	valid_preparations.slug,
+	valid_preparations.minimum_ingredient_count,
+	valid_preparations.maximum_ingredient_count,
+	valid_preparations.minimum_instrument_count,
+	valid_preparations.maximum_instrument_count,
+	valid_preparations.temperature_required,
+	valid_preparations.time_estimate_required,
+	valid_preparations.condition_expression_required,
+	valid_preparations.consumes_vessel,
+	valid_preparations.only_for_vessels,
+	valid_preparations.minimum_vessel_count,
+	valid_preparations.maximum_vessel_count,
+	valid_preparations.last_indexed_at,
+	valid_preparations.created_at,
+	valid_preparations.last_updated_at,
+	valid_preparations.archived_at
+FROM valid_preparations
+WHERE valid_preparations.archived_at IS NULL
+	AND valid_preparations.id = sqlc.arg(id);
+
 -- name: CheckValidPreparationExistence :one
 SELECT EXISTS (
 	SELECT valid_preparations.id
@@ -51,6 +77,44 @@ SELECT EXISTS (
 	WHERE valid_preparations.archived_at IS NULL
 		AND valid_preparations.id = sqlc.arg(id)
 );
+
+-- name: UpdateValidPreparation :execrows
+UPDATE valid_preparations SET
+	name = sqlc.arg(name),
+	description = sqlc.arg(description),
+	icon_path = sqlc.arg(icon_path),
+	yields_nothing = sqlc.arg(yields_nothing),
+	restrict_to_ingredients = sqlc.arg(restrict_to_ingredients),
+	past_tense = sqlc.arg(past_tense),
+	slug = sqlc.arg(slug),
+	minimum_ingredient_count = sqlc.arg(minimum_ingredient_count),
+	maximum_ingredient_count = sqlc.arg(maximum_ingredient_count),
+	minimum_instrument_count = sqlc.arg(minimum_instrument_count),
+	maximum_instrument_count = sqlc.arg(maximum_instrument_count),
+	temperature_required = sqlc.arg(temperature_required),
+	time_estimate_required = sqlc.arg(time_estimate_required),
+	condition_expression_required = sqlc.arg(condition_expression_required),
+	consumes_vessel = sqlc.arg(consumes_vessel),
+	only_for_vessels = sqlc.arg(only_for_vessels),
+	minimum_vessel_count = sqlc.arg(minimum_vessel_count),
+	maximum_vessel_count = sqlc.arg(maximum_vessel_count),
+	last_updated_at = NOW()
+WHERE archived_at IS NULL
+	AND id = sqlc.arg(id);
+
+-- name: ArchiveValidPreparation :execrows
+UPDATE valid_preparations SET
+	archived_at = NOW()
+WHERE archived_at IS NULL
+	AND id = sqlc.arg(id);
+
+-- name: ScanValidPreparationIDsForReindex :many
+SELECT valid_preparations.id
+FROM valid_preparations
+WHERE valid_preparations.archived_at IS NULL
+	AND valid_preparations.id COLLATE "C" > sqlc.arg(cursor)
+ORDER BY valid_preparations.id COLLATE "C"
+LIMIT COALESCE(sqlc.narg(result_limit), 50);
 
 -- name: GetValidPreparations :many
 SELECT
@@ -118,14 +182,6 @@ GROUP BY valid_preparations.id
 ORDER BY valid_preparations.id ASC
 LIMIT COALESCE(sqlc.narg(result_limit), 50);
 
--- name: ScanValidPreparationIDsForReindex :many
-SELECT valid_preparations.id
-FROM valid_preparations
-WHERE valid_preparations.archived_at IS NULL
-	AND valid_preparations.id COLLATE "C" > sqlc.arg(cursor)
-ORDER BY valid_preparations.id COLLATE "C"
-LIMIT COALESCE(sqlc.narg(result_limit), 50);
-
 -- name: GetValidPreparationsNeedingIndexing :many
 SELECT valid_preparations.id
 FROM valid_preparations
@@ -134,35 +190,6 @@ WHERE valid_preparations.archived_at IS NULL
 	valid_preparations.last_indexed_at IS NULL
 	OR valid_preparations.last_indexed_at < NOW() - '24 hours'::INTERVAL
 );
-
--- name: GetValidPreparation :one
-SELECT
-	valid_preparations.id,
-	valid_preparations.name,
-	valid_preparations.description,
-	valid_preparations.icon_path,
-	valid_preparations.yields_nothing,
-	valid_preparations.restrict_to_ingredients,
-	valid_preparations.past_tense,
-	valid_preparations.slug,
-	valid_preparations.minimum_ingredient_count,
-	valid_preparations.maximum_ingredient_count,
-	valid_preparations.minimum_instrument_count,
-	valid_preparations.maximum_instrument_count,
-	valid_preparations.temperature_required,
-	valid_preparations.time_estimate_required,
-	valid_preparations.condition_expression_required,
-	valid_preparations.consumes_vessel,
-	valid_preparations.only_for_vessels,
-	valid_preparations.minimum_vessel_count,
-	valid_preparations.maximum_vessel_count,
-	valid_preparations.last_indexed_at,
-	valid_preparations.created_at,
-	valid_preparations.last_updated_at,
-	valid_preparations.archived_at
-FROM valid_preparations
-WHERE valid_preparations.archived_at IS NULL
-	AND valid_preparations.id = sqlc.arg(id);
 
 -- name: GetRandomValidPreparation :one
 SELECT
@@ -286,30 +313,6 @@ WHERE valid_preparations.archived_at IS NULL
 	AND valid_preparations.id > COALESCE(sqlc.narg(cursor), '')
 ORDER BY valid_preparations.id ASC
 LIMIT COALESCE(sqlc.narg(result_limit), 50);
-
--- name: UpdateValidPreparation :execrows
-UPDATE valid_preparations SET
-	name = sqlc.arg(name),
-	description = sqlc.arg(description),
-	icon_path = sqlc.arg(icon_path),
-	yields_nothing = sqlc.arg(yields_nothing),
-	restrict_to_ingredients = sqlc.arg(restrict_to_ingredients),
-	past_tense = sqlc.arg(past_tense),
-	slug = sqlc.arg(slug),
-	minimum_ingredient_count = sqlc.arg(minimum_ingredient_count),
-	maximum_ingredient_count = sqlc.arg(maximum_ingredient_count),
-	minimum_instrument_count = sqlc.arg(minimum_instrument_count),
-	maximum_instrument_count = sqlc.arg(maximum_instrument_count),
-	temperature_required = sqlc.arg(temperature_required),
-	time_estimate_required = sqlc.arg(time_estimate_required),
-	condition_expression_required = sqlc.arg(condition_expression_required),
-	consumes_vessel = sqlc.arg(consumes_vessel),
-	only_for_vessels = sqlc.arg(only_for_vessels),
-	minimum_vessel_count = sqlc.arg(minimum_vessel_count),
-	maximum_vessel_count = sqlc.arg(maximum_vessel_count),
-	last_updated_at = NOW()
-WHERE archived_at IS NULL
-	AND id = sqlc.arg(id);
 
 -- name: UpdateValidPreparationLastIndexedAt :execrows
 UPDATE valid_preparations SET last_indexed_at = NOW() WHERE id = sqlc.arg(id) AND archived_at IS NULL;

--- a/backend/internal/repositories/postgres/mealplanning/sqlc_queries/valid_vessels.generated.sql
+++ b/backend/internal/repositories/postgres/mealplanning/sqlc_queries/valid_vessels.generated.sql
@@ -1,6 +1,3 @@
--- name: ArchiveValidVessel :execrows
-UPDATE valid_vessels SET archived_at = NOW() WHERE archived_at IS NULL AND id = sqlc.arg(id);
-
 -- name: CreateValidVessel :exec
 INSERT INTO valid_vessels (
 	id,
@@ -43,6 +40,40 @@ SELECT EXISTS (
 	WHERE valid_vessels.archived_at IS NULL
 		AND valid_vessels.id = sqlc.arg(id)
 );
+
+-- name: UpdateValidVessel :execrows
+UPDATE valid_vessels SET
+	name = sqlc.arg(name),
+	plural_name = sqlc.arg(plural_name),
+	description = sqlc.arg(description),
+	icon_path = sqlc.arg(icon_path),
+	usable_for_storage = sqlc.arg(usable_for_storage),
+	slug = sqlc.arg(slug),
+	display_in_summary_lists = sqlc.arg(display_in_summary_lists),
+	include_in_generated_instructions = sqlc.arg(include_in_generated_instructions),
+	capacity = sqlc.arg(capacity),
+	capacity_unit = sqlc.arg(capacity_unit),
+	width_in_millimeters = sqlc.arg(width_in_millimeters),
+	length_in_millimeters = sqlc.arg(length_in_millimeters),
+	height_in_millimeters = sqlc.arg(height_in_millimeters),
+	shape = sqlc.arg(shape),
+	last_updated_at = NOW()
+WHERE archived_at IS NULL
+	AND id = sqlc.arg(id);
+
+-- name: ArchiveValidVessel :execrows
+UPDATE valid_vessels SET
+	archived_at = NOW()
+WHERE archived_at IS NULL
+	AND id = sqlc.arg(id);
+
+-- name: ScanValidVesselIDsForReindex :many
+SELECT valid_vessels.id
+FROM valid_vessels
+WHERE valid_vessels.archived_at IS NULL
+	AND valid_vessels.id COLLATE "C" > sqlc.arg(cursor)
+ORDER BY valid_vessels.id COLLATE "C"
+LIMIT COALESCE(sqlc.narg(result_limit), 50);
 
 -- name: GetValidVessels :many
 SELECT
@@ -104,14 +135,6 @@ WHERE
 	AND valid_vessels.id > COALESCE(sqlc.narg(cursor), '')
 GROUP BY valid_vessels.id
 ORDER BY valid_vessels.id ASC
-LIMIT COALESCE(sqlc.narg(result_limit), 50);
-
--- name: ScanValidVesselIDsForReindex :many
-SELECT valid_vessels.id
-FROM valid_vessels
-WHERE valid_vessels.archived_at IS NULL
-	AND valid_vessels.id COLLATE "C" > sqlc.arg(cursor)
-ORDER BY valid_vessels.id COLLATE "C"
 LIMIT COALESCE(sqlc.narg(result_limit), 50);
 
 -- name: GetValidVesselIDsNeedingIndexing :many
@@ -303,26 +326,6 @@ WHERE valid_vessels.archived_at IS NULL
 	AND valid_vessels.id > COALESCE(sqlc.narg(cursor), '')
 ORDER BY valid_vessels.id ASC
 LIMIT COALESCE(sqlc.narg(result_limit), 50);
-
--- name: UpdateValidVessel :execrows
-UPDATE valid_vessels SET
-	name = sqlc.arg(name),
-	plural_name = sqlc.arg(plural_name),
-	description = sqlc.arg(description),
-	icon_path = sqlc.arg(icon_path),
-	usable_for_storage = sqlc.arg(usable_for_storage),
-	slug = sqlc.arg(slug),
-	display_in_summary_lists = sqlc.arg(display_in_summary_lists),
-	include_in_generated_instructions = sqlc.arg(include_in_generated_instructions),
-	capacity = sqlc.arg(capacity),
-	capacity_unit = sqlc.arg(capacity_unit),
-	width_in_millimeters = sqlc.arg(width_in_millimeters),
-	length_in_millimeters = sqlc.arg(length_in_millimeters),
-	height_in_millimeters = sqlc.arg(height_in_millimeters),
-	shape = sqlc.arg(shape),
-	last_updated_at = NOW()
-WHERE archived_at IS NULL
-	AND id = sqlc.arg(id);
 
 -- name: UpdateValidVesselLastIndexedAt :execrows
 UPDATE valid_vessels SET last_indexed_at = NOW() WHERE id = sqlc.arg(id) AND archived_at IS NULL;


### PR DESCRIPTION
First slice of #1292. No behavior change.

## Why

platform-go's `database/querygen` emits the seven queries a table following the module's row conventions needs, and **derives which ones appear from the column list rather than taking configuration**: `created_at` present means the `created_after`/`created_before` window, `archived_at` means soft delete, `last_indexed_at` means the reindex scan `search/sync` reads through. A table without `archived_at` cannot end up with an `Archive`.

We are the consumer that wrote all of that by hand, once per table, 70 times — `cmd/tools/codegen/queries` is 76 files and 16,613 lines, and `helpers.go` is our copy of the convention logic.

## Scope

Seven tables: the `valid_*` leaf enumerations, whose JOINs are all confined to bespoke search queries. The remaining `valid_*` tables are bridge tables carrying 10–22 JOINs each and come in a later PR.

**This deliberately omits the list query and leaves the hand-written one in place.** The list is where `include_archived` lives, and ours has never worked — each table's generator opens the `WHERE` with `archived_at IS NULL` itself, so the toggle is masked, and `buildFilterConditions` then emits `NOT COALESCE(...)` which inverts it on top. The flag is plumbed end to end (gRPC converter → `filter.IncludeArchived` → ~40 repository call sites) and does nothing. Turning it on changes what every list endpoint returns and what `total_count` reports, so it lands as its own PR across all tables rather than domain by domain, where the flag would work on some endpoints and not others for weeks.

That is the axis split this migration follows: mechanical adoption per domain first, the one behavior change once, across everything.

## What that leaves here

| | |
|---|---|
| Queries byte-identical | 72 |
| Differing only in whitespace | 12 |
| **Semantic changes** | **0** |
| Added / removed | none |

The twelve are an `ARCHIVE` reformatted from one line onto four and a `Get` indented one tab.

Verified by parsing both `.generated.sql` files into name→content maps and comparing per query, not by line diff — the file order changes, but sqlc sorts by query name, so the generated Go does not move. `sqlc generate` output is identical modulo those string literals: **no signature, struct, or field-type change anywhere**. `sqlc compile`, `sqlc vet`, and `codegen/queries --check` all pass, and the postgres mealplanning suite is green across repeated shuffled runs.

624 net lines of hand-rolled SQL assembly removed for these seven tables.

## Two implicit facts now declared

- `valid_ingredients` bound two storage-temperature columns through `sqlc.narg` via a `switch` on column names inside its create and update builders. That is `WithNullable` now.
- `valid_vessels`' `GetValidVessel` joins `valid_measurement_units` for the capacity unit, so it is not the standard single-row read. It is omitted rather than quietly replaced.

Both options are new in platform-go **v11.1.0** (primandproper/platform-go#268), added because this migration needed them — hence the dependency bump in the first commit.

`cmd/tools/codegen/queries/sqlc.go` was a byte-for-byte duplicate of querygen's `Query`, `QueryAnnotation`, `QueryType` and `Render`, and `main.go`'s file assembly duplicated `RenderFile`. Aliases now, which is what lets a table's bespoke queries and its `StandardCRUD` call go into one slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017iSaVKFpZdnMSt7W174AgB