### PR TITLE
build(proto): format protos with protolint instead of buf

### DIFF
--- a/.github/workflows/proto_formatting.yaml
+++ b/.github/workflows/proto_formatting.yaml
@@ -1,0 +1,24 @@
+---
+on:
+  pull_request:
+    paths:
+      - proto/**/*.proto
+      - .protolint.yaml
+      - Makefile
+      - .github/workflows/proto_formatting.yaml
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+name: proto formatting
+jobs:
+  protolint:
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: check formatting
+        run: make check_proto_format

--- a/.protolint.yaml
+++ b/.protolint.yaml
@@ -1,0 +1,29 @@
+# Configuration for protolint (github.com/yoheimuta/protolint), which formats the
+# .proto files under proto/ via `make format_proto`. Generation stays on protoc.
+#
+# Every rule removed below is removed because enforcing it would change the
+# *content* of the protos, and therefore the generated Go, Swift, and TypeScript
+# that the rest of the repo compiles against. The formatter is here to normalize
+# whitespace, not to rename anything.
+lint:
+  rules:
+    remove:
+      # protolint wraps at 80 columns and its fixer cannot rewrap; every one of the
+      # ~420 findings is a doc comment or an rpc signature that would have to be
+      # rewritten by hand, and comment text is copied verbatim into the generated
+      # doc comments. buf format had no line-length opinion either.
+      - MAX_LINE_LENGTH
+      # Wants `VESSEL_SHAPE_*` renamed to `VALID_VESSEL_SHAPE_*` to match the
+      # enclosing enum. The enum value names are wire-visible and appear in the
+      # generated Go/Swift/TS identifiers; renaming them is a breaking change, not
+      # a formatting one.
+      - ENUM_FIELD_NAMES_PREFIX
+      # Wants every zero value suffixed `_UNSPECIFIED`. These enums deliberately
+      # give element 0 a real meaning (MEAL_PLAN_STATUS_AWAITING_VOTES, and so on)
+      # to mirror the database enums they are generated against, so adding an
+      # UNSPECIFIED member would renumber every value.
+      - ENUM_FIELD_NAMES_ZERO_VALUE_END_WITH
+      # Wants `repeated ... created` to become `createds` and `enumeration` to
+      # become `enumerations`. The first is not English, and both are field names
+      # that map onto existing Go struct fields and JSON keys.
+      - REPEATED_FIELD_NAMES_PLURALIZED

--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,8 @@ CONTAINER_RUNNER      := docker
 RUN_CONTAINER         := $(CONTAINER_RUNNER) run --rm --volume $(PWD):$(PWD) --workdir=$(PWD)
 RUN_CONTAINER_AS_USER := $(CONTAINER_RUNNER) run --rm --volume $(PWD):$(PWD) --workdir=$(PWD) --user $(MYSELF):$(MY_GROUP)
 
-PROTOBUF_FORMAT       := bufbuild/buf:1.70.0
-FORMAT_PROTOBUFS      := $(RUN_CONTAINER) $(PROTOBUF_FORMAT)
+PROTOBUF_FORMAT       := yoheimuta/protolint:0.57.0
+FORMAT_PROTOBUFS      := $(RUN_CONTAINER_AS_USER) $(PROTOBUF_FORMAT)
 ARTIFACTS_DIR         := artifacts
 
 # Exclude monolithic proto/X/X.proto files (they're duplicates of the split files)
@@ -181,7 +181,13 @@ full_prod_deploy: deploy_prod_infra deploy_prod_software verify_prod
 
 .PHONY: format_proto
 format_proto:
-	$(FORMAT_PROTOBUFS) format proto --write
+	$(FORMAT_PROTOBUFS) lint -fix proto/
+
+# check_proto_format is format_proto without the fixer: it reports what would change
+# and exits non-zero, which is what CI runs.
+.PHONY: check_proto_format
+check_proto_format:
+	$(FORMAT_PROTOBUFS) lint proto/
 
 .PHONY: proto_golang
 proto_golang: ensure_protoc_installed ensure_protoc-gen-go_installed ensure_protoc-gen-go-grpc_installed

--- a/README.md
+++ b/README.md
@@ -121,7 +121,8 @@ Deploy pipeline (see [docs/deployment.md](docs/deployment.md)):
 ## Protobuf and code generation
 
 - **Source:** `proto/` — per-domain `.proto` files (e.g. `mealplanning/`, `auth/`, `identity/`).
-- **Generate:** `make proto` (format with buf, then `proto_golang` and `proto_swift`). For the frontend API client: `make proto_typescript` (outputs to `frontend/packages/api-client/src`).
+- **Format:** `make format_proto` runs `protolint lint -fix proto/` out of a pinned container. `make check_proto_format` is the same thing without the fixer, and is what the `proto formatting` workflow runs on pull requests. The rules the repo turns off, and why, are in [.protolint.yaml](.protolint.yaml).
+- **Generate:** `make proto` (format, then `proto_golang` and `proto_swift`). For the frontend API client: `make proto_typescript` (outputs to `frontend/packages/api-client/src`).
 - **Output:** Go → `backend/internal/grpc`, Swift → `ios/ios/Generated`, TypeScript → `frontend/packages/api-client/src`.
 
 Requires `protoc`, `protoc-gen-go`, `protoc-gen-go-grpc`, and for Swift `protoc-gen-swift` and `protoc-gen-grpc-swift`. The root Makefile has `ensure_*` targets; see `make proto` and [Makefile](Makefile) around the `PROTO_*` variables.

--- a/proto/auth/auth_service_types.proto
+++ b/proto/auth/auth_service_types.proto
@@ -42,14 +42,16 @@ message ExchangeTokenResponse {
   google.protobuf.Timestamp expires_utc = 6;
 }
 
-message GetActiveAccountRequest {}
+message GetActiveAccountRequest {
+}
 
 message GetActiveAccountResponse {
   common.ResponseDetails response_details = 1;
   identity.Account result = 2;
 }
 
-message GetAuthStatusRequest {}
+message GetAuthStatusRequest {
+}
 
 message GetAuthStatusResponse {
   common.ResponseDetails response_details = 1;
@@ -215,7 +217,8 @@ message EvaluateStringFeatureFlagResponse {
   string value = 2;
 }
 
-message BeginPasskeyRegistrationRequest {}
+message BeginPasskeyRegistrationRequest {
+}
 
 message BeginPasskeyRegistrationResponse {
   common.ResponseDetails response_details = 1;
@@ -248,14 +251,16 @@ message FinishPasskeyAuthenticationRequest {
   string username = 3;
 }
 
-message GetSelfRequest {}
+message GetSelfRequest {
+}
 
 message GetSelfResponse {
   common.ResponseDetails response_details = 1;
   identity.User result = 2;
 }
 
-message ListPasskeysRequest {}
+message ListPasskeysRequest {
+}
 
 message ListPasskeysResponse {
   common.ResponseDetails response_details = 1;
@@ -295,13 +300,15 @@ message RevokeSessionResponse {
   common.ResponseDetails response_details = 1;
 }
 
-message RevokeAllOtherSessionsRequest {}
+message RevokeAllOtherSessionsRequest {
+}
 
 message RevokeAllOtherSessionsResponse {
   common.ResponseDetails response_details = 1;
 }
 
-message RevokeCurrentSessionRequest {}
+message RevokeCurrentSessionRequest {
+}
 
 message RevokeCurrentSessionResponse {
   common.ResponseDetails response_details = 1;

--- a/proto/dataprivacy/dataprivacy_service_types.proto
+++ b/proto/dataprivacy/dataprivacy_service_types.proto
@@ -8,7 +8,8 @@ import "filtering.proto";
 
 option go_package = "github.com/primandproper/dinnerdonebetter/backend/internal/grpc/generated/services/dataprivacy";
 
-message AggregateUserDataReportRequest {}
+message AggregateUserDataReportRequest {
+}
 
 message AggregateUserDataReportResponse {
   common.ResponseDetails response_details = 1;
@@ -19,7 +20,8 @@ message AggregateUserDataReportResponse {
   DataPrivacyRequest request = 2;
 }
 
-message DestroyAllUserDataRequest {}
+message DestroyAllUserDataRequest {
+}
 
 message DestroyAllUserDataResponse {
   common.ResponseDetails response_details = 1;

--- a/proto/mealplanning/mealplanning_service_types.proto
+++ b/proto/mealplanning/mealplanning_service_types.proto
@@ -601,28 +601,32 @@ message CreateValidVesselResponse {
   ValidVessel result = 2;
 }
 
-message GetRandomValidIngredientRequest {}
+message GetRandomValidIngredientRequest {
+}
 
 message GetRandomValidIngredientResponse {
   common.ResponseDetails response_details = 1;
   ValidIngredient result = 2;
 }
 
-message GetRandomValidInstrumentRequest {}
+message GetRandomValidInstrumentRequest {
+}
 
 message GetRandomValidInstrumentResponse {
   common.ResponseDetails response_details = 1;
   ValidInstrument result = 2;
 }
 
-message GetRandomValidPreparationRequest {}
+message GetRandomValidPreparationRequest {
+}
 
 message GetRandomValidPreparationResponse {
   common.ResponseDetails response_details = 1;
   ValidPreparation result = 2;
 }
 
-message GetRandomValidVesselRequest {}
+message GetRandomValidVesselRequest {
+}
 
 message GetRandomValidVesselResponse {
   common.ResponseDetails response_details = 1;
@@ -919,7 +923,8 @@ message GetValidMeasurementUnitConversionsForIngredientsResponse {
   repeated ValidMeasurementUnitConversion results = 2;
 }
 
-message GetMeasurementUnitConversionMismatchesRequest {}
+message GetMeasurementUnitConversionMismatchesRequest {
+}
 
 message GetMeasurementUnitConversionMismatchesResponse {
   common.ResponseDetails response_details = 1;
@@ -2888,20 +2893,23 @@ message ArchiveRecipeListItemResponse {
   common.ResponseDetails response_details = 1;
 }
 
-message RunFinalizeMealPlanWorkerRequest {}
+message RunFinalizeMealPlanWorkerRequest {
+}
 
 message RunFinalizeMealPlanWorkerResponse {
   common.ResponseDetails response_details = 1;
   uint32 finalized = 2;
 }
 
-message RunMealPlanGroceryListInitializerWorkerRequest {}
+message RunMealPlanGroceryListInitializerWorkerRequest {
+}
 
 message RunMealPlanGroceryListInitializerWorkerResponse {
   common.ResponseDetails response_details = 1;
 }
 
-message RunMealPlanTaskCreatorWorkerRequest {}
+message RunMealPlanTaskCreatorWorkerRequest {
+}
 
 message RunMealPlanTaskCreatorWorkerResponse {
   common.ResponseDetails response_details = 1;

--- a/proto/webhooks/webhooks_service_types.proto
+++ b/proto/webhooks/webhooks_service_types.proto
@@ -116,7 +116,8 @@ message RotateWebhookSecretResponse {
   string secret = 2;
 }
 
-message GetWebhookEventTypesRequest {}
+message GetWebhookEventTypesRequest {
+}
 
 message GetWebhookEventTypesResponse {
   common.ResponseDetails response_details = 1;


### PR DESCRIPTION
Closes #1298.

## What changed

`make format_proto` ran `buf format proto --write` out of a pinned `bufbuild/buf` container. That was the only thing buf was used for in this repo — no `buf.yaml`, no `buf.gen.yaml`, no BSR dependency, and generation already on plain `protoc`. It now runs `protolint lint -fix proto/` out of a pinned `yoheimuta/protolint:0.57.0` container instead, so the day a `.proto` needs to be shared across repos (primandproper/platform-go#225 is deciding this for `filtering.QueryFilter`), the question doesn't arrive bundled with a tool whose answer is a hosted registry.

`FORMAT_PROTOBUFS` also moves from `RUN_CONTAINER` to `RUN_CONTAINER_AS_USER`, since the fixer writes into the mounted tree.

## The part that wasn't a drop-in

`buf format` has no opinions about content; protolint is a linter whose `-fix` happens to reformat. Running it over the 48 files produced **458 findings**. Split into accept and disable:

| Rule | Count | Disposition |
| --- | ---: | --- |
| `MAX_LINE_LENGTH` | 418 | disabled |
| `INDENT` | 18 | **accepted** |
| `ENUM_FIELD_NAMES_ZERO_VALUE_END_WITH` | 10 | disabled |
| `ENUM_FIELD_NAMES_PREFIX` | 8 | disabled |
| `REPEATED_FIELD_NAMES_PLURALIZED` | 4 | disabled |

The disables live in a new `.protolint.yaml`, one comment per rule saying why. Every one of them is disabled for the same underlying reason: enforcing it would change the *content* of the protos, and therefore the generated code.

- **`MAX_LINE_LENGTH`** — protolint wraps at 80 and its fixer cannot rewrap. All 418 are doc comments or `rpc` signatures, and comment text is copied verbatim into the generated Go/Swift/TS doc comments. `buf format` had no line-length opinion either, so this is not a regression in strictness relative to what was there.
- **`ENUM_FIELD_NAMES_PREFIX`** — wants `VESSEL_SHAPE_*` renamed to `VALID_VESSEL_SHAPE_*`. Enum value names are wire-visible and become generated identifiers.
- **`ENUM_FIELD_NAMES_ZERO_VALUE_END_WITH`** — wants every zero value suffixed `_UNSPECIFIED`. These enums mirror Postgres enum types where element 0 is a real default (`meal_plan_status DEFAULT 'awaiting_votes'`, `00021_mealplanning.sql:656`), so satisfying it means renumbering.
- **`REPEATED_FIELD_NAMES_PLURALIZED`** — wants `repeated ... created` to become `createds`, and `enumeration` to become `enumerations`.

`INDENT` is accepted, and it accounts for the entire diff to `proto/`: 18 empty message bodies go from `message X {}` to `message X {\n}`. Pure whitespace.

## Generated output is byte-identical

Generated from the pre-change protos and the post-change protos into separate trees and diffed:

- **Go + Swift** — 160 files via `protoc-gen-go`, `protoc-gen-go-grpc`, `protoc-gen-swift`, `protoc-gen-grpc-swift-2` with the flags from `proto_golang`/`proto_swift` → identical
- **TypeScript** — 50 files via `ts-proto` 2.11.5 with the flags from `proto_typescript` → identical

`protolint lint proto/` on the result exits 0, and a second `-fix` pass is a no-op, so the format is a fixed point.

## Enforcement

Nothing checked proto formatting before. Adds `make check_proto_format` (the same container invocation without `-fix`, which exits non-zero on any finding) and a `proto formatting` workflow that runs it on pull requests touching `proto/`, `.protolint.yaml`, the `Makefile`, or the workflow itself.

Verified the gate actually bites: reverting one message body to `{}` makes `make check_proto_format` exit non-zero, and `make format_proto` restores it to passing.

## Out of scope, and left alone

Generation stays on `protoc`. No proto contents changed beyond what the accepted rule required. The two unrelated files `markdownlint --fix` wanted to touch (`backend/docs/audit.md`, `docs/data-privacy.md`) were reverted — that drift predates this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)