### PR TITLE
feat(indexing): stamp last_indexed_at from the search sync path

### DIFF
--- a/backend/internal/build/functions/data_change_message_handler/build_test.go
+++ b/backend/internal/build/functions/data_change_message_handler/build_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	"github.com/primandproper/dinnerdonebetter/backend/internal/config"
+	identityindexing "github.com/primandproper/dinnerdonebetter/backend/internal/services/identity/indexing"
+	mealplanningindexing "github.com/primandproper/dinnerdonebetter/backend/internal/services/mealplanning/indexing"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -20,4 +22,34 @@ func TestBuildInjector_RegistersAllProviders(t *testing.T) {
 	services := i.ListProvidedServices()
 	assert.NotEmpty(t, services, "expected providers to be registered")
 	assert.Greater(t, len(services), 10, "expected many providers to be registered")
+}
+
+// TestBuildInjector_RegistersAStamperPerIndex guards the one thing about the search sync
+// wiring that a compiler cannot: the Stamper each Syncer writes last_indexed_at through is
+// registered under its index's name, and this process resolves it by that name in order to
+// close it. A name registered in one place and looked up in another is a runtime panic during
+// startup, which is exactly the failure a build test is for.
+func TestBuildInjector_RegistersAStamperPerIndex(t *testing.T) {
+	t.Parallel()
+
+	i := BuildInjector(context.Background(), &config.AsyncMessageHandlerConfig{})
+
+	registered := map[string]struct{}{}
+	for _, service := range i.ListProvidedServices() {
+		registered[service.Service] = struct{}{}
+	}
+
+	for _, index := range []string{
+		identityindexing.IndexTypeUsers,
+		mealplanningindexing.IndexTypeMeals,
+		mealplanningindexing.IndexTypeRecipes,
+		mealplanningindexing.IndexTypeValidIngredients,
+		mealplanningindexing.IndexTypeValidInstruments,
+		mealplanningindexing.IndexTypeValidMeasurementUnits,
+		mealplanningindexing.IndexTypeValidPreparations,
+		mealplanningindexing.IndexTypeValidIngredientStates,
+		mealplanningindexing.IndexTypeValidVessels,
+	} {
+		assert.Contains(t, registered, index, "no stamper registered for the %s index", index)
+	}
 }

--- a/backend/internal/functions/datachangemessagehandler/do.go
+++ b/backend/internal/functions/datachangemessagehandler/do.go
@@ -9,6 +9,7 @@ import (
 	"github.com/primandproper/dinnerdonebetter/backend/internal/domain/internalops"
 	"github.com/primandproper/dinnerdonebetter/backend/internal/domain/mealplanning"
 	notificationsmanager "github.com/primandproper/dinnerdonebetter/backend/internal/domain/notifications/manager"
+	"github.com/primandproper/dinnerdonebetter/backend/internal/indexstamp"
 	identityindexing "github.com/primandproper/dinnerdonebetter/backend/internal/services/identity/indexing"
 	mealplanningindexing "github.com/primandproper/dinnerdonebetter/backend/internal/services/mealplanning/indexing"
 
@@ -50,48 +51,62 @@ func RegisterAsyncDataChangeMessageHandler(i do.Injector) {
 	})
 }
 
-// searchSyncers collects every index's Syncer, paired with the topic its events arrive on.
+// searchSyncers collects every index's Syncer, paired with the topic its events arrive on and
+// with the Stamper it writes last_indexed_at through.
 //
 // The list is written out rather than discovered because it is the definition of which indexes
 // this process consumes for: an index whose Syncer is missing here has a topic nobody reads,
 // and the only symptom is search results that quietly stop moving.
+//
+// The Stamper is resolved by the index's name, which is the same string as the topic, so this
+// gets the very object the Syncer was built over rather than a second buffer for the same
+// index.
 func searchSyncers(i do.Injector) []SearchSyncer {
 	return []SearchSyncer{
 		{
 			Topic:  identityindexing.IndexTypeUsers,
 			Handle: do.MustInvoke[*searchsync.Syncer[identityindexing.UserSearchSubset]](i).Handle,
+			Close:  do.MustInvokeNamed[*indexstamp.Stamper](i, identityindexing.IndexTypeUsers).Close,
 		},
 		{
 			Topic:  mealplanningindexing.IndexTypeMeals,
 			Handle: do.MustInvoke[*searchsync.Syncer[mealplanningindexing.MealSearchSubset]](i).Handle,
+			Close:  do.MustInvokeNamed[*indexstamp.Stamper](i, mealplanningindexing.IndexTypeMeals).Close,
 		},
 		{
 			Topic:  mealplanningindexing.IndexTypeRecipes,
 			Handle: do.MustInvoke[*searchsync.Syncer[mealplanningindexing.RecipeSearchSubset]](i).Handle,
+			Close:  do.MustInvokeNamed[*indexstamp.Stamper](i, mealplanningindexing.IndexTypeRecipes).Close,
 		},
 		{
 			Topic:  mealplanningindexing.IndexTypeValidIngredients,
 			Handle: do.MustInvoke[*searchsync.Syncer[mealplanningindexing.ValidIngredientSearchSubset]](i).Handle,
+			Close:  do.MustInvokeNamed[*indexstamp.Stamper](i, mealplanningindexing.IndexTypeValidIngredients).Close,
 		},
 		{
 			Topic:  mealplanningindexing.IndexTypeValidInstruments,
 			Handle: do.MustInvoke[*searchsync.Syncer[mealplanningindexing.ValidInstrumentSearchSubset]](i).Handle,
+			Close:  do.MustInvokeNamed[*indexstamp.Stamper](i, mealplanningindexing.IndexTypeValidInstruments).Close,
 		},
 		{
 			Topic:  mealplanningindexing.IndexTypeValidMeasurementUnits,
 			Handle: do.MustInvoke[*searchsync.Syncer[mealplanningindexing.ValidMeasurementUnitSearchSubset]](i).Handle,
+			Close:  do.MustInvokeNamed[*indexstamp.Stamper](i, mealplanningindexing.IndexTypeValidMeasurementUnits).Close,
 		},
 		{
 			Topic:  mealplanningindexing.IndexTypeValidPreparations,
 			Handle: do.MustInvoke[*searchsync.Syncer[mealplanningindexing.ValidPreparationSearchSubset]](i).Handle,
+			Close:  do.MustInvokeNamed[*indexstamp.Stamper](i, mealplanningindexing.IndexTypeValidPreparations).Close,
 		},
 		{
 			Topic:  mealplanningindexing.IndexTypeValidIngredientStates,
 			Handle: do.MustInvoke[*searchsync.Syncer[mealplanningindexing.ValidIngredientStateSearchSubset]](i).Handle,
+			Close:  do.MustInvokeNamed[*indexstamp.Stamper](i, mealplanningindexing.IndexTypeValidIngredientStates).Close,
 		},
 		{
 			Topic:  mealplanningindexing.IndexTypeValidVessels,
 			Handle: do.MustInvoke[*searchsync.Syncer[mealplanningindexing.ValidVesselSearchSubset]](i).Handle,
+			Close:  do.MustInvokeNamed[*indexstamp.Stamper](i, mealplanningindexing.IndexTypeValidVessels).Close,
 		},
 	}
 }

--- a/backend/internal/functions/datachangemessagehandler/pools.go
+++ b/backend/internal/functions/datachangemessagehandler/pools.go
@@ -2,6 +2,7 @@ package datachangemessagehandler
 
 import (
 	"context"
+	"errors"
 
 	"github.com/primandproper/platform-go/v11/jobs"
 )
@@ -41,11 +42,11 @@ func (a *AsyncDataChangeMessageHandler) poolSpecs() []jobs.PoolSpec {
 	// index-type field. platform-go keys an index event by its topic, so the fan-out that used
 	// to happen inside a handler happens here instead — which also means one index's backlog no
 	// longer sits behind another's, and a poison message dead-letters for its own index alone.
-	for _, syncer := range a.searchSyncers {
+	for i := range a.searchSyncers {
 		specs = append(specs, jobs.PoolSpec{
-			Topic:   syncer.Topic,
+			Topic:   a.searchSyncers[i].Topic,
 			Config:  &a.poolsConfig.SearchIndexRequests,
-			Handler: syncer.Handle,
+			Handler: a.searchSyncers[i].Handle,
 		})
 	}
 
@@ -81,6 +82,22 @@ func (a *AsyncDataChangeMessageHandler) Start(ctx context.Context) error {
 
 // Close stops every pool and waits for in-flight handlers to drain. The context bounds the wait;
 // when it expires the pools cancel their workers and Close reports why.
+//
+// The search syncers are closed afterwards rather than alongside, because closing one flushes
+// the last_indexed_at stamps its buffer is holding and a handler that was still running would
+// otherwise have its stamp arrive after the flush. Their errors are joined onto the pools'
+// rather than swallowed: losing a stamp costs only an observation, but losing it silently
+// costs the ability to tell that from a consumer that stopped indexing.
 func (a *AsyncDataChangeMessageHandler) Close(ctx context.Context) error {
-	return a.poolGroup.Close(ctx)
+	err := a.poolGroup.Close(ctx)
+
+	for i := range a.searchSyncers {
+		if a.searchSyncers[i].Close == nil {
+			continue
+		}
+
+		err = errors.Join(err, a.searchSyncers[i].Close(ctx))
+	}
+
+	return err
 }

--- a/backend/internal/functions/datachangemessagehandler/pools_test.go
+++ b/backend/internal/functions/datachangemessagehandler/pools_test.go
@@ -292,6 +292,36 @@ func TestAsyncDataChangeMessageHandler_Close(T *testing.T) {
 
 		assert.NoError(t, buildTestPoolsHandler(t, &msgqueuemock.ConsumerProviderMock{}).Close(t.Context()))
 	})
+
+	T.Run("closes each syncer's stamper", func(t *testing.T) {
+		t.Parallel()
+
+		handler := buildTestPoolsHandler(t, &msgqueuemock.ConsumerProviderMock{})
+
+		var closed int
+		handler.searchSyncers[0].Close = func(context.Context) error {
+			closed++
+
+			return nil
+		}
+
+		require.NoError(t, handler.Close(t.Context()))
+
+		// The stamper holds the last interval's last_indexed_at writes in memory, so a
+		// shutdown that does not close it drops them.
+		assert.Equal(t, 1, closed)
+	})
+
+	T.Run("with a stamper that will not close", func(t *testing.T) {
+		t.Parallel()
+
+		handler := buildTestPoolsHandler(t, &msgqueuemock.ConsumerProviderMock{})
+
+		expected := errors.New("blah")
+		handler.searchSyncers[0].Close = func(context.Context) error { return expected }
+
+		assert.ErrorIs(t, handler.Close(t.Context()), expected)
+	})
 }
 
 func TestNewPoolGroup(T *testing.T) {

--- a/backend/internal/functions/datachangemessagehandler/search_syncers.go
+++ b/backend/internal/functions/datachangemessagehandler/search_syncers.go
@@ -1,6 +1,8 @@
 package datachangemessagehandler
 
 import (
+	"context"
+
 	"github.com/primandproper/platform-go/v11/jobs"
 )
 
@@ -13,9 +15,16 @@ import (
 // belongs to is where it came from.
 //
 // Handle is the Syncer's own jobs.Handler. Concurrency, retry with backoff, dead-lettering and
-// draining shutdown all belong to the jobs.Pool that runs it, which is why there is nothing
+// draining shutdown all belong to the jobs.Pool that runs it, which is why there is so little
 // else on this type.
+//
+// Close is the one thing the Pool cannot own: the Syncer writes through an indexstamp.Stamper,
+// whose buffer holds the last interval's worth of last_indexed_at stamps in memory and owns a
+// goroutine to flush them. It is closed after the pools drain, so a document indexed by a
+// handler that was still running at shutdown is stamped rather than dropped. A nil Close is a
+// syncer with nothing to shut down, which is what the tests build.
 type SearchSyncer struct {
 	Handle jobs.Handler
+	Close  func(ctx context.Context) error
 	Topic  string
 }

--- a/backend/internal/indexstamp/indexstamp.go
+++ b/backend/internal/indexstamp/indexstamp.go
@@ -1,0 +1,170 @@
+/*
+Package indexstamp records, on the row a search document was built from, when that document
+was last written to the search index.
+
+# Why this exists
+
+last_indexed_at is a column nine tables carry. Before platform-go v10 it drove indexing: a
+sampler asked "which rows look stale" and published an index request for each, so the column
+was both written by the indexer and read by the query that chose its next batch. The reindexer
+that replaced the sampler walks every ID in byte order instead — see ScanXIDsForReindex — and
+asks the column nothing. That left it written by nobody and read by nobody, and a column in
+that state is a lie about the schema rather than a spare field.
+
+Deleting it was the alternative, and it is not free: querygen.StandardCRUD derives whether to
+emit the reindex scan from this column's presence, so removing it here would silently stop
+nine tables getting the query the reindexer walks. This package takes the other answer —
+write it — which needs no agreement with the platform and turns the column into the one thing
+nothing else can currently say: how current a document in the index is.
+
+# Why the write is buffered
+
+A Stamper wraps the index the Syncer writes through, so a stamp happens exactly when a
+document is accepted by the index and not merely when an event is consumed. That puts a write
+on the sync path, and the sync path is as concurrent as its jobs.Pool.
+
+One UPDATE per applied document, issued from every worker at once, is the shape
+batching.Buffer's documentation is about: statements against the same handful of popular rows,
+taking row locks in whatever order each caller built them in, deadlocking on 40P01 and holding
+a pool connection while they do. A Buffer collapses repeats of a key, flushes on an interval
+from one goroutine, and emits in key order, so however busy the consumer is there is one
+stamping write in flight and one lock order.
+
+Nothing waits on the result. A stamp that is lost to a failing flush, or to a shutdown that
+outran the interval, costs an observation and nothing else — no read path consults this column,
+and the reindexer's correctness does not depend on it. That is what makes Buffer the right half
+of the package rather than GroupCommit.
+*/
+package indexstamp
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/primandproper/platform-go/v11/batching"
+	platformerrors "github.com/primandproper/platform-go/v11/errors"
+	textsearch "github.com/primandproper/platform-go/v11/search/text"
+)
+
+// maxPending is how many distinct IDs accumulate before a flush is forced.
+//
+// It is lower than batching's own default because a flush here is a loop of single-row
+// UPDATEs rather than one statement — the repositories' MarkXAsIndexed is the write, and
+// giving it a bulk sibling would mean a bespoke query on all nine tables that
+// querygen.StandardCRUD does not emit. A few hundred round trips fit inside a flush timeout
+// comfortably; a few thousand would not.
+const maxPending = 256
+
+var (
+	// ErrNilIndex is returned when New is given no index to wrap.
+	ErrNilIndex = errors.New("nil index provided")
+
+	// ErrNilMarkFunc is returned when New is given no way to stamp a row.
+	ErrNilMarkFunc = errors.New("nil mark function provided")
+)
+
+// MarkFunc stamps one row as indexed. It is a repository's MarkXAsIndexed method.
+type MarkFunc func(ctx context.Context, id string) error
+
+// Stamper is a textsearch.IndexManager that also records, on the row each document came from,
+// that the document was written.
+//
+// It is an IndexManager rather than a wrapper around the Syncer because that is the level at
+// which "the document was indexed" is true: an event for a row that has since been deleted
+// reaches the Syncer and turns into a delete, and a document the index refused was not
+// indexed. Neither should stamp anything, and neither does.
+//
+// A Stamper owns the goroutine its Buffer owns, and must be Closed.
+type Stamper struct {
+	index  textsearch.IndexManager
+	buffer *batching.Buffer[string]
+}
+
+var _ textsearch.IndexManager = (*Stamper)(nil)
+
+// New wraps index so that every document it accepts stamps its row through mark.
+//
+// opts are passed to the underlying batching.Buffer, after the defaults this package sets, so
+// a caller supplies the observability pillars — and, in a test, a shorter flush interval —
+// with batching's own options.
+func New(index textsearch.IndexManager, mark MarkFunc, opts ...batching.Option) (*Stamper, error) {
+	if index == nil {
+		return nil, ErrNilIndex
+	}
+
+	if mark == nil {
+		return nil, ErrNilMarkFunc
+	}
+
+	buffer, err := batching.NewBuffer(
+		stampAll(mark),
+		append([]batching.Option{
+			// Emitting in ID order is what turns contention between a flush and any other
+			// writer of these rows into a queue rather than a deadlock cycle.
+			batching.WithOrder(strings.Compare),
+			batching.WithMaxPending(maxPending),
+		}, opts...)...,
+	)
+	if err != nil {
+		return nil, platformerrors.Wrap(err, "building index stamp buffer")
+	}
+
+	return &Stamper{index: index, buffer: buffer}, nil
+}
+
+// Index writes the document, and buffers a stamp for its row once the index has taken it.
+//
+// The stamp is buffered after the write rather than alongside it, so a failed index leaves
+// last_indexed_at saying what it said before: that this document has not been written since
+// whenever it last was.
+func (s *Stamper) Index(ctx context.Context, id string, value any) error {
+	if err := s.index.Index(ctx, id, value); err != nil {
+		return err
+	}
+
+	s.buffer.Add(id)
+
+	return nil
+}
+
+// Delete removes the document and stamps nothing. There is no row left to stamp — a delete
+// reaches the index because the row was archived or vanished — and the column is about
+// documents the index holds.
+func (s *Stamper) Delete(ctx context.Context, id string) error {
+	return s.index.Delete(ctx, id)
+}
+
+// Wipe empties the index and stamps nothing, for the same reason Delete does not: it is the
+// removal half of a rebuild, and the writes that follow it are what stamp.
+func (s *Stamper) Wipe(ctx context.Context) error {
+	return s.index.Wipe(ctx)
+}
+
+// Close stops the flusher and writes whatever stamps it still holds, bounded by ctx.
+//
+// Call it after whatever is writing through this Stamper has drained, so a document indexed
+// during shutdown still stamps.
+func (s *Stamper) Close(ctx context.Context) error {
+	return s.buffer.Close(ctx)
+}
+
+// stampAll is the buffer's write: the keys one flush accumulated, stamped one row at a time.
+//
+// It does not stop at the first failure. The IDs in a batch are unrelated rows, so one that
+// cannot be stamped — archived between the index write and the flush, most likely — says
+// nothing about the rest, and abandoning them would lose observations for a reason that
+// applies to only one.
+func stampAll(mark MarkFunc) func(ctx context.Context, ids []string) error {
+	return func(ctx context.Context, ids []string) error {
+		var errs []error
+
+		for _, id := range ids {
+			if err := mark(ctx, id); err != nil {
+				errs = append(errs, platformerrors.Wrapf(err, "stamping %q as indexed", id))
+			}
+		}
+
+		return errors.Join(errs...)
+	}
+}

--- a/backend/internal/indexstamp/indexstamp_test.go
+++ b/backend/internal/indexstamp/indexstamp_test.go
@@ -1,0 +1,326 @@
+package indexstamp
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/primandproper/platform-go/v11/batching"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var errFromIndex = errors.New("index said no")
+
+// recordingIndex is a textsearch.IndexManager that remembers what it was asked to do, and
+// fails the calls a test tells it to fail.
+type recordingIndex struct {
+	indexErr  error
+	deleteErr error
+	wipeErr   error
+
+	indexed []string
+	deleted []string
+
+	mu    sync.Mutex
+	wiped int
+}
+
+func (r *recordingIndex) Index(_ context.Context, id string, _ any) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.indexErr != nil {
+		return r.indexErr
+	}
+
+	r.indexed = append(r.indexed, id)
+
+	return nil
+}
+
+func (r *recordingIndex) Delete(_ context.Context, id string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.deleteErr != nil {
+		return r.deleteErr
+	}
+
+	r.deleted = append(r.deleted, id)
+
+	return nil
+}
+
+func (r *recordingIndex) Wipe(context.Context) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.wipeErr != nil {
+		return r.wipeErr
+	}
+
+	r.wiped++
+
+	return nil
+}
+
+// recordingMark is a MarkFunc that remembers every ID it stamped, and optionally refuses one.
+type recordingMark struct {
+	refuse  string
+	stamped []string
+
+	mu sync.Mutex
+}
+
+func (r *recordingMark) mark(_ context.Context, id string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if id == r.refuse {
+		return errors.New("cannot stamp " + id)
+	}
+
+	r.stamped = append(r.stamped, id)
+
+	return nil
+}
+
+func (r *recordingMark) all() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return slices.Clone(r.stamped)
+}
+
+// buildStamperForTest builds a Stamper whose buffer only ever flushes when it is closed, so a
+// test observes one flush at a moment it chose rather than one the interval chose for it.
+func buildStamperForTest(t *testing.T, index *recordingIndex, mark *recordingMark) *Stamper {
+	t.Helper()
+
+	stamper, err := New(index, mark.mark, batching.WithFlushInterval(time.Hour))
+	require.NoError(t, err)
+	require.NotNil(t, stamper)
+
+	return stamper
+}
+
+func TestNew(T *testing.T) {
+	T.Parallel()
+
+	T.Run("standard", func(t *testing.T) {
+		t.Parallel()
+
+		stamper, err := New(&recordingIndex{}, (&recordingMark{}).mark)
+		require.NoError(t, err)
+		require.NotNil(t, stamper)
+
+		assert.NoError(t, stamper.Close(t.Context()))
+	})
+
+	T.Run("with nil index", func(t *testing.T) {
+		t.Parallel()
+
+		stamper, err := New(nil, (&recordingMark{}).mark)
+		assert.Nil(t, stamper)
+		assert.ErrorIs(t, err, ErrNilIndex)
+	})
+
+	T.Run("with nil mark func", func(t *testing.T) {
+		t.Parallel()
+
+		stamper, err := New(&recordingIndex{}, nil)
+		assert.Nil(t, stamper)
+		assert.ErrorIs(t, err, ErrNilMarkFunc)
+	})
+}
+
+func TestStamper_Index(T *testing.T) {
+	T.Parallel()
+
+	T.Run("standard", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		index, mark := &recordingIndex{}, &recordingMark{}
+		stamper := buildStamperForTest(t, index, mark)
+
+		require.NoError(t, stamper.Index(ctx, "abc", "whatever"))
+
+		// Nothing is stamped until the buffer flushes, which is the whole point of it.
+		assert.Empty(t, mark.all())
+
+		require.NoError(t, stamper.Close(ctx))
+
+		assert.Equal(t, []string{"abc"}, index.indexed)
+		assert.Equal(t, []string{"abc"}, mark.all())
+	})
+
+	T.Run("collapses repeats of one document into one stamp", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		index, mark := &recordingIndex{}, &recordingMark{}
+		stamper := buildStamperForTest(t, index, mark)
+
+		for range 10 {
+			require.NoError(t, stamper.Index(ctx, "abc", "whatever"))
+		}
+
+		require.NoError(t, stamper.Close(ctx))
+
+		assert.Len(t, index.indexed, 10)
+		assert.Equal(t, []string{"abc"}, mark.all())
+	})
+
+	T.Run("stamps every distinct document in one flush", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		index, mark := &recordingIndex{}, &recordingMark{}
+		stamper := buildStamperForTest(t, index, mark)
+
+		require.NoError(t, stamper.Index(ctx, "ccc", "whatever"))
+		require.NoError(t, stamper.Index(ctx, "aaa", "whatever"))
+		require.NoError(t, stamper.Index(ctx, "bbb", "whatever"))
+
+		require.NoError(t, stamper.Close(ctx))
+
+		// In ID order, because that is the lock order the buffer was given.
+		assert.Equal(t, []string{"aaa", "bbb", "ccc"}, mark.all())
+	})
+
+	T.Run("with failing index", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		index, mark := &recordingIndex{indexErr: errFromIndex}, &recordingMark{}
+		stamper := buildStamperForTest(t, index, mark)
+
+		require.ErrorIs(t, stamper.Index(ctx, "abc", "whatever"), errFromIndex)
+
+		require.NoError(t, stamper.Close(ctx))
+
+		// A document the index refused was not indexed, so its row says what it said before.
+		assert.Empty(t, mark.all())
+	})
+
+	T.Run("with one row that cannot be stamped", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		index, mark := &recordingIndex{}, &recordingMark{refuse: "bbb"}
+		stamper := buildStamperForTest(t, index, mark)
+
+		require.NoError(t, stamper.Index(ctx, "aaa", "whatever"))
+		require.NoError(t, stamper.Index(ctx, "bbb", "whatever"))
+		require.NoError(t, stamper.Index(ctx, "ccc", "whatever"))
+
+		require.Error(t, stamper.Close(ctx))
+
+		// The other two are stamped regardless: one unstampable row says nothing about them.
+		assert.Equal(t, []string{"aaa", "ccc"}, mark.all())
+	})
+}
+
+func TestStamper_Delete(T *testing.T) {
+	T.Parallel()
+
+	T.Run("standard", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		index, mark := &recordingIndex{}, &recordingMark{}
+		stamper := buildStamperForTest(t, index, mark)
+
+		require.NoError(t, stamper.Delete(ctx, "abc"))
+		require.NoError(t, stamper.Close(ctx))
+
+		assert.Equal(t, []string{"abc"}, index.deleted)
+		assert.Empty(t, mark.all())
+	})
+
+	T.Run("with failing index", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		index, mark := &recordingIndex{deleteErr: errFromIndex}, &recordingMark{}
+		stamper := buildStamperForTest(t, index, mark)
+
+		require.ErrorIs(t, stamper.Delete(ctx, "abc"), errFromIndex)
+		require.NoError(t, stamper.Close(ctx))
+
+		assert.Empty(t, mark.all())
+	})
+}
+
+func TestStamper_Wipe(T *testing.T) {
+	T.Parallel()
+
+	T.Run("standard", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		index, mark := &recordingIndex{}, &recordingMark{}
+		stamper := buildStamperForTest(t, index, mark)
+
+		require.NoError(t, stamper.Wipe(ctx))
+		require.NoError(t, stamper.Close(ctx))
+
+		assert.Equal(t, 1, index.wiped)
+		assert.Empty(t, mark.all())
+	})
+
+	T.Run("with failing index", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		index, mark := &recordingIndex{wipeErr: errFromIndex}, &recordingMark{}
+		stamper := buildStamperForTest(t, index, mark)
+
+		require.ErrorIs(t, stamper.Wipe(ctx), errFromIndex)
+		require.NoError(t, stamper.Close(ctx))
+
+		assert.Empty(t, mark.all())
+	})
+}
+
+func TestStamper_Close(T *testing.T) {
+	T.Parallel()
+
+	T.Run("is safe to call more than once", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		index, mark := &recordingIndex{}, &recordingMark{}
+		stamper := buildStamperForTest(t, index, mark)
+
+		require.NoError(t, stamper.Index(ctx, "abc", "whatever"))
+		require.NoError(t, stamper.Close(ctx))
+		require.NoError(t, stamper.Close(ctx))
+
+		assert.Equal(t, []string{"abc"}, mark.all())
+	})
+
+	T.Run("flushes on the interval without a close", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		index, mark := &recordingIndex{}, &recordingMark{}
+
+		stamper, err := New(index, mark.mark, batching.WithFlushInterval(10*time.Millisecond))
+		require.NoError(t, err)
+
+		t.Cleanup(func() { assert.NoError(t, stamper.Close(context.WithoutCancel(ctx))) })
+
+		require.NoError(t, stamper.Index(ctx, "abc", "whatever"))
+
+		assert.Eventually(t, func() bool {
+			return slices.Equal([]string{"abc"}, mark.all())
+		}, time.Second, 5*time.Millisecond)
+	})
+}

--- a/backend/internal/repositories/postgres/mealplanning/index_stamping_test.go
+++ b/backend/internal/repositories/postgres/mealplanning/index_stamping_test.go
@@ -1,0 +1,100 @@
+package mealplanning
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/primandproper/dinnerdonebetter/backend/internal/domain/mealplanning/fakes"
+	"github.com/primandproper/dinnerdonebetter/backend/internal/indexstamp"
+	mealplanningindexing "github.com/primandproper/dinnerdonebetter/backend/internal/services/mealplanning/indexing"
+
+	loggingnoop "github.com/primandproper/platform-go/v11/observability/logging/noop"
+	tracingnoop "github.com/primandproper/platform-go/v11/observability/tracing/noop"
+	searchsync "github.com/primandproper/platform-go/v11/search/sync"
+	syncsource "github.com/primandproper/platform-go/v11/search/sync/source"
+	textsearchnoop "github.com/primandproper/platform-go/v11/search/text/noop"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// lastIndexedAtForTest reads the column directly, because nothing maps it onto a domain type.
+// That is the point of the column as it stands: it is written by the sync path and read by
+// whoever is asking how current the index is, not by the application.
+func lastIndexedAtForTest(t *testing.T, ctx context.Context, dbc *repository, validInstrumentID string) sql.NullTime {
+	t.Helper()
+
+	var stamp sql.NullTime
+	require.NoError(t, dbc.readDB.QueryRowContext(
+		ctx,
+		"SELECT last_indexed_at FROM valid_instruments WHERE id = $1",
+		validInstrumentID,
+	).Scan(&stamp))
+
+	return stamp
+}
+
+// buildSyncerForTest wires the real search sync path over a real repository, writing into the
+// noop index. What is under test is not the index — it keeps nothing — but the Stamper between
+// the Syncer and it, and the row the Syncer's document came from.
+func buildSyncerForTest(t *testing.T, dbc *repository) (*searchsync.Syncer[mealplanningindexing.ValidInstrumentSearchSubset], *indexstamp.Stamper) {
+	t.Helper()
+
+	stamper, err := indexstamp.New(
+		textsearchnoop.NewIndexManager[mealplanningindexing.ValidInstrumentSearchSubset](),
+		dbc.MarkValidInstrumentAsIndexed,
+	)
+	require.NoError(t, err)
+
+	source, err := mealplanningindexing.NewValidInstrumentSource(dbc)
+	require.NoError(t, err)
+
+	syncer, err := syncsource.NewSyncer(source, stamper,
+		syncsource.WithLogger(loggingnoop.NewLogger()),
+		syncsource.WithTracerProvider(tracingnoop.NewTracerProvider()),
+	)
+	require.NoError(t, err)
+
+	return syncer, stamper
+}
+
+func TestQuerier_Integration_SyncedDocumentIsStamped(t *testing.T) {
+	ctx := t.Context()
+	dbc, _ := buildDatabaseClientForTest(t)
+
+	validInstrument := createValidInstrumentForTest(t, ctx, fakes.BuildFakeValidInstrument(), dbc)
+
+	// A row nothing has indexed carries no stamp, which is what every row looked like before
+	// anything wrote this column.
+	assert.False(t, lastIndexedAtForTest(t, ctx, dbc, validInstrument.ID).Valid)
+
+	syncer, stamper := buildSyncerForTest(t, dbc)
+
+	require.NoError(t, syncer.Apply(ctx, searchsync.NewEvent(searchsync.OpUpsert, validInstrument.ID)))
+
+	// Applying the event does not write the stamp — the buffer holds it — which is what keeps
+	// one UPDATE per applied document off the sync path.
+	assert.False(t, lastIndexedAtForTest(t, ctx, dbc, validInstrument.ID).Valid)
+
+	require.NoError(t, stamper.Close(ctx))
+
+	stamp := lastIndexedAtForTest(t, ctx, dbc, validInstrument.ID)
+	assert.True(t, stamp.Valid)
+	assert.False(t, stamp.Time.IsZero())
+}
+
+func TestQuerier_Integration_DeletedDocumentIsNotStamped(t *testing.T) {
+	ctx := t.Context()
+	dbc, _ := buildDatabaseClientForTest(t)
+
+	validInstrument := createValidInstrumentForTest(t, ctx, fakes.BuildFakeValidInstrument(), dbc)
+
+	syncer, stamper := buildSyncerForTest(t, dbc)
+
+	require.NoError(t, syncer.Apply(ctx, searchsync.NewEvent(searchsync.OpDelete, validInstrument.ID)))
+	require.NoError(t, stamper.Close(ctx))
+
+	// The column says when a document was last written to the index, and a delete wrote none.
+	assert.False(t, lastIndexedAtForTest(t, ctx, dbc, validInstrument.ID).Valid)
+}

--- a/backend/internal/services/identity/indexing/do.go
+++ b/backend/internal/services/identity/indexing/do.go
@@ -2,7 +2,9 @@ package indexing
 
 import (
 	"github.com/primandproper/dinnerdonebetter/backend/internal/domain/identity"
+	"github.com/primandproper/dinnerdonebetter/backend/internal/indexstamp"
 
+	"github.com/primandproper/platform-go/v11/batching"
 	"github.com/primandproper/platform-go/v11/observability/logging"
 	"github.com/primandproper/platform-go/v11/observability/metrics"
 	"github.com/primandproper/platform-go/v11/observability/tracing"
@@ -11,15 +13,29 @@ import (
 	"github.com/samber/do/v2"
 )
 
-// RegisterUserSyncer registers the Syncer that applies users-index events.
+// RegisterUserSyncer registers the Syncer that applies users-index events, and the Stamper it
+// writes through.
 //
 // It is registered for the process that consumes the index topic. Handle is a jobs.Handler, so
 // the Pool that runs it is wired where the other consumers are rather than here.
 func RegisterUserSyncer(i do.Injector) {
+	// Named for its index, so that the consumer can resolve the same Stamper the Syncer got in
+	// order to close it. do provides one instance per name, which is what makes those the same
+	// object rather than two buffers over one index.
+	do.ProvideNamed(i, IndexTypeUsers, func(i do.Injector) (*indexstamp.Stamper, error) {
+		return indexstamp.New(
+			do.MustInvoke[UserTextSearcher](i),
+			do.MustInvoke[identity.Repository](i).MarkUserAsIndexed,
+			batching.WithLogger(logging.NewNamedLogger(do.MustInvoke[logging.Logger](i), o11yName)),
+			batching.WithTracerProvider(do.MustInvoke[tracing.Provider](i)),
+			batching.WithMetricsProvider(do.MustInvoke[metrics.Provider](i)),
+		)
+	})
+
 	do.Provide(i, func(i do.Injector) (*searchsync.Syncer[UserSearchSubset], error) {
 		return NewUserSyncer(
 			do.MustInvoke[identity.Repository](i),
-			do.MustInvoke[UserTextSearcher](i),
+			do.MustInvokeNamed[*indexstamp.Stamper](i, IndexTypeUsers),
 			do.MustInvoke[logging.Logger](i),
 			do.MustInvoke[tracing.Provider](i),
 			do.MustInvoke[metrics.Provider](i),
@@ -28,6 +44,10 @@ func RegisterUserSyncer(i do.Injector) {
 }
 
 // RegisterUserReindexer registers the users reindex backstop, which runs as a scheduled job.
+//
+// It writes to the searcher directly rather than through a Stamper. A reindex writes every
+// document there is, so stamping it would turn last_indexed_at into a record of when the last
+// rebuild ran — the same value on every row — instead of how current each document is.
 func RegisterUserReindexer(i do.Injector) {
 	do.Provide(i, func(i do.Injector) (*searchsync.Reindexer[UserSearchSubset], error) {
 		return NewUserReindexer(

--- a/backend/internal/services/identity/indexing/indexing.go
+++ b/backend/internal/services/identity/indexing/indexing.go
@@ -8,6 +8,7 @@ import (
 	"github.com/primandproper/platform-go/v11/observability/tracing"
 	searchsync "github.com/primandproper/platform-go/v11/search/sync"
 	syncsource "github.com/primandproper/platform-go/v11/search/sync/source"
+	textsearch "github.com/primandproper/platform-go/v11/search/text"
 )
 
 // o11yName names the loggers, spans and metrics of the search sync sources built here. It
@@ -29,9 +30,13 @@ func UserSource(repo identity.Repository) (*syncsource.Source[identity.User, Use
 //
 // It replaces the scheduler that used to publish an index request for every user a sampler
 // thought looked stale. The events now come from the transactions that changed the rows.
+//
+// index is a textsearch.IndexManager rather than a UserTextSearcher because syncing never
+// reads, and because what the consumer hands it is the indexstamp.Stamper wrapping the
+// searcher rather than the searcher itself.
 func NewUserSyncer(
 	repo identity.Repository,
-	index UserTextSearcher,
+	index textsearch.IndexManager,
 	logger logging.Logger,
 	tracerProvider tracing.Provider,
 	metricsProvider metrics.Provider,

--- a/backend/internal/services/mealplanning/indexing/do.go
+++ b/backend/internal/services/mealplanning/indexing/do.go
@@ -1,8 +1,12 @@
 package indexing
 
 import (
-	"github.com/primandproper/dinnerdonebetter/backend/internal/domain/mealplanning"
+	"context"
 
+	"github.com/primandproper/dinnerdonebetter/backend/internal/domain/mealplanning"
+	"github.com/primandproper/dinnerdonebetter/backend/internal/indexstamp"
+
+	"github.com/primandproper/platform-go/v11/batching"
 	"github.com/primandproper/platform-go/v11/observability/logging"
 	"github.com/primandproper/platform-go/v11/observability/metrics"
 	"github.com/primandproper/platform-go/v11/observability/tracing"
@@ -18,7 +22,8 @@ import (
 // query has to change.
 const o11yName = "search_sync_source"
 
-// registerPair registers the Syncer and Reindexer for one entity over one index.
+// registerPair registers the Syncer and Reindexer for one entity over one index, plus the
+// Stamper the Syncer writes through.
 //
 // The two are registered together because they are the two halves of keeping one index right,
 // and registering one without the other is the mistake worth making impossible: a Syncer with
@@ -27,21 +32,44 @@ const o11yName = "search_sync_source"
 //
 // Which of them a given process actually resolves is still that process's business — the API
 // server resolves neither, the consumer resolves Syncers, the scheduler resolves Reindexers —
-// because do is lazy and nothing is constructed until something asks for it.
+// because do is lazy and nothing is constructed until something asks for it. That laziness is
+// also why the Stamper registered here costs the scheduler nothing: only the Syncer asks for
+// one.
+//
+// mark is spelled as a method expression at the call sites — mealplanning.Repository.MarkXAsIndexed
+// — so the entity's stamping method is named next to its source and its index, and a pair
+// wired to the wrong one does not compile.
 func registerPair[E, T any](
 	i do.Injector,
+	name string,
 	source func(mealplanning.Repository) (*syncsource.Source[E, T], error),
+	mark func(mealplanning.Repository, context.Context, string) error,
 	index func(do.Injector) textsearch.IndexManager,
 ) {
+	// Named for its index, so that the consumer can resolve the same Stamper the Syncer got in
+	// order to close it. do provides one instance per name, which is what makes those the same
+	// object rather than two buffers over one index.
+	do.ProvideNamed(i, name, func(i do.Injector) (*indexstamp.Stamper, error) {
+		repo := do.MustInvoke[mealplanning.Repository](i)
+
+		return indexstamp.New(index(i), func(ctx context.Context, id string) error {
+			return mark(repo, ctx, id)
+		}, stampOptions(i)...)
+	})
+
 	do.Provide(i, func(i do.Injector) (*searchsync.Syncer[T], error) {
 		src, err := source(do.MustInvoke[mealplanning.Repository](i))
 		if err != nil {
 			return nil, err
 		}
 
-		return syncsource.NewSyncer(src, index(i), o11yOptions(i)...)
+		return syncsource.NewSyncer(src, do.MustInvokeNamed[*indexstamp.Stamper](i, name), o11yOptions(i)...)
 	})
 
+	// The Reindexer writes to the searcher directly rather than through the Stamper. A reindex
+	// writes every document there is, so stamping it would turn last_indexed_at into a record
+	// of when the last rebuild ran — the same value on every row — instead of how current each
+	// document is.
 	do.Provide(i, func(i do.Injector) (*searchsync.Reindexer[T], error) {
 		src, err := source(do.MustInvoke[mealplanning.Repository](i))
 		if err != nil {
@@ -62,30 +90,39 @@ func o11yOptions(i do.Injector) []syncsource.Option {
 	}
 }
 
+// stampOptions is the same three pillars as batching options, for the Stamper's buffer.
+func stampOptions(i do.Injector) []batching.Option {
+	return []batching.Option{
+		batching.WithLogger(logging.NewNamedLogger(do.MustInvoke[logging.Logger](i), o11yName)),
+		batching.WithTracerProvider(do.MustInvoke[tracing.Provider](i)),
+		batching.WithMetricsProvider(do.MustInvoke[metrics.Provider](i)),
+	}
+}
+
 // RegisterIndexSyncers registers the Syncer and Reindexer for all eight meal planning indexes.
 func RegisterIndexSyncers(i do.Injector) {
-	registerPair(i, NewMealSource, func(i do.Injector) textsearch.IndexManager {
+	registerPair(i, IndexTypeMeals, NewMealSource, mealplanning.Repository.MarkMealAsIndexed, func(i do.Injector) textsearch.IndexManager {
 		return do.MustInvoke[MealTextSearcher](i)
 	})
-	registerPair(i, NewRecipeSource, func(i do.Injector) textsearch.IndexManager {
+	registerPair(i, IndexTypeRecipes, NewRecipeSource, mealplanning.Repository.MarkRecipeAsIndexed, func(i do.Injector) textsearch.IndexManager {
 		return do.MustInvoke[RecipeTextSearcher](i)
 	})
-	registerPair(i, NewValidIngredientSource, func(i do.Injector) textsearch.IndexManager {
+	registerPair(i, IndexTypeValidIngredients, NewValidIngredientSource, mealplanning.Repository.MarkValidIngredientAsIndexed, func(i do.Injector) textsearch.IndexManager {
 		return do.MustInvoke[ValidIngredientTextSearcher](i)
 	})
-	registerPair(i, NewValidInstrumentSource, func(i do.Injector) textsearch.IndexManager {
+	registerPair(i, IndexTypeValidInstruments, NewValidInstrumentSource, mealplanning.Repository.MarkValidInstrumentAsIndexed, func(i do.Injector) textsearch.IndexManager {
 		return do.MustInvoke[ValidInstrumentTextSearcher](i)
 	})
-	registerPair(i, NewValidMeasurementUnitSource, func(i do.Injector) textsearch.IndexManager {
+	registerPair(i, IndexTypeValidMeasurementUnits, NewValidMeasurementUnitSource, mealplanning.Repository.MarkValidMeasurementUnitAsIndexed, func(i do.Injector) textsearch.IndexManager {
 		return do.MustInvoke[ValidMeasurementUnitTextSearcher](i)
 	})
-	registerPair(i, NewValidPreparationSource, func(i do.Injector) textsearch.IndexManager {
+	registerPair(i, IndexTypeValidPreparations, NewValidPreparationSource, mealplanning.Repository.MarkValidPreparationAsIndexed, func(i do.Injector) textsearch.IndexManager {
 		return do.MustInvoke[ValidPreparationTextSearcher](i)
 	})
-	registerPair(i, NewValidIngredientStateSource, func(i do.Injector) textsearch.IndexManager {
+	registerPair(i, IndexTypeValidIngredientStates, NewValidIngredientStateSource, mealplanning.Repository.MarkValidIngredientStateAsIndexed, func(i do.Injector) textsearch.IndexManager {
 		return do.MustInvoke[ValidIngredientStateTextSearcher](i)
 	})
-	registerPair(i, NewValidVesselSource, func(i do.Injector) textsearch.IndexManager {
+	registerPair(i, IndexTypeValidVessels, NewValidVesselSource, mealplanning.Repository.MarkValidVesselAsIndexed, func(i do.Injector) textsearch.IndexManager {
 		return do.MustInvoke[ValidVesselTextSearcher](i)
 	})
 }


### PR DESCRIPTION
Closes #1319.

The issue asked for a decision between deleting `last_indexed_at` and writing it. **This takes
(2): keep it, and write it from the sync path.** The reasoning is recorded in the issue
([comment](https://github.com/primandproper/dinnerdonebetter/issues/1319#issuecomment-5333899130))
and, durably, in `internal/indexstamp`'s package doc.

## Why (2)

`querygen.StandardCRUD` derives the reindex scan from this column's presence and derives only
that from it — it emits no `UpdateXLastIndexedAt` at all; our nine are bespoke queries written
out per table. So deleting the column takes a platform change, a release, a bump here and a
migration, and if those land out of order the symptom is nine tables silently losing
`ScanXIDsForReindex`, the query the reindexer walks. The whole exercise buys one fewer column.

Writing it buys an answer to "how current is this document in the index", which today nothing
can give: the syncer reports lag as a histogram and the reindexer walks everything regardless
of freshness.

## How

`internal/indexstamp.Stamper` wraps the `textsearch.IndexManager` the Syncer writes through and
buffers a stamp per accepted document into a `batching.Buffer[string]`.

- **The index is the seam, not the handler.** A stamp then happens exactly when the index
  accepts a document. An event for a row that has since vanished turns into a delete, and a
  document the index refused was not indexed — neither stamps, and neither is distinguishable
  from a handler's return value.
- **The reindexer is not wrapped.** It writes every document there is, so stamping it would
  make the column a record of when the last rebuild ran — the same value on every row — rather
  than how current each document is.
- **The flush loops over the existing `MarkXAsIndexed`.** The buffer already gives the property
  that matters: one flush goroutine, keys deduped, emitted in ID order, so one stamping write
  in flight and one lock order. A bulk sibling would mean a bespoke query on all nine tables
  that `StandardCRUD` does not emit — the shape #1292 exists to stop hand-writing. `maxPending`
  is 256 rather than batching's 1024 to keep a flush inside its timeout.

Nothing waits on the result, which is what makes `Buffer` right rather than `GroupCommit`: a
stamp lost to a failed flush costs an observation and nothing else. `SearchSyncer` gains a
`Close`, and the consumer closes each Stamper after its pools drain, so a document indexed
during shutdown still stamps.

The `poolSpecs` range loop changed to index form only because adding `Close` grew `SearchSyncer`
past `gocritic`'s `rangeValCopy` threshold.

## Tests

- `internal/indexstamp` — dedupe, ID ordering, a failed index leaving no stamp, deletes and
  wipes stamping nothing, one unstampable row not taking the batch down with it, interval flush.
- `TestQuerier_Integration_SyncedDocumentIsStamped` — the real `searchsync.Syncer` over the real
  repository: apply an upsert event and `valid_instruments.last_indexed_at` goes NULL → set.
  Plus its negative, that a delete event leaves it NULL. This is the DoD's "a synced document
  leaves a stamped row".
- `TestBuildInjector_RegistersAStamperPerIndex` — all nine indexes have a Stamper the consumer
  can resolve in order to close it.
- `TestAsyncDataChangeMessageHandler_Close` — shutdown closes each syncer's stamper, and a
  refusing stamper is reported rather than swallowed.

`make test` passes, with one unrelated failure: `internal/repositories/postgres/issuereports`
hit the 10-minute test timeout blocked on a postgres read under container contention, and
passes in 4.4s when run on its own.

## Follow-on for #1292

The nine tables keep the column, so `StandardCRUD` keeps emitting their reindex scans. Their
`UpdateXLastIndexedAt` queries now have a production caller and must survive the querygen
migration as bespoke queries rather than being dropped with the rest of the hand-written set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
