### PR TITLE
refactor(queries): build every table's standard queries on database/querygen

### DIFF
--- a/backend/cmd/tools/codegen/queries/auth_user_sessions.go
+++ b/backend/cmd/tools/codegen/queries/auth_user_sessions.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"fmt"
+	"slices"
 	"strings"
+
+	"github.com/primandproper/platform-go/v11/database/querygen"
 
 	"github.com/cristalhq/builq"
 )
@@ -43,86 +46,73 @@ func buildUserSessionsQueries(database string) []*Query {
 	switch database {
 	case postgres:
 
-		insertColumns := filterFromSlice(userSessionsColumns, createdAtColumn, lastActiveAtColumn, revokedAtColumn)
-
 		fullSelectColumns := applyToEach(userSessionsColumns, func(i int, s string) string {
 			return fmt.Sprintf("%s.%s", userSessionsTableName, s)
 		})
 
-		return []*Query{
-			{
-				Annotation: QueryAnnotation{
-					Name: "CreateUserSession",
-					Type: ExecType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`INSERT INTO %s (
-	%s
-) VALUES (
-	%s
-);`,
-					userSessionsTableName,
-					strings.Join(insertColumns, ",\n\t"),
-					strings.Join(applyToEach(insertColumns, func(i int, s string) string {
-						return fmt.Sprintf("sqlc.arg(%s)", s)
-					}), ",\n\t"),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetUserSessionBySessionTokenID",
-					Type: OneType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+		return slices.Concat(
+			querygen.StandardCRUD(userSessionsTableName, userSessionsColumns,
+				querygen.WithEntity("UserSession", "UserSessions"),
+				querygen.WithDatabaseOwned(lastActiveAtColumn, revokedAtColumn),
+				querygen.WithOmitted(querygen.ExistsQuery, querygen.GetQuery, querygen.ListQuery, querygen.UpdateQuery),
+			),
+			[]*Query{
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetUserSessionBySessionTokenID",
+						Type: OneType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s
 FROM %s
 WHERE %s.%s = sqlc.arg(%s)
 	AND %s.%s IS NULL
 	AND %s.%s > %s;`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					userSessionsTableName,
-					userSessionsTableName, sessionTokenIDColumn, sessionTokenIDColumn,
-					userSessionsTableName, revokedAtColumn,
-					userSessionsTableName, expiresAtColumn, currentTimeExpression,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetUserSessionByRefreshTokenID",
-					Type: OneType,
+						strings.Join(fullSelectColumns, ",\n\t"),
+						userSessionsTableName,
+						userSessionsTableName, sessionTokenIDColumn, sessionTokenIDColumn,
+						userSessionsTableName, revokedAtColumn,
+						userSessionsTableName, expiresAtColumn, currentTimeExpression,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetUserSessionByRefreshTokenID",
+						Type: OneType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s
 FROM %s
 WHERE %s.%s = sqlc.arg(%s)
 	AND %s.%s IS NULL;`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					userSessionsTableName,
-					userSessionsTableName, refreshTokenIDColumn, refreshTokenIDColumn,
-					userSessionsTableName, revokedAtColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetActiveSessionsForUser",
-					Type: ManyType,
+						strings.Join(fullSelectColumns, ",\n\t"),
+						userSessionsTableName,
+						userSessionsTableName, refreshTokenIDColumn, refreshTokenIDColumn,
+						userSessionsTableName, revokedAtColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetActiveSessionsForUser",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	(
 		SELECT COUNT(%s.%s)
 		FROM %s
 		WHERE %s.%s = sqlc.arg(%s)
-			AND %s.%s IS NULL
-			AND %s.%s > %s
-			AND %s.%s > COALESCE(sqlc.narg(created_after), (SELECT %s - '999 years'::INTERVAL))
-			AND %s.%s < COALESCE(sqlc.narg(created_before), (SELECT %s + '999 years'::INTERVAL))
+				AND %s.%s IS NULL
+				AND %s.%s > %s
+				AND %s.%s > COALESCE(sqlc.narg(created_after), (SELECT %s - '999 years'::INTERVAL))
+				AND %s.%s < COALESCE(sqlc.narg(created_before), (SELECT %s + '999 years'::INTERVAL))
 	) AS filtered_count,
 	(
 		SELECT COUNT(%s.%s)
 		FROM %s
 		WHERE %s.%s = sqlc.arg(%s)
-			AND %s.%s IS NULL
-			AND %s.%s > %s
+				AND %s.%s IS NULL
+				AND %s.%s > %s
 	) AS total_count
 FROM %s
 WHERE %s.%s = sqlc.arg(%s)
@@ -133,133 +123,134 @@ WHERE %s.%s = sqlc.arg(%s)
 	AND %s.%s > COALESCE(sqlc.narg(cursor), '')
 ORDER BY %s.%s DESC
 LIMIT COALESCE(sqlc.narg(result_limit), 50);`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					// filtered_count subquery
-					userSessionsTableName, idColumn,
-					userSessionsTableName,
-					userSessionsTableName, belongsToUserColumn, belongsToUserColumn,
-					userSessionsTableName, revokedAtColumn,
-					userSessionsTableName, expiresAtColumn, currentTimeExpression,
-					userSessionsTableName, createdAtColumn, currentTimeExpression,
-					userSessionsTableName, createdAtColumn, currentTimeExpression,
-					// total_count subquery
-					userSessionsTableName, idColumn,
-					userSessionsTableName,
-					userSessionsTableName, belongsToUserColumn, belongsToUserColumn,
-					userSessionsTableName, revokedAtColumn,
-					userSessionsTableName, expiresAtColumn, currentTimeExpression,
-					// main query
-					userSessionsTableName,
-					userSessionsTableName, belongsToUserColumn, belongsToUserColumn,
-					userSessionsTableName, revokedAtColumn,
-					userSessionsTableName, expiresAtColumn, currentTimeExpression,
-					userSessionsTableName, createdAtColumn, currentTimeExpression,
-					userSessionsTableName, createdAtColumn, currentTimeExpression,
-					userSessionsTableName, idColumn,
-					userSessionsTableName, lastActiveAtColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "RevokeUserSession",
-					Type: ExecRowsType,
+						strings.Join(fullSelectColumns, ",\n\t"),
+						// filtered_count subquery
+						userSessionsTableName, idColumn,
+						userSessionsTableName,
+						userSessionsTableName, belongsToUserColumn, belongsToUserColumn,
+						userSessionsTableName, revokedAtColumn,
+						userSessionsTableName, expiresAtColumn, currentTimeExpression,
+						userSessionsTableName, createdAtColumn, currentTimeExpression,
+						userSessionsTableName, createdAtColumn, currentTimeExpression,
+						// total_count subquery
+						userSessionsTableName, idColumn,
+						userSessionsTableName,
+						userSessionsTableName, belongsToUserColumn, belongsToUserColumn,
+						userSessionsTableName, revokedAtColumn,
+						userSessionsTableName, expiresAtColumn, currentTimeExpression,
+						// main query
+						userSessionsTableName,
+						userSessionsTableName, belongsToUserColumn, belongsToUserColumn,
+						userSessionsTableName, revokedAtColumn,
+						userSessionsTableName, expiresAtColumn, currentTimeExpression,
+						userSessionsTableName, createdAtColumn, currentTimeExpression,
+						userSessionsTableName, createdAtColumn, currentTimeExpression,
+						userSessionsTableName, idColumn,
+						userSessionsTableName, lastActiveAtColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
+				{
+					Annotation: QueryAnnotation{
+						Name: "RevokeUserSession",
+						Type: ExecRowsType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
 	%s = %s
 WHERE %s.%s = sqlc.arg(%s)
 	AND %s.%s = sqlc.arg(%s)
 	AND %s.%s IS NULL;`,
-					userSessionsTableName,
-					revokedAtColumn, currentTimeExpression,
-					userSessionsTableName, idColumn, idColumn,
-					userSessionsTableName, belongsToUserColumn, belongsToUserColumn,
-					userSessionsTableName, revokedAtColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "RevokeAllSessionsForUser",
-					Type: ExecRowsType,
+						userSessionsTableName,
+						revokedAtColumn, currentTimeExpression,
+						userSessionsTableName, idColumn, idColumn,
+						userSessionsTableName, belongsToUserColumn, belongsToUserColumn,
+						userSessionsTableName, revokedAtColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
+				{
+					Annotation: QueryAnnotation{
+						Name: "RevokeAllSessionsForUser",
+						Type: ExecRowsType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
 	%s = %s
 WHERE %s.%s = sqlc.arg(%s)
 	AND %s.%s IS NULL;`,
-					userSessionsTableName,
-					revokedAtColumn, currentTimeExpression,
-					userSessionsTableName, belongsToUserColumn, belongsToUserColumn,
-					userSessionsTableName, revokedAtColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "RevokeAllSessionsForUserExcept",
-					Type: ExecRowsType,
+						userSessionsTableName,
+						revokedAtColumn, currentTimeExpression,
+						userSessionsTableName, belongsToUserColumn, belongsToUserColumn,
+						userSessionsTableName, revokedAtColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
+				{
+					Annotation: QueryAnnotation{
+						Name: "RevokeAllSessionsForUserExcept",
+						Type: ExecRowsType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
 	%s = %s
 WHERE %s.%s = sqlc.arg(%s)
 	AND %s.%s != sqlc.arg(session_id)
 	AND %s.%s IS NULL;`,
-					userSessionsTableName,
-					revokedAtColumn, currentTimeExpression,
-					userSessionsTableName, belongsToUserColumn, belongsToUserColumn,
-					userSessionsTableName, idColumn,
-					userSessionsTableName, revokedAtColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "UpdateSessionTokenIDs",
-					Type: ExecRowsType,
+						userSessionsTableName,
+						revokedAtColumn, currentTimeExpression,
+						userSessionsTableName, belongsToUserColumn, belongsToUserColumn,
+						userSessionsTableName, idColumn,
+						userSessionsTableName, revokedAtColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
+				{
+					Annotation: QueryAnnotation{
+						Name: "UpdateSessionTokenIDs",
+						Type: ExecRowsType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
 	%s = sqlc.arg(%s),
 	%s = sqlc.arg(%s),
 	%s = sqlc.arg(%s),
 	%s = %s
 WHERE %s.%s = sqlc.arg(%s)
 	AND %s.%s IS NULL;`,
-					userSessionsTableName,
-					sessionTokenIDColumn, sessionTokenIDColumn,
-					refreshTokenIDColumn, refreshTokenIDColumn,
-					expiresAtColumn, expiresAtColumn,
-					lastActiveAtColumn, currentTimeExpression,
-					userSessionsTableName, idColumn, idColumn,
-					userSessionsTableName, revokedAtColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "TouchSessionLastActive",
-					Type: ExecRowsType,
+						userSessionsTableName,
+						sessionTokenIDColumn, sessionTokenIDColumn,
+						refreshTokenIDColumn, refreshTokenIDColumn,
+						expiresAtColumn, expiresAtColumn,
+						lastActiveAtColumn, currentTimeExpression,
+						userSessionsTableName, idColumn, idColumn,
+						userSessionsTableName, revokedAtColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
+				{
+					Annotation: QueryAnnotation{
+						Name: "TouchSessionLastActive",
+						Type: ExecRowsType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
 	%s = %s
 WHERE %s.%s = sqlc.arg(%s)
 	AND %s.%s IS NULL;`,
-					userSessionsTableName,
-					lastActiveAtColumn, currentTimeExpression,
-					userSessionsTableName, sessionTokenIDColumn, sessionTokenIDColumn,
-					userSessionsTableName, revokedAtColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CleanupExpiredSessions",
-					Type: ExecRowsType,
+						userSessionsTableName,
+						lastActiveAtColumn, currentTimeExpression,
+						userSessionsTableName, sessionTokenIDColumn, sessionTokenIDColumn,
+						userSessionsTableName, revokedAtColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
+				{
+					Annotation: QueryAnnotation{
+						Name: "CleanupExpiredSessions",
+						Type: ExecRowsType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
 	%s = %s
 WHERE %s.%s IS NULL
 	AND %s.%s < %s;`,
-					userSessionsTableName,
-					revokedAtColumn, currentTimeExpression,
-					userSessionsTableName, revokedAtColumn,
-					userSessionsTableName, expiresAtColumn, currentTimeExpression,
-				)),
+						userSessionsTableName,
+						revokedAtColumn, currentTimeExpression,
+						userSessionsTableName, revokedAtColumn,
+						userSessionsTableName, expiresAtColumn, currentTimeExpression,
+					)),
+				},
 			},
-		}
+		)
 	default:
 		return nil
 	}

--- a/backend/cmd/tools/codegen/queries/comments_comments.go
+++ b/backend/cmd/tools/codegen/queries/comments_comments.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"fmt"
+	"slices"
 	"strings"
+
+	"github.com/primandproper/platform-go/v11/database/querygen"
 
 	"github.com/cristalhq/builq"
 )
@@ -31,83 +34,35 @@ func buildCommentsQueries(database string) []*Query {
 	switch database {
 	case postgres:
 
-		insertColumns := filterForInsert(commentsColumns)
-
-		return []*Query{
-			{
-				Annotation: QueryAnnotation{
-					Name: "ArchiveComment",
-					Type: ExecRowsType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET %s = %s WHERE %s IS NULL AND %s = sqlc.arg(%s);`,
-					commentsTableName,
-					archivedAtColumn,
-					currentTimeExpression,
-					archivedAtColumn,
-					idColumn,
-					idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "ArchiveCommentsForReference",
-					Type: ExecRowsType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET %s = %s WHERE %s IS NULL
+		return slices.Concat(
+			querygen.StandardCRUD(commentsTableName, commentsColumns,
+				querygen.WithEntity("Comment", "Comments"),
+				querygen.WithNullable("parent_comment_id"),
+				querygen.WithOmitted(querygen.ExistsQuery, querygen.ListQuery, querygen.UpdateQuery),
+			),
+			[]*Query{
+				{
+					Annotation: QueryAnnotation{
+						Name: "ArchiveCommentsForReference",
+						Type: ExecRowsType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET %s = %s WHERE %s IS NULL
 	AND %s = sqlc.arg(target_type)
 	AND %s = sqlc.arg(referenced_id);`,
-					commentsTableName,
-					archivedAtColumn,
-					currentTimeExpression,
-					archivedAtColumn,
-					"target_type",
-					"referenced_id",
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CreateComment",
-					Type: ExecType,
+						commentsTableName,
+						archivedAtColumn,
+						currentTimeExpression,
+						archivedAtColumn,
+						"target_type",
+						"referenced_id",
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`INSERT INTO %s (
-	%s
-) VALUES (
-	%s
-);`,
-					commentsTableName,
-					strings.Join(insertColumns, ",\n\t"),
-					strings.Join(applyToEach(insertColumns, func(_ int, s string) string {
-						if s == "parent_comment_id" {
-							return "sqlc.narg(parent_comment_id)"
-						}
-						return fmt.Sprintf("sqlc.arg(%s)", s)
-					}), ",\n\t"),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetComment",
-					Type: OneType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
-	%s
-FROM %s
-WHERE %s.%s IS NULL
-	AND %s.%s = sqlc.arg(%s);`,
-					strings.Join(applyToEach(commentsColumns, func(i int, s string) string {
-						return fmt.Sprintf("%s.%s", commentsTableName, s)
-					}), ",\n\t"),
-					commentsTableName,
-					commentsTableName, archivedAtColumn,
-					commentsTableName, idColumn, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetCommentsForReference",
-					Type: ManyType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetCommentsForReference",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s
@@ -117,31 +72,31 @@ WHERE %s.%s IS NULL
 	AND %s.%s = sqlc.arg(referenced_id)
 	%s
 %s;`,
-					strings.Join(applyToEach(commentsColumns, func(i int, s string) string {
-						return fmt.Sprintf("%s.%s", commentsTableName, s)
-					}), ",\n\t"),
-					buildFilterCountSelect(commentsTableName, true, true, []string{},
-						fmt.Sprintf("%s.%s = sqlc.arg(target_type)", commentsTableName, "target_type"),
-						fmt.Sprintf("%s.%s = sqlc.arg(referenced_id)", commentsTableName, "referenced_id")),
-					buildTotalCountSelect(commentsTableName, true, []string{},
-						fmt.Sprintf("%s.%s = sqlc.arg(target_type)", commentsTableName, "target_type"),
-						fmt.Sprintf("%s.%s = sqlc.arg(referenced_id)", commentsTableName, "referenced_id")),
-					commentsTableName,
-					commentsTableName, archivedAtColumn,
-					commentsTableName, "target_type",
-					commentsTableName, "referenced_id",
-					buildFilterConditions(commentsTableName, true, true,
-						fmt.Sprintf("%s.%s = sqlc.arg(target_type)", commentsTableName, "target_type"),
-						fmt.Sprintf("%s.%s = sqlc.arg(referenced_id)", commentsTableName, "referenced_id")),
-					buildCursorLimitClause(commentsTableName),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetCommentsForUser",
-					Type: ManyType,
+						strings.Join(applyToEach(commentsColumns, func(i int, s string) string {
+							return fmt.Sprintf("%s.%s", commentsTableName, s)
+						}), ",\n\t"),
+						buildFilterCountSelect(commentsTableName, true, true, []string{},
+							fmt.Sprintf("%s.%s = sqlc.arg(target_type)", commentsTableName, "target_type"),
+							fmt.Sprintf("%s.%s = sqlc.arg(referenced_id)", commentsTableName, "referenced_id")),
+						buildTotalCountSelect(commentsTableName, true, []string{},
+							fmt.Sprintf("%s.%s = sqlc.arg(target_type)", commentsTableName, "target_type"),
+							fmt.Sprintf("%s.%s = sqlc.arg(referenced_id)", commentsTableName, "referenced_id")),
+						commentsTableName,
+						commentsTableName, archivedAtColumn,
+						commentsTableName, "target_type",
+						commentsTableName, "referenced_id",
+						buildFilterConditions(commentsTableName, true, true,
+							fmt.Sprintf("%s.%s = sqlc.arg(target_type)", commentsTableName, "target_type"),
+							fmt.Sprintf("%s.%s = sqlc.arg(referenced_id)", commentsTableName, "referenced_id")),
+						buildCursorLimitClause(commentsTableName),
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetCommentsForUser",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s
@@ -150,43 +105,44 @@ WHERE %s.%s IS NULL
 	AND %s.%s = sqlc.arg(%s)
 	%s
 %s;`,
-					strings.Join(applyToEach(commentsColumns, func(i int, s string) string {
-						return fmt.Sprintf("%s.%s", commentsTableName, s)
-					}), ",\n\t"),
-					buildFilterCountSelect(commentsTableName, true, true, []string{},
-						fmt.Sprintf("%s.%s = sqlc.arg(%s)", commentsTableName, belongsToUserColumn, belongsToUserColumn)),
-					buildTotalCountSelect(commentsTableName, true, []string{},
-						fmt.Sprintf("%s.%s = sqlc.arg(%s)", commentsTableName, belongsToUserColumn, belongsToUserColumn)),
-					commentsTableName,
-					commentsTableName, archivedAtColumn,
-					commentsTableName, belongsToUserColumn, belongsToUserColumn,
-					buildFilterConditions(commentsTableName, true, true,
-						fmt.Sprintf("%s.%s = sqlc.arg(%s)", commentsTableName, belongsToUserColumn, belongsToUserColumn)),
-					buildCursorLimitClause(commentsTableName),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "UpdateComment",
-					Type: ExecRowsType,
+						strings.Join(applyToEach(commentsColumns, func(i int, s string) string {
+							return fmt.Sprintf("%s.%s", commentsTableName, s)
+						}), ",\n\t"),
+						buildFilterCountSelect(commentsTableName, true, true, []string{},
+							fmt.Sprintf("%s.%s = sqlc.arg(%s)", commentsTableName, belongsToUserColumn, belongsToUserColumn)),
+						buildTotalCountSelect(commentsTableName, true, []string{},
+							fmt.Sprintf("%s.%s = sqlc.arg(%s)", commentsTableName, belongsToUserColumn, belongsToUserColumn)),
+						commentsTableName,
+						commentsTableName, archivedAtColumn,
+						commentsTableName, belongsToUserColumn, belongsToUserColumn,
+						buildFilterConditions(commentsTableName, true, true,
+							fmt.Sprintf("%s.%s = sqlc.arg(%s)", commentsTableName, belongsToUserColumn, belongsToUserColumn)),
+						buildCursorLimitClause(commentsTableName),
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
+				{
+					Annotation: QueryAnnotation{
+						Name: "UpdateComment",
+						Type: ExecRowsType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
 	%s,
 	%s = %s
 WHERE %s IS NULL
 	AND %s = sqlc.arg(%s)
 	AND %s = sqlc.arg(%s);`,
-					commentsTableName,
-					strings.Join(applyToEach(filterForUpdate(commentsColumns, "target_type", "referenced_id", belongsToUserColumn, "parent_comment_id"), func(i int, s string) string {
-						return fmt.Sprintf("%s = sqlc.arg(%s)", s, s)
-					}), ",\n\t"),
-					lastUpdatedAtColumn, currentTimeExpression,
-					archivedAtColumn,
-					idColumn, idColumn,
-					belongsToUserColumn, belongsToUserColumn,
-				)),
+						commentsTableName,
+						strings.Join(applyToEach(filterForUpdate(commentsColumns, "target_type", "referenced_id", belongsToUserColumn, "parent_comment_id"), func(i int, s string) string {
+							return fmt.Sprintf("%s = sqlc.arg(%s)", s, s)
+						}), ",\n\t"),
+						lastUpdatedAtColumn, currentTimeExpression,
+						archivedAtColumn,
+						idColumn, idColumn,
+						belongsToUserColumn, belongsToUserColumn,
+					)),
+				},
 			},
-		}
+		)
 	default:
 		return nil
 	}

--- a/backend/cmd/tools/codegen/queries/identity_account_invitations.go
+++ b/backend/cmd/tools/codegen/queries/identity_account_invitations.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"fmt"
+	"slices"
 	"strings"
+
+	"github.com/primandproper/platform-go/v11/database/querygen"
 
 	"github.com/cristalhq/builq"
 )
@@ -44,11 +47,6 @@ func buildAccountInvitationsQueries(database string) []*Query {
 	switch database {
 	case postgres:
 
-		insertColumns := filterForInsert(accountInvitationsColumns,
-			"status",
-			"status_note",
-		)
-
 		userWithAvatarColumns := append(
 			applyToEach(usersColumns, func(i int, s string) string {
 				return fmt.Sprintf("%s.%s as user_%s", usersTableName, s, s)
@@ -68,79 +66,51 @@ func buildAccountInvitationsQueries(database string) []*Query {
 			1,
 		)
 
-		return []*Query{
-			{
-				Annotation: QueryAnnotation{
-					Name: "AttachAccountInvitationsToUserID",
-					Type: ExecRowsType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
+		return slices.Concat(
+			querygen.StandardCRUD(accountInvitationsTableName, accountInvitationsColumns,
+				querygen.WithEntity("AccountInvitation", "AccountInvitations"),
+				querygen.WithDatabaseOwned("status", accountInvitationsStatusNoteColumn),
+				querygen.WithOmitted(querygen.ArchiveQuery, querygen.GetQuery, querygen.ListQuery, querygen.UpdateQuery),
+			),
+			[]*Query{
+				{
+					Annotation: QueryAnnotation{
+						Name: "AttachAccountInvitationsToUserID",
+						Type: ExecRowsType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
 	%s = sqlc.arg(%s),
 	%s = %s
 WHERE %s IS NULL
 	AND %s = LOWER(sqlc.arg(%s));`,
-					accountInvitationsTableName,
-					toUserColumn, toUserColumn,
-					lastUpdatedAtColumn, currentTimeExpression,
-					archivedAtColumn,
-					toEmailColumn, toEmailColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CreateAccountInvitation",
-					Type: ExecType,
+						accountInvitationsTableName,
+						toUserColumn, toUserColumn,
+						lastUpdatedAtColumn, currentTimeExpression,
+						archivedAtColumn,
+						toEmailColumn, toEmailColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`INSERT INTO %s (
-	%s
-) VALUES (
-	%s
-);`,
-					accountInvitationsTableName,
-					strings.Join(insertColumns, ",\n\t"),
-					strings.Join(applyToEach(insertColumns, func(_ int, s string) string {
-						return fmt.Sprintf("sqlc.arg(%s)", s)
-					}), ",\n\t"),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "AssignInvitationsToUserByEmail",
-					Type: ExecRowsType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
+				{
+					Annotation: QueryAnnotation{
+						Name: "AssignInvitationsToUserByEmail",
+						Type: ExecRowsType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
 	%s = sqlc.arg(%s),
 	last_updated_at = NOW()
 WHERE archived_at IS NULL
 	AND %s = LOWER(sqlc.arg(%s))`,
-					accountInvitationsTableName,
-					toUserColumn, toUserColumn,
-					toEmailColumn, emailAddressColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CheckAccountInvitationExistence",
-					Type: OneType,
+						accountInvitationsTableName,
+						toUserColumn, toUserColumn,
+						toEmailColumn, emailAddressColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT EXISTS (
-	SELECT %s.%s
-	FROM %s
-	WHERE %s.%s IS NULL
-	AND %s.%s = sqlc.arg(%s)
-);`,
-					accountInvitationsTableName, idColumn,
-					accountInvitationsTableName,
-					accountInvitationsTableName, archivedAtColumn,
-					accountInvitationsTableName, idColumn, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetAccountInvitationByEmailAndToken",
-					Type: OneType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetAccountInvitationByEmailAndToken",
+						Type: OneType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s
 FROM %s
 	JOIN %s ON %s.%s = %s.%s
@@ -150,183 +120,184 @@ WHERE %s.%s IS NULL
 	AND %s.%s > %s
 	AND %s.%s = LOWER(sqlc.arg(%s))
 	AND %s.%s = sqlc.arg(%s);`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					accountInvitationsTableName,
-					accountsTableName, accountInvitationsTableName, destinationAccountColumn, accountsTableName, idColumn,
-					usersTableName, accountInvitationsTableName, fromUserColumn, usersTableName, idColumn,
-					avatarJoinClause,
-					accountInvitationsTableName, archivedAtColumn,
-					accountInvitationsTableName, accountInvitationsExpiresAtColumn, currentTimeExpression,
-					accountInvitationsTableName, toEmailColumn, toEmailColumn,
-					accountInvitationsTableName, accountInvitationsTokenColumn, accountInvitationsTokenColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetAccountInvitationByAccountAndID",
-					Type: OneType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
-	%s
-FROM %s
-	JOIN %s ON %s.%s = %s.%s
-	JOIN %s ON %s.%s = %s.%s
-	%s
-WHERE %s.%s IS NULL
-	AND %s.%s > %s
-	AND %s.%s = sqlc.arg(%s)
-	AND %s.%s = sqlc.arg(%s);`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					accountInvitationsTableName,
-					accountsTableName, accountInvitationsTableName, destinationAccountColumn, accountsTableName, idColumn,
-					usersTableName, accountInvitationsTableName, fromUserColumn, usersTableName, idColumn,
-					avatarJoinClause,
-					accountInvitationsTableName, archivedAtColumn,
-					accountInvitationsTableName, accountInvitationsExpiresAtColumn, currentTimeExpression,
-					accountInvitationsTableName, destinationAccountColumn, destinationAccountColumn,
-					accountInvitationsTableName, idColumn, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetAccountInvitationByTokenAndID",
-					Type: OneType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
-	%s
-FROM %s
-	JOIN %s ON %s.%s = %s.%s
-	JOIN %s ON %s.%s = %s.%s
-	%s
-WHERE %s.%s IS NULL
-	AND %s.%s > %s
-	AND %s.%s = sqlc.arg(%s)
-	AND %s.%s = sqlc.arg(%s);`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					accountInvitationsTableName,
-					accountsTableName, accountInvitationsTableName, destinationAccountColumn, accountsTableName, idColumn,
-					usersTableName, accountInvitationsTableName, fromUserColumn, usersTableName, idColumn,
-					avatarJoinClause,
-					accountInvitationsTableName, archivedAtColumn,
-					accountInvitationsTableName, accountInvitationsExpiresAtColumn, currentTimeExpression,
-					accountInvitationsTableName, accountInvitationsTokenColumn, accountInvitationsTokenColumn,
-					accountInvitationsTableName, idColumn, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetAccountInvitationByToken",
-					Type: OneType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
-	%s
-FROM %s
-	JOIN %s ON %s.%s = %s.%s
-	JOIN %s ON %s.%s = %s.%s
-	%s
-WHERE %s.%s IS NULL
-	AND %s.%s > %s
-	AND %s.%s = sqlc.arg(%s);`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					accountInvitationsTableName,
-					accountsTableName, accountInvitationsTableName, destinationAccountColumn, accountsTableName, idColumn,
-					usersTableName, accountInvitationsTableName, fromUserColumn, usersTableName, idColumn,
-					avatarJoinClause,
-					accountInvitationsTableName, archivedAtColumn,
-					accountInvitationsTableName, accountInvitationsExpiresAtColumn, currentTimeExpression,
-					accountInvitationsTableName, accountInvitationsTokenColumn, accountInvitationsTokenColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetPendingInvitesFromUser",
-					Type: ManyType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
-	%s,
-	%s,
-	%s
-FROM %s
-	JOIN %s ON %s.%s = %s.%s
-	JOIN %s ON %s.%s = %s.%s
-	%s
-WHERE %s.%s IS NULL
-	AND %s.%s = sqlc.arg(%s)
-	AND %s.%s = sqlc.arg(%s)
-	%s
-%s;`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					buildFilterCountSelect(accountInvitationsTableName, true, true, []string{}),
-					buildTotalCountSelect(accountInvitationsTableName, true, []string{}),
-					accountInvitationsTableName,
-					accountsTableName, accountInvitationsTableName, destinationAccountColumn, accountsTableName, idColumn,
-					usersTableName, accountInvitationsTableName, fromUserColumn, usersTableName, idColumn,
-					avatarJoinClause,
-					accountInvitationsTableName, archivedAtColumn,
-					accountInvitationsTableName, fromUserColumn, fromUserColumn,
-					accountInvitationsTableName, accountInvitationsStatusColumn, accountInvitationsStatusColumn,
-					buildFilterConditions(accountInvitationsTableName, true, false),
-					buildCursorLimitClause(accountInvitationsTableName),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetPendingInvitesForUser",
-					Type: ManyType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
-	%s,
-	%s,
-	%s
-FROM %s
-	JOIN %s ON %s.%s = %s.%s
-	JOIN %s ON %s.%s = %s.%s
-	%s
-WHERE %s.%s IS NULL
-	AND %s.%s = sqlc.arg(%s)
-	AND %s.%s = sqlc.arg(%s)
-	%s
-%s;`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					buildFilterCountSelect(accountInvitationsTableName, true, true, []string{}),
-					buildTotalCountSelect(accountInvitationsTableName, true, []string{}),
-					accountInvitationsTableName,
-					accountsTableName, accountInvitationsTableName, destinationAccountColumn, accountsTableName, idColumn,
-					usersTableName, accountInvitationsTableName, fromUserColumn, usersTableName, idColumn,
-					avatarJoinClause,
-					accountInvitationsTableName, archivedAtColumn,
-					accountInvitationsTableName, toUserColumn, toUserColumn,
-					accountInvitationsTableName, accountInvitationsStatusColumn, accountInvitationsStatusColumn,
-					buildFilterConditions(
+						strings.Join(fullSelectColumns, ",\n\t"),
 						accountInvitationsTableName,
-						true,
-						true,
-					),
-					buildCursorLimitClause(accountInvitationsTableName),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "SetAccountInvitationStatus",
-					Type: ExecType,
+						accountsTableName, accountInvitationsTableName, destinationAccountColumn, accountsTableName, idColumn,
+						usersTableName, accountInvitationsTableName, fromUserColumn, usersTableName, idColumn,
+						avatarJoinClause,
+						accountInvitationsTableName, archivedAtColumn,
+						accountInvitationsTableName, accountInvitationsExpiresAtColumn, currentTimeExpression,
+						accountInvitationsTableName, toEmailColumn, toEmailColumn,
+						accountInvitationsTableName, accountInvitationsTokenColumn, accountInvitationsTokenColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetAccountInvitationByAccountAndID",
+						Type: OneType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+	%s
+FROM %s
+	JOIN %s ON %s.%s = %s.%s
+	JOIN %s ON %s.%s = %s.%s
+	%s
+WHERE %s.%s IS NULL
+	AND %s.%s > %s
+	AND %s.%s = sqlc.arg(%s)
+	AND %s.%s = sqlc.arg(%s);`,
+						strings.Join(fullSelectColumns, ",\n\t"),
+						accountInvitationsTableName,
+						accountsTableName, accountInvitationsTableName, destinationAccountColumn, accountsTableName, idColumn,
+						usersTableName, accountInvitationsTableName, fromUserColumn, usersTableName, idColumn,
+						avatarJoinClause,
+						accountInvitationsTableName, archivedAtColumn,
+						accountInvitationsTableName, accountInvitationsExpiresAtColumn, currentTimeExpression,
+						accountInvitationsTableName, destinationAccountColumn, destinationAccountColumn,
+						accountInvitationsTableName, idColumn, idColumn,
+					)),
+				},
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetAccountInvitationByTokenAndID",
+						Type: OneType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+	%s
+FROM %s
+	JOIN %s ON %s.%s = %s.%s
+	JOIN %s ON %s.%s = %s.%s
+	%s
+WHERE %s.%s IS NULL
+	AND %s.%s > %s
+	AND %s.%s = sqlc.arg(%s)
+	AND %s.%s = sqlc.arg(%s);`,
+						strings.Join(fullSelectColumns, ",\n\t"),
+						accountInvitationsTableName,
+						accountsTableName, accountInvitationsTableName, destinationAccountColumn, accountsTableName, idColumn,
+						usersTableName, accountInvitationsTableName, fromUserColumn, usersTableName, idColumn,
+						avatarJoinClause,
+						accountInvitationsTableName, archivedAtColumn,
+						accountInvitationsTableName, accountInvitationsExpiresAtColumn, currentTimeExpression,
+						accountInvitationsTableName, accountInvitationsTokenColumn, accountInvitationsTokenColumn,
+						accountInvitationsTableName, idColumn, idColumn,
+					)),
+				},
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetAccountInvitationByToken",
+						Type: OneType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+	%s
+FROM %s
+	JOIN %s ON %s.%s = %s.%s
+	JOIN %s ON %s.%s = %s.%s
+	%s
+WHERE %s.%s IS NULL
+	AND %s.%s > %s
+	AND %s.%s = sqlc.arg(%s);`,
+						strings.Join(fullSelectColumns, ",\n\t"),
+						accountInvitationsTableName,
+						accountsTableName, accountInvitationsTableName, destinationAccountColumn, accountsTableName, idColumn,
+						usersTableName, accountInvitationsTableName, fromUserColumn, usersTableName, idColumn,
+						avatarJoinClause,
+						accountInvitationsTableName, archivedAtColumn,
+						accountInvitationsTableName, accountInvitationsExpiresAtColumn, currentTimeExpression,
+						accountInvitationsTableName, accountInvitationsTokenColumn, accountInvitationsTokenColumn,
+					)),
+				},
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetPendingInvitesFromUser",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+	%s,
+	%s,
+	%s
+FROM %s
+	JOIN %s ON %s.%s = %s.%s
+	JOIN %s ON %s.%s = %s.%s
+	%s
+WHERE %s.%s IS NULL
+	AND %s.%s = sqlc.arg(%s)
+	AND %s.%s = sqlc.arg(%s)
+	%s
+%s;`,
+						strings.Join(fullSelectColumns, ",\n\t"),
+						buildFilterCountSelect(accountInvitationsTableName, true, true, []string{}),
+						buildTotalCountSelect(accountInvitationsTableName, true, []string{}),
+						accountInvitationsTableName,
+						accountsTableName, accountInvitationsTableName, destinationAccountColumn, accountsTableName, idColumn,
+						usersTableName, accountInvitationsTableName, fromUserColumn, usersTableName, idColumn,
+						avatarJoinClause,
+						accountInvitationsTableName, archivedAtColumn,
+						accountInvitationsTableName, fromUserColumn, fromUserColumn,
+						accountInvitationsTableName, accountInvitationsStatusColumn, accountInvitationsStatusColumn,
+						buildFilterConditions(accountInvitationsTableName, true, false),
+						buildCursorLimitClause(accountInvitationsTableName),
+					)),
+				},
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetPendingInvitesForUser",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+	%s,
+	%s,
+	%s
+FROM %s
+	JOIN %s ON %s.%s = %s.%s
+	JOIN %s ON %s.%s = %s.%s
+	%s
+WHERE %s.%s IS NULL
+	AND %s.%s = sqlc.arg(%s)
+	AND %s.%s = sqlc.arg(%s)
+	%s
+%s;`,
+						strings.Join(fullSelectColumns, ",\n\t"),
+						buildFilterCountSelect(accountInvitationsTableName, true, true, []string{}),
+						buildTotalCountSelect(accountInvitationsTableName, true, []string{}),
+						accountInvitationsTableName,
+						accountsTableName, accountInvitationsTableName, destinationAccountColumn, accountsTableName, idColumn,
+						usersTableName, accountInvitationsTableName, fromUserColumn, usersTableName, idColumn,
+						avatarJoinClause,
+						accountInvitationsTableName, archivedAtColumn,
+						accountInvitationsTableName, toUserColumn, toUserColumn,
+						accountInvitationsTableName, accountInvitationsStatusColumn, accountInvitationsStatusColumn,
+						buildFilterConditions(
+							accountInvitationsTableName,
+							true,
+							true,
+						),
+						buildCursorLimitClause(accountInvitationsTableName),
+					)),
+				},
+				{
+					Annotation: QueryAnnotation{
+						Name: "SetAccountInvitationStatus",
+						Type: ExecType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
 	%s = sqlc.arg(%s),
 	%s = sqlc.arg(%s),
 	%s = %s,
 	%s = %s
 WHERE %s IS NULL
 	AND %s = sqlc.arg(%s);`,
-					accountInvitationsTableName,
-					accountInvitationsStatusColumn, accountInvitationsStatusColumn,
-					accountInvitationsStatusNoteColumn, accountInvitationsStatusNoteColumn,
-					lastUpdatedAtColumn, currentTimeExpression,
-					archivedAtColumn, currentTimeExpression,
-					archivedAtColumn,
-					idColumn, idColumn,
-				)),
+						accountInvitationsTableName,
+						accountInvitationsStatusColumn, accountInvitationsStatusColumn,
+						accountInvitationsStatusNoteColumn, accountInvitationsStatusNoteColumn,
+						lastUpdatedAtColumn, currentTimeExpression,
+						archivedAtColumn, currentTimeExpression,
+						archivedAtColumn,
+						idColumn, idColumn,
+					)),
+				},
 			},
-		}
+		)
 	default:
 		return nil
 	}

--- a/backend/cmd/tools/codegen/queries/identity_account_user_memberships.go
+++ b/backend/cmd/tools/codegen/queries/identity_account_user_memberships.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"fmt"
+	"slices"
 	"strings"
+
+	"github.com/primandproper/platform-go/v11/database/querygen"
 
 	"github.com/cristalhq/builq"
 )
@@ -31,176 +34,167 @@ func buildAccountUserMembershipsQueries(database string) []*Query {
 	switch database {
 	case postgres:
 
-		return []*Query{
-			{
-				Annotation: QueryAnnotation{
-					Name: "AddUserToAccount",
-					Type: ExecType,
+		return slices.Concat(
+			querygen.StandardCRUD(accountUserMembershipsTableName, accountUserMembershipsColumns,
+				querygen.WithEntity("AccountUserMemberships", "AccountUserMembershipss"),
+				querygen.WithDatabaseOwned(defaultAccountColumn),
+				querygen.WithQueryName(querygen.CreateQuery, "AddUserToAccount"),
+				querygen.WithOmitted(querygen.ArchiveQuery, querygen.ExistsQuery, querygen.GetQuery, querygen.ListQuery, querygen.UpdateQuery),
+			),
+			[]*Query{
+				{
+					Annotation: QueryAnnotation{
+						Name: "ArchiveUserMemberships",
+						Type: ExecRowsType,
+					},
+					Content: buildUpdateAccountMembershipsQuery(belongsToUserColumn, []string{}),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`INSERT INTO %s (
+				{
+					Annotation: QueryAnnotation{
+						Name: "CreateAccountUserMembershipForNewUser",
+						Type: ExecType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`INSERT INTO %s (
 	%s
 ) VALUES (
 	%s
 );`,
-					accountUserMembershipsTableName,
-					strings.Join(filterForInsert(accountUserMembershipsColumns, "default_account"), ",\n\t"),
-					strings.Join(applyToEach(filterForInsert(accountUserMembershipsColumns, "default_account"), func(i int, s string) string {
-						return fmt.Sprintf("sqlc.arg(%s)", s)
-					}), ",\n\t"),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "ArchiveUserMemberships",
-					Type: ExecRowsType,
+						accountUserMembershipsTableName,
+						strings.Join(filterForInsert(accountUserMembershipsColumns), ",\n\t"),
+						strings.Join(applyToEach(filterForInsert(accountUserMembershipsColumns), func(i int, s string) string {
+							return fmt.Sprintf("sqlc.arg(%s)", s)
+						}), ",\n\t"),
+					)),
 				},
-				Content: buildUpdateAccountMembershipsQuery(belongsToUserColumn, []string{}),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CreateAccountUserMembershipForNewUser",
-					Type: ExecType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`INSERT INTO %s (
-	%s
-) VALUES (
-	%s
-);`,
-					accountUserMembershipsTableName,
-					strings.Join(filterForInsert(accountUserMembershipsColumns), ",\n\t"),
-					strings.Join(applyToEach(filterForInsert(accountUserMembershipsColumns), func(i int, s string) string {
-						return fmt.Sprintf("sqlc.arg(%s)", s)
-					}), ",\n\t"),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetDefaultAccountIDForUser",
-					Type: OneType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT %s.%s
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetDefaultAccountIDForUser",
+						Type: OneType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT %s.%s
 FROM %s
 	JOIN %s ON %s.%s = %s.%s
 WHERE %s.%s = sqlc.arg(%s)
 	AND %s.%s = TRUE;`,
-					accountsTableName, idColumn,
-					accountsTableName,
-					accountUserMembershipsTableName, accountUserMembershipsTableName, belongsToAccountColumn, accountsTableName, idColumn,
-					accountUserMembershipsTableName, belongsToUserColumn, belongsToUserColumn,
-					accountUserMembershipsTableName, defaultAccountColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetAccountUserMembershipsForUser",
-					Type: ManyType,
+						accountsTableName, idColumn,
+						accountsTableName,
+						accountUserMembershipsTableName, accountUserMembershipsTableName, belongsToAccountColumn, accountsTableName, idColumn,
+						accountUserMembershipsTableName, belongsToUserColumn, belongsToUserColumn,
+						accountUserMembershipsTableName, defaultAccountColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetAccountUserMembershipsForUser",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s
 FROM %s
 	JOIN %s ON %s.%s = %s.%s
 WHERE %s.%s IS NULL
 	AND %s.%s = sqlc.arg(%s);`,
-					strings.Join(applyToEach(accountUserMembershipsColumns, func(i int, s string) string {
-						return fmt.Sprintf("%s.%s", accountUserMembershipsTableName, s)
-					}), ",\n\t"),
-					accountUserMembershipsTableName,
-					accountsTableName, accountsTableName, idColumn, accountUserMembershipsTableName, belongsToAccountColumn,
-					accountUserMembershipsTableName, archivedAtColumn,
-					accountUserMembershipsTableName, belongsToUserColumn, belongsToUserColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "MarkAccountUserMembershipAsUserDefault",
-					Type: ExecType,
+						strings.Join(applyToEach(accountUserMembershipsColumns, func(i int, s string) string {
+							return fmt.Sprintf("%s.%s", accountUserMembershipsTableName, s)
+						}), ",\n\t"),
+						accountUserMembershipsTableName,
+						accountsTableName, accountsTableName, idColumn, accountUserMembershipsTableName, belongsToAccountColumn,
+						accountUserMembershipsTableName, archivedAtColumn,
+						accountUserMembershipsTableName, belongsToUserColumn, belongsToUserColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
+				{
+					Annotation: QueryAnnotation{
+						Name: "MarkAccountUserMembershipAsUserDefault",
+						Type: ExecType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
 	%s = (%s = sqlc.arg(%s) AND %s = sqlc.arg(%s))
 WHERE %s IS NULL
 	AND %s = sqlc.arg(%s);`,
-					accountUserMembershipsTableName,
-					defaultAccountColumn, belongsToUserColumn, belongsToUserColumn, belongsToAccountColumn, belongsToAccountColumn,
-					archivedAtColumn,
-					belongsToUserColumn, belongsToUserColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "RemoveUserFromAccount",
-					Type: ExecType,
+						accountUserMembershipsTableName,
+						defaultAccountColumn, belongsToUserColumn, belongsToUserColumn, belongsToAccountColumn, belongsToAccountColumn,
+						archivedAtColumn,
+						belongsToUserColumn, belongsToUserColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
+				{
+					Annotation: QueryAnnotation{
+						Name: "RemoveUserFromAccount",
+						Type: ExecType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
 	%s = %s,
 	%s = 'false'
 WHERE %s.%s IS NULL
 	AND %s.%s = sqlc.arg(%s)
 	AND %s.%s = sqlc.arg(%s);`,
-					accountUserMembershipsTableName,
-					archivedAtColumn, currentTimeExpression,
-					defaultAccountColumn,
-					accountUserMembershipsTableName, archivedAtColumn,
-					accountUserMembershipsTableName, belongsToAccountColumn, belongsToAccountColumn,
-					accountUserMembershipsTableName, belongsToUserColumn, belongsToUserColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "TransferAccountMembership",
-					Type: ExecType,
+						accountUserMembershipsTableName,
+						archivedAtColumn, currentTimeExpression,
+						defaultAccountColumn,
+						accountUserMembershipsTableName, archivedAtColumn,
+						accountUserMembershipsTableName, belongsToAccountColumn, belongsToAccountColumn,
+						accountUserMembershipsTableName, belongsToUserColumn, belongsToUserColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
+				{
+					Annotation: QueryAnnotation{
+						Name: "TransferAccountMembership",
+						Type: ExecType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
 	%s = sqlc.arg(%s)
 WHERE %s IS NULL
 	AND %s = sqlc.arg(%s)
 	AND %s = sqlc.arg(%s);`,
-					accountUserMembershipsTableName,
-					belongsToUserColumn,
-					belongsToUserColumn,
-					archivedAtColumn,
-					belongsToAccountColumn,
-					belongsToAccountColumn,
-					belongsToUserColumn,
-					belongsToUserColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "TransferAccountOwnership",
-					Type: ExecType,
+						accountUserMembershipsTableName,
+						belongsToUserColumn,
+						belongsToUserColumn,
+						archivedAtColumn,
+						belongsToAccountColumn,
+						belongsToAccountColumn,
+						belongsToUserColumn,
+						belongsToUserColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
+				{
+					Annotation: QueryAnnotation{
+						Name: "TransferAccountOwnership",
+						Type: ExecType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
 	%s = sqlc.arg(new_owner)
 WHERE %s IS NULL
 	AND %s = sqlc.arg(old_owner)
 	AND %s = sqlc.arg(account_id);`,
-					accountsTableName,
-					belongsToUserColumn,
-					archivedAtColumn,
-					belongsToUserColumn,
-					idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "UserIsAccountMember",
-					Type: OneType,
+						accountsTableName,
+						belongsToUserColumn,
+						archivedAtColumn,
+						belongsToUserColumn,
+						idColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT EXISTS (
+				{
+					Annotation: QueryAnnotation{
+						Name: "UserIsAccountMember",
+						Type: OneType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT EXISTS (
 	SELECT %s.%s
 	FROM %s
 	WHERE %s.%s IS NULL
 		AND %s.%s = sqlc.arg(%s)
 		AND %s.%s = sqlc.arg(%s)
 );`,
-					accountUserMembershipsTableName, idColumn,
-					accountUserMembershipsTableName,
-					accountUserMembershipsTableName, archivedAtColumn,
-					accountUserMembershipsTableName, belongsToAccountColumn, belongsToAccountColumn,
-					accountUserMembershipsTableName, belongsToUserColumn, belongsToUserColumn,
-				)),
+						accountUserMembershipsTableName, idColumn,
+						accountUserMembershipsTableName,
+						accountUserMembershipsTableName, archivedAtColumn,
+						accountUserMembershipsTableName, belongsToAccountColumn, belongsToAccountColumn,
+						accountUserMembershipsTableName, belongsToUserColumn, belongsToUserColumn,
+					)),
+				},
 			},
-		}
+		)
 	default:
 		return nil
 	}

--- a/backend/cmd/tools/codegen/queries/identity_accounts.go
+++ b/backend/cmd/tools/codegen/queries/identity_accounts.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"fmt"
+	"slices"
 	"strings"
+
+	"github.com/primandproper/platform-go/v11/database/querygen"
 
 	"github.com/cristalhq/builq"
 )
@@ -46,83 +49,60 @@ func buildAccountsQueries(database string) []*Query {
 	switch database {
 	case postgres:
 
-		insertColumns := filterForInsert(accountsColumns)
-
-		return []*Query{
-			{
-				Annotation: QueryAnnotation{
-					Name: "AddToAccountDuringCreation",
-					Type: ExecType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`INSERT INTO account_user_memberships (
+		return slices.Concat(
+			querygen.StandardCRUD(accountsTableName, accountsColumns,
+				querygen.WithEntity("Account", "Accounts"),
+				querygen.WithOwnership(belongsToUserColumn),
+				querygen.WithDatabaseOwned("payment_processor_customer_id", "subscription_plan_id", "time_zone", "last_payment_provider_sync_occurred_at"),
+				querygen.WithImmutable("billing_status", webhookHMACSecretColumn),
+				querygen.WithOmitted(querygen.ArchiveQuery, querygen.ExistsQuery, querygen.GetQuery, querygen.ListQuery),
+			),
+			[]*Query{
+				{
+					Annotation: QueryAnnotation{
+						Name: "AddToAccountDuringCreation",
+						Type: ExecType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`INSERT INTO account_user_memberships (
 	%s
 ) VALUES (
 	%s
 );`,
-					strings.Join(filterForInsert(accountUserMembershipsColumns, "default_account"), ",\n\t"),
-					strings.Join(applyToEach(filterForInsert(accountUserMembershipsColumns, "default_account"), func(_ int, s string) string {
-						return fmt.Sprintf("sqlc.arg(%s)", s)
-					}), ",\n\t"),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "ArchiveAccount",
-					Type: ExecRowsType,
+						strings.Join(filterForInsert(accountUserMembershipsColumns, "default_account"), ",\n\t"),
+						strings.Join(applyToEach(filterForInsert(accountUserMembershipsColumns, "default_account"), func(_ int, s string) string {
+							return fmt.Sprintf("sqlc.arg(%s)", s)
+						}), ",\n\t"),
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
+				{
+					Annotation: QueryAnnotation{
+						Name: "ArchiveAccount",
+						Type: ExecRowsType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
 	%s = %s,
 	%s = %s
 WHERE %s IS NULL
 	AND %s = sqlc.arg(%s)
 	AND %s = sqlc.arg(%s);`,
-					accountsTableName,
-					lastUpdatedAtColumn,
-					currentTimeExpression,
-					archivedAtColumn,
-					currentTimeExpression,
-					archivedAtColumn,
-					belongsToUserColumn,
-					belongsToUserColumn,
-					idColumn,
-					idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CreateAccount",
-					Type: ExecType,
+						accountsTableName,
+						lastUpdatedAtColumn,
+						currentTimeExpression,
+						archivedAtColumn,
+						currentTimeExpression,
+						archivedAtColumn,
+						belongsToUserColumn,
+						belongsToUserColumn,
+						idColumn,
+						idColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`INSERT INTO %s (
-	%s
-) VALUES (
-	%s
-);`,
-					accountsTableName,
-					strings.Join(filterForInsert(
-						insertColumns,
-						"time_zone",
-						"payment_processor_customer_id",
-						"last_payment_provider_sync_occurred_at",
-						"subscription_plan_id",
-					), ",\n\t"),
-					strings.Join(applyToEach(filterForInsert(
-						insertColumns,
-						"time_zone",
-						"payment_processor_customer_id",
-						"last_payment_provider_sync_occurred_at",
-						"subscription_plan_id",
-					), func(_ int, s string) string {
-						return fmt.Sprintf("sqlc.arg(%s)", s)
-					}), ",\n\t"),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetAccountByIDWithMemberships",
-					Type: ManyType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetAccountByIDWithMemberships",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s
 FROM %s
 	JOIN %s ON %s.%s = %s.%s
@@ -131,39 +111,39 @@ FROM %s
 WHERE %s.%s IS NULL
 	AND %s.%s IS NULL
 	AND %s.%s = sqlc.arg(%s);`,
-					strings.Join(append(
-						append(
+						strings.Join(append(
 							append(
-								applyToEach(accountsColumns, func(_ int, s string) string {
-									return fmt.Sprintf("%s.%s", accountsTableName, s)
-								}),
-								applyToEach(usersColumns, func(_ int, s string) string {
-									return fmt.Sprintf("%s.%s as user_%s", usersTableName, s, s)
+								append(
+									applyToEach(accountsColumns, func(_ int, s string) string {
+										return fmt.Sprintf("%s.%s", accountsTableName, s)
+									}),
+									applyToEach(usersColumns, func(_ int, s string) string {
+										return fmt.Sprintf("%s.%s as user_%s", usersTableName, s, s)
+									})...,
+								),
+								applyToEach(avatarJoinSelect("user_avatar"), func(_ int, s string) string {
+									return s
 								})...,
 							),
-							applyToEach(avatarJoinSelect("user_avatar"), func(_ int, s string) string {
-								return s
+							applyToEach(accountUserMembershipsColumns, func(_ int, s string) string {
+								return fmt.Sprintf("%s.%s as membership_%s", accountUserMembershipsTableName, s, s)
 							})...,
-						),
-						applyToEach(accountUserMembershipsColumns, func(_ int, s string) string {
-							return fmt.Sprintf("%s.%s as membership_%s", accountUserMembershipsTableName, s, s)
-						})...,
-					), ",\n\t"),
-					accountsTableName,
-					accountUserMembershipsTableName, accountUserMembershipsTableName, belongsToAccountColumn, accountsTableName, idColumn,
-					usersTableName, accountUserMembershipsTableName, belongsToUserColumn, usersTableName, idColumn,
-					avatarJoinClause,
-					accountsTableName, archivedAtColumn,
-					accountUserMembershipsTableName, archivedAtColumn,
-					accountsTableName, idColumn, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetAccountsForUser",
-					Type: ManyType,
+						), ",\n\t"),
+						accountsTableName,
+						accountUserMembershipsTableName, accountUserMembershipsTableName, belongsToAccountColumn, accountsTableName, idColumn,
+						usersTableName, accountUserMembershipsTableName, belongsToUserColumn, usersTableName, idColumn,
+						avatarJoinClause,
+						accountsTableName, archivedAtColumn,
+						accountUserMembershipsTableName, archivedAtColumn,
+						accountsTableName, idColumn, idColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetAccountsForUser",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s
@@ -173,64 +153,25 @@ WHERE %s.%s IS NULL
 	AND %s.%s IS NULL
 	%s
 %s;`,
-					strings.Join(applyToEach(accountsColumns, func(_ int, s string) string {
-						return fmt.Sprintf("%s.%s", accountsTableName, s)
-					}), ",\n\t"),
-					buildFilterCountSelect(accountsTableName, true, true, nil),
-					buildTotalCountSelect(accountsTableName, true, []string{}, fmt.Sprintf("%s.%s = sqlc.arg(%s)", accountUserMembershipsTableName, belongsToUserColumn, belongsToUserColumn)),
-					accountsTableName,
-					accountUserMembershipsTableName, accountUserMembershipsTableName, belongsToAccountColumn, accountsTableName, idColumn,
-					accountsTableName, archivedAtColumn,
-					accountUserMembershipsTableName, archivedAtColumn,
-					buildFilterConditions(accountsTableName, true, false, fmt.Sprintf("%s.%s = sqlc.arg(%s)", accountUserMembershipsTableName, belongsToUserColumn, belongsToUserColumn)),
-					buildCursorLimitClause(accountsTableName),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "UpdateAccount",
-					Type: ExecRowsType,
+						strings.Join(applyToEach(accountsColumns, func(_ int, s string) string {
+							return fmt.Sprintf("%s.%s", accountsTableName, s)
+						}), ",\n\t"),
+						buildFilterCountSelect(accountsTableName, true, true, nil),
+						buildTotalCountSelect(accountsTableName, true, []string{}, fmt.Sprintf("%s.%s = sqlc.arg(%s)", accountUserMembershipsTableName, belongsToUserColumn, belongsToUserColumn)),
+						accountsTableName,
+						accountUserMembershipsTableName, accountUserMembershipsTableName, belongsToAccountColumn, accountsTableName, idColumn,
+						accountsTableName, archivedAtColumn,
+						accountUserMembershipsTableName, archivedAtColumn,
+						buildFilterConditions(accountsTableName, true, false, fmt.Sprintf("%s.%s = sqlc.arg(%s)", accountUserMembershipsTableName, belongsToUserColumn, belongsToUserColumn)),
+						buildCursorLimitClause(accountsTableName),
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
-	%s,
-	%s = %s
-WHERE %s IS NULL
-	AND %s = sqlc.arg(%s)
-	AND %s = sqlc.arg(%s);`,
-					accountsTableName,
-					strings.Join(
-						applyToEach(
-							filterForUpdate(
-								accountsColumns,
-								"billing_status",
-								"payment_processor_customer_id",
-								"subscription_plan_id",
-								belongsToUserColumn,
-								"time_zone",
-								"last_payment_provider_sync_occurred_at",
-								"webhook_hmac_secret",
-							),
-							func(_ int, s string) string {
-								return fmt.Sprintf("%s = sqlc.arg(%s)", s, s)
-							},
-						),
-						",\n\t",
-					),
-					lastUpdatedAtColumn,
-					currentTimeExpression,
-					archivedAtColumn,
-					belongsToUserColumn,
-					belongsToUserColumn,
-					idColumn,
-					idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "UpdateAccountBillingFields",
-					Type: ExecRowsType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
+				{
+					Annotation: QueryAnnotation{
+						Name: "UpdateAccountBillingFields",
+						Type: ExecRowsType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
 	billing_status = COALESCE(sqlc.narg(billing_status), billing_status),
 	subscription_plan_id = COALESCE(sqlc.narg(subscription_plan_id), subscription_plan_id),
 	payment_processor_customer_id = COALESCE(sqlc.narg(payment_processor_customer_id), payment_processor_customer_id),
@@ -238,32 +179,33 @@ WHERE %s IS NULL
 	%s = %s
 WHERE %s IS NULL
 	AND %s = sqlc.arg(%s);`,
-					accountsTableName,
-					lastUpdatedAtColumn, currentTimeExpression,
-					archivedAtColumn,
-					idColumn, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "UpdateAccountWebhookEncryptionKey",
-					Type: ExecRowsType,
+						accountsTableName,
+						lastUpdatedAtColumn, currentTimeExpression,
+						archivedAtColumn,
+						idColumn, idColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
+				{
+					Annotation: QueryAnnotation{
+						Name: "UpdateAccountWebhookEncryptionKey",
+						Type: ExecRowsType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
 	%s = sqlc.arg(%s),
 	%s = %s
 WHERE %s IS NULL
 	AND %s = sqlc.arg(%s)
 	AND %s = sqlc.arg(%s);`,
-					accountsTableName,
-					webhookHMACSecretColumn, webhookHMACSecretColumn,
-					lastUpdatedAtColumn, currentTimeExpression,
-					archivedAtColumn,
-					belongsToUserColumn, belongsToUserColumn,
-					idColumn, idColumn,
-				)),
+						accountsTableName,
+						webhookHMACSecretColumn, webhookHMACSecretColumn,
+						lastUpdatedAtColumn, currentTimeExpression,
+						archivedAtColumn,
+						belongsToUserColumn, belongsToUserColumn,
+						idColumn, idColumn,
+					)),
+				},
 			},
-		}
+		)
 	default:
 		return nil
 	}

--- a/backend/cmd/tools/codegen/queries/identity_permissions.go
+++ b/backend/cmd/tools/codegen/queries/identity_permissions.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"fmt"
+	"slices"
 	"strings"
+
+	"github.com/primandproper/platform-go/v11/database/querygen"
 
 	"github.com/cristalhq/builq"
 )
@@ -28,66 +31,37 @@ func buildPermissionsQueries(database string) []*Query {
 	switch database {
 	case postgres:
 
-		return []*Query{
-			{
-				Annotation: QueryAnnotation{
-					Name: "CreatePermission",
-					Type: ExecType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`INSERT INTO %s (
-	%s
-) VALUES (
-	%s
-);`,
-					permissionsTableName,
-					strings.Join(filterForInsert(permissionsColumns), ",\n\t"),
-					strings.Join(applyToEach(filterForInsert(permissionsColumns), func(i int, s string) string {
-						return fmt.Sprintf("sqlc.arg(%s)", s)
-					}), ",\n\t"),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetPermissionByID",
-					Type: OneType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+		return slices.Concat(
+			querygen.StandardCRUD(permissionsTableName, permissionsColumns,
+				querygen.WithEntity("Permission", "Permissions"),
+				querygen.WithQueryName(querygen.GetQuery, "GetPermissionByID"),
+				querygen.WithOmitted(querygen.ExistsQuery, querygen.ListQuery, querygen.UpdateQuery),
+			),
+			[]*Query{
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetPermissionByName",
+						Type: OneType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s
 FROM %s
 WHERE %s.%s IS NULL
 	AND %s.%s = sqlc.arg(%s);`,
-					strings.Join(applyToEach(permissionsColumns, func(i int, s string) string {
-						return fmt.Sprintf("%s.%s", permissionsTableName, s)
-					}), ",\n\t"),
-					permissionsTableName,
-					permissionsTableName, archivedAtColumn,
-					permissionsTableName, idColumn, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetPermissionByName",
-					Type: OneType,
+						strings.Join(applyToEach(permissionsColumns, func(i int, s string) string {
+							return fmt.Sprintf("%s.%s", permissionsTableName, s)
+						}), ",\n\t"),
+						permissionsTableName,
+						permissionsTableName, archivedAtColumn,
+						permissionsTableName, nameColumn, nameColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
-	%s
-FROM %s
-WHERE %s.%s IS NULL
-	AND %s.%s = sqlc.arg(%s);`,
-					strings.Join(applyToEach(permissionsColumns, func(i int, s string) string {
-						return fmt.Sprintf("%s.%s", permissionsTableName, s)
-					}), ",\n\t"),
-					permissionsTableName,
-					permissionsTableName, archivedAtColumn,
-					permissionsTableName, nameColumn, nameColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetPermissions",
-					Type: ManyType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetPermissions",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s
@@ -95,30 +69,19 @@ FROM %s
 WHERE %s.%s IS NULL
 	%s
 %s;`,
-					strings.Join(applyToEach(permissionsColumns, func(i int, s string) string {
-						return fmt.Sprintf("%s.%s", permissionsTableName, s)
-					}), ",\n\t"),
-					buildFilterCountSelect(permissionsTableName, true, true, []string{}),
-					buildTotalCountSelect(permissionsTableName, true, []string{}),
-					permissionsTableName,
-					permissionsTableName, archivedAtColumn,
-					buildFilterConditions(permissionsTableName, true, true),
-					buildCursorLimitClause(permissionsTableName),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "ArchivePermission",
-					Type: ExecRowsType,
+						strings.Join(applyToEach(permissionsColumns, func(i int, s string) string {
+							return fmt.Sprintf("%s.%s", permissionsTableName, s)
+						}), ",\n\t"),
+						buildFilterCountSelect(permissionsTableName, true, true, []string{}),
+						buildTotalCountSelect(permissionsTableName, true, []string{}),
+						permissionsTableName,
+						permissionsTableName, archivedAtColumn,
+						buildFilterConditions(permissionsTableName, true, true),
+						buildCursorLimitClause(permissionsTableName),
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET %s = %s WHERE %s IS NULL AND %s = sqlc.arg(%s);`,
-					permissionsTableName,
-					archivedAtColumn, currentTimeExpression,
-					archivedAtColumn,
-					idColumn, idColumn,
-				)),
 			},
-		}
+		)
 	default:
 		return nil
 	}

--- a/backend/cmd/tools/codegen/queries/identity_user_role_assignments.go
+++ b/backend/cmd/tools/codegen/queries/identity_user_role_assignments.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"fmt"
-	"strings"
+	"slices"
+
+	"github.com/primandproper/platform-go/v11/database/querygen"
 
 	"github.com/cristalhq/builq"
 )
@@ -31,79 +33,67 @@ func buildUserRoleAssignmentsQueries(database string) []*Query {
 	switch database {
 	case postgres:
 
-		return []*Query{
-			{
-				Annotation: QueryAnnotation{
-					Name: "AssignRoleToUser",
-					Type: ExecType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`INSERT INTO %s (
-	%s
-) VALUES (
-	%s
-);`,
-					userRoleAssignmentsTableName,
-					strings.Join(filterForInsert(userRoleAssignmentsColumns), ",\n\t"),
-					strings.Join(applyToEach(filterForInsert(userRoleAssignmentsColumns), func(i int, s string) string {
-						return fmt.Sprintf("sqlc.arg(%s)", s)
-					}), ",\n\t"),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "ArchiveRoleAssignment",
-					Type: ExecType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET %s = %s
+		return slices.Concat(
+			querygen.StandardCRUD(userRoleAssignmentsTableName, userRoleAssignmentsColumns,
+				querygen.WithEntity("UserRoleAssignments", "UserRoleAssignmentss"),
+				querygen.WithQueryName(querygen.CreateQuery, "AssignRoleToUser"),
+				querygen.WithOmitted(querygen.ArchiveQuery, querygen.ExistsQuery, querygen.GetQuery, querygen.ListQuery, querygen.UpdateQuery),
+			),
+			[]*Query{
+				{
+					Annotation: QueryAnnotation{
+						Name: "ArchiveRoleAssignment",
+						Type: ExecType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET %s = %s
 WHERE %s IS NULL
 	AND %s = sqlc.arg(%s)
 	AND %s = sqlc.arg(%s);`,
-					userRoleAssignmentsTableName,
-					archivedAtColumn, currentTimeExpression,
-					archivedAtColumn,
-					idColumn, idColumn,
-					userIDColumn, userIDColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "ArchiveRoleAssignmentsForUserAndAccount",
-					Type: ExecType,
+						userRoleAssignmentsTableName,
+						archivedAtColumn, currentTimeExpression,
+						archivedAtColumn,
+						idColumn, idColumn,
+						userIDColumn, userIDColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET %s = %s
+				{
+					Annotation: QueryAnnotation{
+						Name: "ArchiveRoleAssignmentsForUserAndAccount",
+						Type: ExecType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET %s = %s
 WHERE %s IS NULL
 	AND %s = sqlc.arg(%s)
 	AND %s = sqlc.arg(%s);`,
-					userRoleAssignmentsTableName,
-					archivedAtColumn, currentTimeExpression,
-					archivedAtColumn,
-					userIDColumn, userIDColumn,
-					accountIDColumn, accountIDColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "UpdateAccountRoleAssignment",
-					Type: ExecType,
+						userRoleAssignmentsTableName,
+						archivedAtColumn, currentTimeExpression,
+						archivedAtColumn,
+						userIDColumn, userIDColumn,
+						accountIDColumn, accountIDColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET %s = sqlc.arg(new_role_id)
+				{
+					Annotation: QueryAnnotation{
+						Name: "UpdateAccountRoleAssignment",
+						Type: ExecType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET %s = sqlc.arg(new_role_id)
 WHERE %s IS NULL
 	AND %s = sqlc.arg(%s)
 	AND %s = sqlc.arg(%s);`,
-					userRoleAssignmentsTableName,
-					roleIDColumn,
-					archivedAtColumn,
-					userIDColumn, userIDColumn,
-					accountIDColumn, accountIDColumn,
-				)),
-			},
-			// Recursive CTE: get all effective service-level permissions for a user
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetServicePermissionsForUser",
-					Type: ManyType,
+						userRoleAssignmentsTableName,
+						roleIDColumn,
+						archivedAtColumn,
+						userIDColumn, userIDColumn,
+						accountIDColumn, accountIDColumn,
+					)),
 				},
-				Content: fmt.Sprintf(`WITH RECURSIVE role_tree AS (
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetServicePermissionsForUser",
+						Type: ManyType,
+					},
+					Content: fmt.Sprintf(`WITH RECURSIVE role_tree AS (
 	SELECT %s.%s AS %s, %s.%s AS role_name
 	FROM %s
 	JOIN %s ON %s.%s = %s.%s
@@ -125,43 +115,42 @@ JOIN %s ON %s.%s = rt.%s
 JOIN %s ON %s.%s = %s.%s
 WHERE %s.%s IS NULL
 	AND %s.%s IS NULL`,
-					// Base case SELECT
-					userRolesTableName, idColumn, roleIDColumn,
-					userRolesTableName, nameColumn,
-					// FROM / JOIN
-					userRoleAssignmentsTableName,
-					userRolesTableName, userRolesTableName, idColumn, userRoleAssignmentsTableName, roleIDColumn,
-					// WHERE
-					userRoleAssignmentsTableName, userIDColumn, userIDColumn,
-					userRoleAssignmentsTableName, accountIDColumn,
-					userRoleAssignmentsTableName, archivedAtColumn,
-					userRolesTableName, archivedAtColumn,
-					// Recursive SELECT
-					userRolesTableName, idColumn,
-					userRolesTableName, nameColumn,
-					// Recursive JOIN
-					userRoleHierarchyTableName, userRoleHierarchyTableName, roleIDColumn,
-					userRolesTableName, userRolesTableName, idColumn, userRoleHierarchyTableName,
-					// Recursive WHERE
-					userRoleHierarchyTableName, archivedAtColumn,
-					userRolesTableName, archivedAtColumn,
-					// Final SELECT
-					permissionsTableName, nameColumn,
-					// Final JOINs
-					userRolePermissionsTableName, userRolePermissionsTableName, roleIDColumn, roleIDColumn,
-					permissionsTableName, permissionsTableName, idColumn, userRolePermissionsTableName, permissionIDColumn,
-					// Final WHERE
-					userRolePermissionsTableName, archivedAtColumn,
-					permissionsTableName, archivedAtColumn,
-				),
-			},
-			// Recursive CTE: get all effective account-level permissions for a user (all accounts)
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetAccountPermissionsForUser",
-					Type: ManyType,
+						// Base case SELECT
+						userRolesTableName, idColumn, roleIDColumn,
+						userRolesTableName, nameColumn,
+						// FROM / JOIN
+						userRoleAssignmentsTableName,
+						userRolesTableName, userRolesTableName, idColumn, userRoleAssignmentsTableName, roleIDColumn,
+						// WHERE
+						userRoleAssignmentsTableName, userIDColumn, userIDColumn,
+						userRoleAssignmentsTableName, accountIDColumn,
+						userRoleAssignmentsTableName, archivedAtColumn,
+						userRolesTableName, archivedAtColumn,
+						// Recursive SELECT
+						userRolesTableName, idColumn,
+						userRolesTableName, nameColumn,
+						// Recursive JOIN
+						userRoleHierarchyTableName, userRoleHierarchyTableName, roleIDColumn,
+						userRolesTableName, userRolesTableName, idColumn, userRoleHierarchyTableName,
+						// Recursive WHERE
+						userRoleHierarchyTableName, archivedAtColumn,
+						userRolesTableName, archivedAtColumn,
+						// Final SELECT
+						permissionsTableName, nameColumn,
+						// Final JOINs
+						userRolePermissionsTableName, userRolePermissionsTableName, roleIDColumn, roleIDColumn,
+						permissionsTableName, permissionsTableName, idColumn, userRolePermissionsTableName, permissionIDColumn,
+						// Final WHERE
+						userRolePermissionsTableName, archivedAtColumn,
+						permissionsTableName, archivedAtColumn,
+					),
 				},
-				Content: fmt.Sprintf(`WITH RECURSIVE role_tree AS (
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetAccountPermissionsForUser",
+						Type: ManyType,
+					},
+					Content: fmt.Sprintf(`WITH RECURSIVE role_tree AS (
 	SELECT %s.%s AS %s, %s.%s AS role_name, %s.%s AS %s
 	FROM %s
 	JOIN %s ON %s.%s = %s.%s
@@ -183,62 +172,62 @@ JOIN %s ON %s.%s = rt.%s
 JOIN %s ON %s.%s = %s.%s
 WHERE %s.%s IS NULL
 	AND %s.%s IS NULL`,
-					// Base case SELECT
-					userRolesTableName, idColumn, roleIDColumn,
-					userRolesTableName, nameColumn,
-					userRoleAssignmentsTableName, accountIDColumn, accountIDColumn,
-					// FROM / JOIN
-					userRoleAssignmentsTableName,
-					userRolesTableName, userRolesTableName, idColumn, userRoleAssignmentsTableName, roleIDColumn,
-					// WHERE
-					userRoleAssignmentsTableName, userIDColumn, userIDColumn,
-					userRoleAssignmentsTableName, accountIDColumn,
-					userRoleAssignmentsTableName, archivedAtColumn,
-					userRolesTableName, archivedAtColumn,
-					// Recursive SELECT
-					userRolesTableName, idColumn,
-					userRolesTableName, nameColumn,
-					accountIDColumn,
-					// Recursive JOIN
-					userRoleHierarchyTableName, userRoleHierarchyTableName, roleIDColumn,
-					userRolesTableName, userRolesTableName, idColumn, userRoleHierarchyTableName,
-					// Recursive WHERE
-					userRoleHierarchyTableName, archivedAtColumn,
-					userRolesTableName, archivedAtColumn,
-					// Final SELECT
-					accountIDColumn,
-					permissionsTableName, nameColumn,
-					// Final JOINs
-					userRolePermissionsTableName, userRolePermissionsTableName, roleIDColumn, roleIDColumn,
-					permissionsTableName, permissionsTableName, idColumn, userRolePermissionsTableName, permissionIDColumn,
-					// Final WHERE
-					userRolePermissionsTableName, archivedAtColumn,
-					permissionsTableName, archivedAtColumn,
-				),
-			},
-			// Get service-level role names for a user (for IsServiceAdmin() etc.)
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetServiceRoleNamesForUser",
-					Type: ManyType,
+						// Base case SELECT
+						userRolesTableName, idColumn, roleIDColumn,
+						userRolesTableName, nameColumn,
+						userRoleAssignmentsTableName, accountIDColumn, accountIDColumn,
+						// FROM / JOIN
+						userRoleAssignmentsTableName,
+						userRolesTableName, userRolesTableName, idColumn, userRoleAssignmentsTableName, roleIDColumn,
+						// WHERE
+						userRoleAssignmentsTableName, userIDColumn, userIDColumn,
+						userRoleAssignmentsTableName, accountIDColumn,
+						userRoleAssignmentsTableName, archivedAtColumn,
+						userRolesTableName, archivedAtColumn,
+						// Recursive SELECT
+						userRolesTableName, idColumn,
+						userRolesTableName, nameColumn,
+						accountIDColumn,
+						// Recursive JOIN
+						userRoleHierarchyTableName, userRoleHierarchyTableName, roleIDColumn,
+						userRolesTableName, userRolesTableName, idColumn, userRoleHierarchyTableName,
+						// Recursive WHERE
+						userRoleHierarchyTableName, archivedAtColumn,
+						userRolesTableName, archivedAtColumn,
+						// Final SELECT
+						accountIDColumn,
+						permissionsTableName, nameColumn,
+						// Final JOINs
+						userRolePermissionsTableName, userRolePermissionsTableName, roleIDColumn, roleIDColumn,
+						permissionsTableName, permissionsTableName, idColumn, userRolePermissionsTableName, permissionIDColumn,
+						// Final WHERE
+						userRolePermissionsTableName, archivedAtColumn,
+						permissionsTableName, archivedAtColumn,
+					),
 				},
-				Content: fmt.Sprintf(`SELECT %s.%s AS role_name
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetServiceRoleNamesForUser",
+						Type: ManyType,
+					},
+					Content: fmt.Sprintf(`SELECT %s.%s AS role_name
 FROM %s
 JOIN %s ON %s.%s = %s.%s
 WHERE %s.%s = sqlc.arg(%s)
 	AND %s.%s IS NULL
 	AND %s.%s IS NULL
 	AND %s.%s IS NULL`,
-					userRolesTableName, nameColumn,
-					userRoleAssignmentsTableName,
-					userRolesTableName, userRolesTableName, idColumn, userRoleAssignmentsTableName, roleIDColumn,
-					userRoleAssignmentsTableName, userIDColumn, userIDColumn,
-					userRoleAssignmentsTableName, accountIDColumn,
-					userRoleAssignmentsTableName, archivedAtColumn,
-					userRolesTableName, archivedAtColumn,
-				),
+						userRolesTableName, nameColumn,
+						userRoleAssignmentsTableName,
+						userRolesTableName, userRolesTableName, idColumn, userRoleAssignmentsTableName, roleIDColumn,
+						userRoleAssignmentsTableName, userIDColumn, userIDColumn,
+						userRoleAssignmentsTableName, accountIDColumn,
+						userRoleAssignmentsTableName, archivedAtColumn,
+						userRolesTableName, archivedAtColumn,
+					),
+				},
 			},
-		}
+		)
 	default:
 		return nil
 	}

--- a/backend/cmd/tools/codegen/queries/identity_user_role_hierarchy.go
+++ b/backend/cmd/tools/codegen/queries/identity_user_role_hierarchy.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"fmt"
+	"slices"
 	"strings"
+
+	"github.com/primandproper/platform-go/v11/database/querygen"
 
 	"github.com/cristalhq/builq"
 )
@@ -30,57 +33,46 @@ func buildUserRoleHierarchyQueries(database string) []*Query {
 	switch database {
 	case postgres:
 
-		return []*Query{
-			{
-				Annotation: QueryAnnotation{
-					Name: "CreateUserRoleHierarchy",
-					Type: ExecType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`INSERT INTO %s (
-	%s
-) VALUES (
-	%s
-);`,
-					userRoleHierarchyTableName,
-					strings.Join(filterForInsert(userRoleHierarchyColumns), ",\n\t"),
-					strings.Join(applyToEach(filterForInsert(userRoleHierarchyColumns), func(i int, s string) string {
-						return fmt.Sprintf("sqlc.arg(%s)", s)
-					}), ",\n\t"),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetUserRoleHierarchy",
-					Type: ManyType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+		return slices.Concat(
+			querygen.StandardCRUD(userRoleHierarchyTableName, userRoleHierarchyColumns,
+				querygen.WithEntity("UserRoleHierarchy", "UserRoleHierarchys"),
+				querygen.WithOmitted(querygen.ArchiveQuery, querygen.ExistsQuery, querygen.GetQuery, querygen.ListQuery, querygen.UpdateQuery),
+			),
+			[]*Query{
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetUserRoleHierarchy",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s
 FROM %s
 WHERE %s.%s IS NULL;`,
-					strings.Join(applyToEach(userRoleHierarchyColumns, func(i int, s string) string {
-						return fmt.Sprintf("%s.%s", userRoleHierarchyTableName, s)
-					}), ",\n\t"),
-					userRoleHierarchyTableName,
-					userRoleHierarchyTableName, archivedAtColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "ArchiveUserRoleHierarchy",
-					Type: ExecType,
+						strings.Join(applyToEach(userRoleHierarchyColumns, func(i int, s string) string {
+							return fmt.Sprintf("%s.%s", userRoleHierarchyTableName, s)
+						}), ",\n\t"),
+						userRoleHierarchyTableName,
+						userRoleHierarchyTableName, archivedAtColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET %s = %s
+				{
+					Annotation: QueryAnnotation{
+						Name: "ArchiveUserRoleHierarchy",
+						Type: ExecType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET %s = %s
 WHERE %s IS NULL
 	AND %s = sqlc.arg(%s)
 	AND %s = sqlc.arg(%s);`,
-					userRoleHierarchyTableName,
-					archivedAtColumn, currentTimeExpression,
-					archivedAtColumn,
-					parentRoleIDColumn, parentRoleIDColumn,
-					childRoleIDColumn, childRoleIDColumn,
-				)),
+						userRoleHierarchyTableName,
+						archivedAtColumn, currentTimeExpression,
+						archivedAtColumn,
+						parentRoleIDColumn, parentRoleIDColumn,
+						childRoleIDColumn, childRoleIDColumn,
+					)),
+				},
 			},
-		}
+		)
 	default:
 		return nil
 	}

--- a/backend/cmd/tools/codegen/queries/identity_user_role_permissions.go
+++ b/backend/cmd/tools/codegen/queries/identity_user_role_permissions.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"fmt"
+	"slices"
 	"strings"
+
+	"github.com/primandproper/platform-go/v11/database/querygen"
 
 	"github.com/cristalhq/builq"
 )
@@ -30,59 +33,48 @@ func buildUserRolePermissionsQueries(database string) []*Query {
 	switch database {
 	case postgres:
 
-		return []*Query{
-			{
-				Annotation: QueryAnnotation{
-					Name: "CreateUserRolePermission",
-					Type: ExecType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`INSERT INTO %s (
-	%s
-) VALUES (
-	%s
-);`,
-					userRolePermissionsTableName,
-					strings.Join(filterForInsert(userRolePermissionsColumns), ",\n\t"),
-					strings.Join(applyToEach(filterForInsert(userRolePermissionsColumns), func(i int, s string) string {
-						return fmt.Sprintf("sqlc.arg(%s)", s)
-					}), ",\n\t"),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetUserRolePermissionsForRole",
-					Type: ManyType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+		return slices.Concat(
+			querygen.StandardCRUD(userRolePermissionsTableName, userRolePermissionsColumns,
+				querygen.WithEntity("UserRolePermission", "UserRolePermissions"),
+				querygen.WithOmitted(querygen.ArchiveQuery, querygen.ExistsQuery, querygen.GetQuery, querygen.ListQuery, querygen.UpdateQuery),
+			),
+			[]*Query{
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetUserRolePermissionsForRole",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s
 FROM %s
 WHERE %s.%s IS NULL
 	AND %s.%s = sqlc.arg(%s);`,
-					strings.Join(applyToEach(userRolePermissionsColumns, func(i int, s string) string {
-						return fmt.Sprintf("%s.%s", userRolePermissionsTableName, s)
-					}), ",\n\t"),
-					userRolePermissionsTableName,
-					userRolePermissionsTableName, archivedAtColumn,
-					userRolePermissionsTableName, roleIDColumn, roleIDColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "ArchiveUserRolePermission",
-					Type: ExecType,
+						strings.Join(applyToEach(userRolePermissionsColumns, func(i int, s string) string {
+							return fmt.Sprintf("%s.%s", userRolePermissionsTableName, s)
+						}), ",\n\t"),
+						userRolePermissionsTableName,
+						userRolePermissionsTableName, archivedAtColumn,
+						userRolePermissionsTableName, roleIDColumn, roleIDColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET %s = %s
+				{
+					Annotation: QueryAnnotation{
+						Name: "ArchiveUserRolePermission",
+						Type: ExecType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET %s = %s
 WHERE %s IS NULL
 	AND %s = sqlc.arg(%s)
 	AND %s = sqlc.arg(%s);`,
-					userRolePermissionsTableName,
-					archivedAtColumn, currentTimeExpression,
-					archivedAtColumn,
-					roleIDColumn, roleIDColumn,
-					permissionIDColumn, permissionIDColumn,
-				)),
+						userRolePermissionsTableName,
+						archivedAtColumn, currentTimeExpression,
+						archivedAtColumn,
+						roleIDColumn, roleIDColumn,
+						permissionIDColumn, permissionIDColumn,
+					)),
+				},
 			},
-		}
+		)
 	default:
 		return nil
 	}

--- a/backend/cmd/tools/codegen/queries/identity_user_roles.go
+++ b/backend/cmd/tools/codegen/queries/identity_user_roles.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"fmt"
+	"slices"
 	"strings"
+
+	"github.com/primandproper/platform-go/v11/database/querygen"
 
 	"github.com/cristalhq/builq"
 )
@@ -31,66 +34,37 @@ func buildUserRolesQueries(database string) []*Query {
 	switch database {
 	case postgres:
 
-		return []*Query{
-			{
-				Annotation: QueryAnnotation{
-					Name: "CreateUserRole",
-					Type: ExecType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`INSERT INTO %s (
-	%s
-) VALUES (
-	%s
-);`,
-					userRolesTableName,
-					strings.Join(filterForInsert(userRolesColumns), ",\n\t"),
-					strings.Join(applyToEach(filterForInsert(userRolesColumns), func(i int, s string) string {
-						return fmt.Sprintf("sqlc.arg(%s)", s)
-					}), ",\n\t"),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetUserRoleByID",
-					Type: OneType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+		return slices.Concat(
+			querygen.StandardCRUD(userRolesTableName, userRolesColumns,
+				querygen.WithEntity("UserRole", "UserRoles"),
+				querygen.WithQueryName(querygen.GetQuery, "GetUserRoleByID"),
+				querygen.WithOmitted(querygen.ExistsQuery, querygen.ListQuery, querygen.UpdateQuery),
+			),
+			[]*Query{
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetUserRoleByName",
+						Type: OneType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s
 FROM %s
 WHERE %s.%s IS NULL
 	AND %s.%s = sqlc.arg(%s);`,
-					strings.Join(applyToEach(userRolesColumns, func(i int, s string) string {
-						return fmt.Sprintf("%s.%s", userRolesTableName, s)
-					}), ",\n\t"),
-					userRolesTableName,
-					userRolesTableName, archivedAtColumn,
-					userRolesTableName, idColumn, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetUserRoleByName",
-					Type: OneType,
+						strings.Join(applyToEach(userRolesColumns, func(i int, s string) string {
+							return fmt.Sprintf("%s.%s", userRolesTableName, s)
+						}), ",\n\t"),
+						userRolesTableName,
+						userRolesTableName, archivedAtColumn,
+						userRolesTableName, nameColumn, nameColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
-	%s
-FROM %s
-WHERE %s.%s IS NULL
-	AND %s.%s = sqlc.arg(%s);`,
-					strings.Join(applyToEach(userRolesColumns, func(i int, s string) string {
-						return fmt.Sprintf("%s.%s", userRolesTableName, s)
-					}), ",\n\t"),
-					userRolesTableName,
-					userRolesTableName, archivedAtColumn,
-					userRolesTableName, nameColumn, nameColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetUserRoles",
-					Type: ManyType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetUserRoles",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s
@@ -98,30 +72,19 @@ FROM %s
 WHERE %s.%s IS NULL
 	%s
 %s;`,
-					strings.Join(applyToEach(userRolesColumns, func(i int, s string) string {
-						return fmt.Sprintf("%s.%s", userRolesTableName, s)
-					}), ",\n\t"),
-					buildFilterCountSelect(userRolesTableName, true, true, []string{}),
-					buildTotalCountSelect(userRolesTableName, true, []string{}),
-					userRolesTableName,
-					userRolesTableName, archivedAtColumn,
-					buildFilterConditions(userRolesTableName, true, true),
-					buildCursorLimitClause(userRolesTableName),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "ArchiveUserRole",
-					Type: ExecRowsType,
+						strings.Join(applyToEach(userRolesColumns, func(i int, s string) string {
+							return fmt.Sprintf("%s.%s", userRolesTableName, s)
+						}), ",\n\t"),
+						buildFilterCountSelect(userRolesTableName, true, true, []string{}),
+						buildTotalCountSelect(userRolesTableName, true, []string{}),
+						userRolesTableName,
+						userRolesTableName, archivedAtColumn,
+						buildFilterConditions(userRolesTableName, true, true),
+						buildCursorLimitClause(userRolesTableName),
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET %s = %s WHERE %s IS NULL AND %s = sqlc.arg(%s);`,
-					userRolesTableName,
-					archivedAtColumn, currentTimeExpression,
-					archivedAtColumn,
-					idColumn, idColumn,
-				)),
 			},
-		}
+		)
 	default:
 		return nil
 	}

--- a/backend/cmd/tools/codegen/queries/identity_users.go
+++ b/backend/cmd/tools/codegen/queries/identity_users.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"fmt"
+	"slices"
 	"strings"
+
+	"github.com/primandproper/platform-go/v11/database/querygen"
 
 	"github.com/cristalhq/builq"
 )
@@ -132,78 +135,54 @@ func buildUsersQueries(database string) []*Query {
 	switch database {
 	case postgres:
 
-		insertColumns := filterForInsert(usersColumns,
-			"password_last_changed_at",
-			"email_address_verified_at",
-			lastAcceptedTOSColumn,
-			lastAcceptedPrivacyPolicyColumn,
-			lastIndexedAtColumn,
-		)
-
-		return []*Query{
-			{
-				Annotation: QueryAnnotation{
-					Name: "AcceptPrivacyPolicyForUser",
-					Type: ExecType,
+		return slices.Concat(
+			querygen.StandardCRUD(usersTableName, usersColumns,
+				querygen.WithEntity("User", "Users"),
+				querygen.WithDatabaseOwned(
+					passwordLastChangedAtColumn,
+					emailAddressVerifiedAtColumn,
+					lastAcceptedTOSColumn,
+					lastAcceptedPrivacyPolicyColumn,
+				),
+				querygen.WithOmitted(
+					querygen.GetQuery,
+					querygen.ExistsQuery,
+					querygen.ListQuery,
+					querygen.UpdateQuery,
+				),
+			),
+			[]*Query{
+				{
+					Annotation: QueryAnnotation{
+						Name: "AcceptPrivacyPolicyForUser",
+						Type: ExecType,
+					},
+					Content: buildUserUpdateQuery(lastAcceptedPrivacyPolicyColumn, nil),
 				},
-				Content: buildUserUpdateQuery(lastAcceptedPrivacyPolicyColumn, nil),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "AcceptTermsOfServiceForUser",
-					Type: ExecType,
+				{
+					Annotation: QueryAnnotation{
+						Name: "AcceptTermsOfServiceForUser",
+						Type: ExecType,
+					},
+					Content: buildUserUpdateQuery(lastAcceptedTOSColumn, nil),
 				},
-				Content: buildUserUpdateQuery(lastAcceptedTOSColumn, nil),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "ArchiveUser",
-					Type: ExecRowsType,
+				{
+					Annotation: QueryAnnotation{
+						Name: "DeleteUser",
+						Type: ExecRowsType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`DELETE FROM %s WHERE %s = sqlc.arg(%s);`,
+						usersTableName,
+						idColumn,
+						idColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET %s = %s WHERE %s IS NULL AND %s = sqlc.arg(%s);`,
-					usersTableName,
-					archivedAtColumn,
-					currentTimeExpression,
-					archivedAtColumn,
-					idColumn,
-					idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "DeleteUser",
-					Type: ExecRowsType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`DELETE FROM %s WHERE %s = sqlc.arg(%s);`,
-					usersTableName,
-					idColumn,
-					idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CreateUser",
-					Type: ExecType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`INSERT INTO %s
-(
-	%s
-) VALUES (
-	%s
-);`,
-					usersTableName,
-					strings.Join(insertColumns, ",\n\t"),
-					strings.Join(applyToEach(insertColumns, func(_ int, s string) string {
-						return fmt.Sprintf("sqlc.arg(%s)", s)
-					}), ",\n\t"),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetAdminUserByUsername",
-					Type: OneType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetAdminUserByUsername",
+						Type: OneType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s
 FROM %s
@@ -214,132 +193,132 @@ WHERE %s.%s IS NULL
 	AND %s.%s = 'service_admin'
 	AND %s.%s = sqlc.arg(%s)
 	AND %s.%s IS NOT NULL;`,
-					strings.Join(applyToEach(usersColumns, func(_ int, s string) string {
-						return fmt.Sprintf("%s.%s", usersTableName, s)
-					}), ",\n\t"),
-					strings.Join(avatarJoinSelect("avatar"), ",\n\t"),
-					usersTableName,
-					avatarJoinClause,
-					userRoleAssignmentsTableName, userRoleAssignmentsTableName, userIDColumn, usersTableName, idColumn, userRoleAssignmentsTableName, accountIDColumn, userRoleAssignmentsTableName, archivedAtColumn,
-					userRolesTableName, userRolesTableName, idColumn, userRoleAssignmentsTableName, roleIDColumn, userRolesTableName, archivedAtColumn,
-					usersTableName, archivedAtColumn,
-					userRolesTableName, nameColumn,
-					usersTableName, usernameColumn, usernameColumn,
-					usersTableName, twoFactorSecretVerifiedAtColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetUserByEmail",
-					Type: OneType,
+						strings.Join(applyToEach(usersColumns, func(_ int, s string) string {
+							return fmt.Sprintf("%s.%s", usersTableName, s)
+						}), ",\n\t"),
+						strings.Join(avatarJoinSelect("avatar"), ",\n\t"),
+						usersTableName,
+						avatarJoinClause,
+						userRoleAssignmentsTableName, userRoleAssignmentsTableName, userIDColumn, usersTableName, idColumn, userRoleAssignmentsTableName, accountIDColumn, userRoleAssignmentsTableName, archivedAtColumn,
+						userRolesTableName, userRolesTableName, idColumn, userRoleAssignmentsTableName, roleIDColumn, userRolesTableName, archivedAtColumn,
+						usersTableName, archivedAtColumn,
+						userRolesTableName, nameColumn,
+						usersTableName, usernameColumn, usernameColumn,
+						usersTableName, twoFactorSecretVerifiedAtColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetUserByEmail",
+						Type: OneType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s
 FROM %s
 	%s
 WHERE %s.%s IS NULL
 	AND %s.%s = sqlc.arg(%s);`,
-					strings.Join(applyToEach(usersColumns, func(_ int, s string) string {
-						return fmt.Sprintf("%s.%s", usersTableName, s)
-					}), ",\n\t"),
-					strings.Join(avatarJoinSelect("avatar"), ",\n\t"),
-					usersTableName,
-					avatarJoinClause,
-					usersTableName, archivedAtColumn,
-					usersTableName, emailAddressColumn, emailAddressColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetUserByEmailAddressVerificationToken",
-					Type: OneType,
+						strings.Join(applyToEach(usersColumns, func(_ int, s string) string {
+							return fmt.Sprintf("%s.%s", usersTableName, s)
+						}), ",\n\t"),
+						strings.Join(avatarJoinSelect("avatar"), ",\n\t"),
+						usersTableName,
+						avatarJoinClause,
+						usersTableName, archivedAtColumn,
+						usersTableName, emailAddressColumn, emailAddressColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetUserByEmailAddressVerificationToken",
+						Type: OneType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s
 FROM %s
 	%s
 WHERE %s.%s IS NULL
 	AND %s.%s = sqlc.arg(%s);`,
-					strings.Join(applyToEach(usersColumns, func(_ int, s string) string {
-						return fmt.Sprintf("%s.%s", usersTableName, s)
-					}), ",\n\t"),
-					strings.Join(avatarJoinSelect("avatar"), ",\n\t"),
-					usersTableName,
-					avatarJoinClause,
-					usersTableName, archivedAtColumn,
-					usersTableName, emailAddressVerificationTokenColumn, emailAddressVerificationTokenColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetUserByID",
-					Type: OneType,
+						strings.Join(applyToEach(usersColumns, func(_ int, s string) string {
+							return fmt.Sprintf("%s.%s", usersTableName, s)
+						}), ",\n\t"),
+						strings.Join(avatarJoinSelect("avatar"), ",\n\t"),
+						usersTableName,
+						avatarJoinClause,
+						usersTableName, archivedAtColumn,
+						usersTableName, emailAddressVerificationTokenColumn, emailAddressVerificationTokenColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetUserByID",
+						Type: OneType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s
 FROM %s
 	%s
 WHERE %s.%s IS NULL
 	AND %s.%s = sqlc.arg(%s);`,
-					strings.Join(applyToEach(usersColumns, func(_ int, s string) string {
-						return fmt.Sprintf("%s.%s", usersTableName, s)
-					}), ",\n\t"),
-					strings.Join(avatarJoinSelect("avatar"), ",\n\t"),
-					usersTableName,
-					avatarJoinClause,
-					usersTableName, archivedAtColumn,
-					usersTableName, idColumn, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetUserByUsername",
-					Type: OneType,
+						strings.Join(applyToEach(usersColumns, func(_ int, s string) string {
+							return fmt.Sprintf("%s.%s", usersTableName, s)
+						}), ",\n\t"),
+						strings.Join(avatarJoinSelect("avatar"), ",\n\t"),
+						usersTableName,
+						avatarJoinClause,
+						usersTableName, archivedAtColumn,
+						usersTableName, idColumn, idColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetUserByUsername",
+						Type: OneType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s
 FROM %s
 	%s
 WHERE %s.%s IS NULL
 	AND %s.%s = sqlc.arg(%s);`,
-					strings.Join(applyToEach(usersColumns, func(_ int, s string) string {
-						return fmt.Sprintf("%s.%s", usersTableName, s)
-					}), ",\n\t"),
-					strings.Join(avatarJoinSelect("avatar"), ",\n\t"),
-					usersTableName,
-					avatarJoinClause,
-					usersTableName, archivedAtColumn,
-					usersTableName, usernameColumn, usernameColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetEmailVerificationTokenByUserID",
-					Type: OneType,
+						strings.Join(applyToEach(usersColumns, func(_ int, s string) string {
+							return fmt.Sprintf("%s.%s", usersTableName, s)
+						}), ",\n\t"),
+						strings.Join(avatarJoinSelect("avatar"), ",\n\t"),
+						usersTableName,
+						avatarJoinClause,
+						usersTableName, archivedAtColumn,
+						usersTableName, usernameColumn, usernameColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetEmailVerificationTokenByUserID",
+						Type: OneType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s.%s
 FROM %s
 WHERE %s.%s IS NULL
 	AND %s.%s IS NULL
 	AND %s.%s = sqlc.arg(%s);`,
-					usersTableName, emailAddressVerificationTokenColumn,
-					usersTableName,
-					usersTableName, archivedAtColumn,
-					usersTableName, emailAddressVerifiedAtColumn,
-					usersTableName, idColumn, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetUsers",
-					Type: ManyType,
+						usersTableName, emailAddressVerificationTokenColumn,
+						usersTableName,
+						usersTableName, archivedAtColumn,
+						usersTableName, emailAddressVerifiedAtColumn,
+						usersTableName, idColumn, idColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetUsers",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s,
@@ -349,29 +328,29 @@ FROM %s
 WHERE %s.%s IS NULL
 	%s
 %s;`,
-					strings.Join(applyToEach(usersColumns, func(_ int, s string) string {
-						return fmt.Sprintf("%s.%s", usersTableName, s)
-					}), ",\n\t"),
-					strings.Join(avatarJoinSelect("avatar"), ",\n\t"),
-					buildFilterCountSelect(usersTableName, true, true, []string{}),
-					buildTotalCountSelect(usersTableName, true, []string{}),
-					usersTableName,
-					avatarJoinClause,
-					usersTableName, archivedAtColumn,
-					buildFilterConditions(
+						strings.Join(applyToEach(usersColumns, func(_ int, s string) string {
+							return fmt.Sprintf("%s.%s", usersTableName, s)
+						}), ",\n\t"),
+						strings.Join(avatarJoinSelect("avatar"), ",\n\t"),
+						buildFilterCountSelect(usersTableName, true, true, []string{}),
+						buildTotalCountSelect(usersTableName, true, []string{}),
 						usersTableName,
-						true,
-						true,
-					),
-					buildCursorLimitClause(usersTableName),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetUsersForAccount",
-					Type: ManyType,
+						avatarJoinClause,
+						usersTableName, archivedAtColumn,
+						buildFilterConditions(
+							usersTableName,
+							true,
+							true,
+						),
+						buildCursorLimitClause(usersTableName),
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetUsersForAccount",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s,
@@ -382,89 +361,82 @@ JOIN %s ON %s.%s = %s.%s
 WHERE %s.%s IS NULL
 	%s
 %s;`,
-					strings.Join(applyToEach(usersColumns, func(_ int, s string) string {
-						return fmt.Sprintf("%s.%s", usersTableName, s)
-					}), ",\n\t"),
-					strings.Join(avatarJoinSelect("avatar"), ",\n\t"),
-					buildFilterCountSelect(usersTableName, true, true, nil),
-					buildTotalCountSelect(usersTableName, true, []string{}, fmt.Sprintf("%s.%s = sqlc.arg(%s)", accountUserMembershipsTableName, belongsToAccountColumn, belongsToAccountColumn)),
-					usersTableName,
-					avatarJoinClause,
-					accountUserMembershipsTableName, accountUserMembershipsTableName, belongsToUserColumn, usersTableName, idColumn,
-					usersTableName, archivedAtColumn,
-					buildFilterConditions(usersTableName, true, true, fmt.Sprintf("%s.%s = sqlc.arg(%s)", accountUserMembershipsTableName, belongsToAccountColumn, belongsToAccountColumn), fmt.Sprintf("%s.%s IS NULL", accountUserMembershipsTableName, archivedAtColumn)),
-					buildCursorLimitClause(usersTableName),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetUsersWithIDs",
-					Type: ManyType,
+						strings.Join(applyToEach(usersColumns, func(_ int, s string) string {
+							return fmt.Sprintf("%s.%s", usersTableName, s)
+						}), ",\n\t"),
+						strings.Join(avatarJoinSelect("avatar"), ",\n\t"),
+						buildFilterCountSelect(usersTableName, true, true, nil),
+						buildTotalCountSelect(usersTableName, true, []string{}, fmt.Sprintf("%s.%s = sqlc.arg(%s)", accountUserMembershipsTableName, belongsToAccountColumn, belongsToAccountColumn)),
+						usersTableName,
+						avatarJoinClause,
+						accountUserMembershipsTableName, accountUserMembershipsTableName, belongsToUserColumn, usersTableName, idColumn,
+						usersTableName, archivedAtColumn,
+						buildFilterConditions(usersTableName, true, true, fmt.Sprintf("%s.%s = sqlc.arg(%s)", accountUserMembershipsTableName, belongsToAccountColumn, belongsToAccountColumn), fmt.Sprintf("%s.%s IS NULL", accountUserMembershipsTableName, archivedAtColumn)),
+						buildCursorLimitClause(usersTableName),
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetUsersWithIDs",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s
 FROM %s
 	%s
 WHERE %s.%s IS NULL
 	AND %s.%s = ANY(sqlc.arg(ids)::text[]);`,
-					strings.Join(applyToEach(usersColumns, func(i int, s string) string {
-						return fmt.Sprintf("%s.%s", usersTableName, s)
-					}), ",\n\t"),
-					strings.Join(avatarJoinSelect("avatar"), ",\n\t"),
-					usersTableName,
-					avatarJoinClause,
-					usersTableName,
-					archivedAtColumn,
-					usersTableName,
-					idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetUserRequiresPasswordChange",
-					Type: OneType,
+						strings.Join(applyToEach(usersColumns, func(i int, s string) string {
+							return fmt.Sprintf("%s.%s", usersTableName, s)
+						}), ",\n\t"),
+						strings.Join(avatarJoinSelect("avatar"), ",\n\t"),
+						usersTableName,
+						avatarJoinClause,
+						usersTableName,
+						archivedAtColumn,
+						usersTableName,
+						idColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT %s.%s
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetUserRequiresPasswordChange",
+						Type: OneType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT %s.%s
 FROM %s
 WHERE %s.%s IS NULL
 	AND %s.%s = sqlc.arg(%s);`,
-					usersTableName, requiresPasswordChangeColumn,
-					usersTableName,
-					usersTableName, archivedAtColumn,
-					usersTableName, idColumn, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "ScanUserIDsForReindex",
-					Type: ManyType,
+						usersTableName, requiresPasswordChangeColumn,
+						usersTableName,
+						usersTableName, archivedAtColumn,
+						usersTableName, idColumn, idColumn,
+					)),
 				},
-				Content: buildReindexScanQuery(usersTableName),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetUserIDsNeedingIndexing",
-					Type: ManyType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT %s.%s
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetUserIDsNeedingIndexing",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT %s.%s
 FROM %s
 WHERE %s.%s IS NULL
 	AND %s.%s IS NULL
 	OR %s.%s < %s - '24 hours'::INTERVAL;`,
-					usersTableName, idColumn,
-					usersTableName,
-					usersTableName, archivedAtColumn,
-					usersTableName, lastIndexedAtColumn,
-					usersTableName, lastIndexedAtColumn, currentTimeExpression,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetUserWithUnverifiedTwoFactor",
-					Type: OneType,
+						usersTableName, idColumn,
+						usersTableName,
+						usersTableName, archivedAtColumn,
+						usersTableName, lastIndexedAtColumn,
+						usersTableName, lastIndexedAtColumn, currentTimeExpression,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetUserWithUnverifiedTwoFactor",
+						Type: OneType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s
 FROM %s
@@ -472,23 +444,23 @@ FROM %s
 WHERE %s.%s IS NULL
 	AND %s.%s = sqlc.arg(%s)
 	AND %s.%s IS NULL;`,
-					strings.Join(applyToEach(usersColumns, func(_ int, s string) string {
-						return fmt.Sprintf("%s.%s", usersTableName, s)
-					}), ",\n\t"),
-					strings.Join(avatarJoinSelect("avatar"), ",\n\t"),
-					usersTableName,
-					avatarJoinClause,
-					usersTableName, archivedAtColumn,
-					usersTableName, idColumn, idColumn,
-					usersTableName, twoFactorSecretVerifiedAtColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetUserWithVerifiedTwoFactor",
-					Type: OneType,
+						strings.Join(applyToEach(usersColumns, func(_ int, s string) string {
+							return fmt.Sprintf("%s.%s", usersTableName, s)
+						}), ",\n\t"),
+						strings.Join(avatarJoinSelect("avatar"), ",\n\t"),
+						usersTableName,
+						avatarJoinClause,
+						usersTableName, archivedAtColumn,
+						usersTableName, idColumn, idColumn,
+						usersTableName, twoFactorSecretVerifiedAtColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetUserWithVerifiedTwoFactor",
+						Type: OneType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s
 FROM %s
@@ -496,101 +468,101 @@ FROM %s
 WHERE %s.%s IS NULL
 	AND %s.%s = sqlc.arg(%s)
 	AND %s.%s IS NOT NULL;`,
-					strings.Join(applyToEach(usersColumns, func(_ int, s string) string {
-						return fmt.Sprintf("%s.%s", usersTableName, s)
-					}), ",\n\t"),
-					strings.Join(avatarJoinSelect("avatar"), ",\n\t"),
-					usersTableName,
-					avatarJoinClause,
-					usersTableName, archivedAtColumn,
-					usersTableName, idColumn, idColumn,
-					usersTableName, twoFactorSecretVerifiedAtColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "MarkEmailAddressAsVerified",
-					Type: ExecType,
+						strings.Join(applyToEach(usersColumns, func(_ int, s string) string {
+							return fmt.Sprintf("%s.%s", usersTableName, s)
+						}), ",\n\t"),
+						strings.Join(avatarJoinSelect("avatar"), ",\n\t"),
+						usersTableName,
+						avatarJoinClause,
+						usersTableName, archivedAtColumn,
+						usersTableName, idColumn, idColumn,
+						usersTableName, twoFactorSecretVerifiedAtColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
+				{
+					Annotation: QueryAnnotation{
+						Name: "MarkEmailAddressAsVerified",
+						Type: ExecType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
 	%s = %s,
 	%s = %s
 WHERE %s IS NULL
 	AND %s IS NULL
 	AND %s = sqlc.arg(%s)
 	AND %s = sqlc.arg(%s);`,
-					usersTableName,
-					emailAddressVerifiedAtColumn, currentTimeExpression,
-					lastUpdatedAtColumn, currentTimeExpression,
-					archivedAtColumn,
-					emailAddressVerifiedAtColumn,
-					idColumn, idColumn,
-					emailAddressVerificationTokenColumn, emailAddressVerificationTokenColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "MarkEmailAddressAsUnverified",
-					Type: ExecType,
+						usersTableName,
+						emailAddressVerifiedAtColumn, currentTimeExpression,
+						lastUpdatedAtColumn, currentTimeExpression,
+						archivedAtColumn,
+						emailAddressVerifiedAtColumn,
+						idColumn, idColumn,
+						emailAddressVerificationTokenColumn, emailAddressVerificationTokenColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
+				{
+					Annotation: QueryAnnotation{
+						Name: "MarkEmailAddressAsUnverified",
+						Type: ExecType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
 	%s = NULL,
 	%s = %s
 WHERE %s IS NULL
 	AND %s IS NOT NULL
 	AND %s = sqlc.arg(%s);`,
-					usersTableName,
-					emailAddressVerifiedAtColumn,
-					lastUpdatedAtColumn, currentTimeExpression,
-					archivedAtColumn,
-					emailAddressVerifiedAtColumn,
-					idColumn, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "MarkTwoFactorSecretAsUnverified",
-					Type: ExecType,
+						usersTableName,
+						emailAddressVerifiedAtColumn,
+						lastUpdatedAtColumn, currentTimeExpression,
+						archivedAtColumn,
+						emailAddressVerifiedAtColumn,
+						idColumn, idColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
+				{
+					Annotation: QueryAnnotation{
+						Name: "MarkTwoFactorSecretAsUnverified",
+						Type: ExecType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
 	%s = NULL,
 	%s = sqlc.arg(%s),
 	%s = %s
 WHERE %s IS NULL
 	AND %s = sqlc.arg(%s);`,
-					usersTableName,
-					twoFactorSecretVerifiedAtColumn,
-					twoFactorSecretColumn, twoFactorSecretColumn,
-					lastUpdatedAtColumn,
-					currentTimeExpression,
-					archivedAtColumn,
-					idColumn,
-					idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "MarkTwoFactorSecretAsVerified",
-					Type: ExecType,
+						usersTableName,
+						twoFactorSecretVerifiedAtColumn,
+						twoFactorSecretColumn, twoFactorSecretColumn,
+						lastUpdatedAtColumn,
+						currentTimeExpression,
+						archivedAtColumn,
+						idColumn,
+						idColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
+				{
+					Annotation: QueryAnnotation{
+						Name: "MarkTwoFactorSecretAsVerified",
+						Type: ExecType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
 	%s = %s,
 	%s = %s
 WHERE %s IS NULL
 	AND %s = sqlc.arg(%s);`,
-					usersTableName,
-					twoFactorSecretVerifiedAtColumn, currentTimeExpression,
-					lastUpdatedAtColumn, currentTimeExpression,
-					archivedAtColumn,
-					idColumn, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "SearchUsersByUsername",
-					Type: ManyType,
+						usersTableName,
+						twoFactorSecretVerifiedAtColumn, currentTimeExpression,
+						lastUpdatedAtColumn, currentTimeExpression,
+						archivedAtColumn,
+						idColumn, idColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "SearchUsersByUsername",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s,
@@ -601,143 +573,127 @@ WHERE %s.%s IS NULL
 	AND %s.%s %s
 	%s
 %s;`,
-					strings.Join(applyToEach(usersColumns, func(_ int, s string) string {
-						return fmt.Sprintf("%s.%s", usersTableName, s)
-					}), ",\n\t"),
-					strings.Join(avatarJoinSelect("avatar"), ",\n\t"),
-					buildFilterCountSelect(usersTableName, true, true, []string{}),
-					buildTotalCountSelect(usersTableName, true, []string{}),
-					usersTableName,
-					avatarJoinClause,
-					usersTableName,
-					archivedAtColumn,
-					usersTableName,
-					usernameColumn,
-					buildILIKEForArgument(usernameColumn),
-					buildFilterConditions(
+						strings.Join(applyToEach(usersColumns, func(_ int, s string) string {
+							return fmt.Sprintf("%s.%s", usersTableName, s)
+						}), ",\n\t"),
+						strings.Join(avatarJoinSelect("avatar"), ",\n\t"),
+						buildFilterCountSelect(usersTableName, true, true, []string{}),
+						buildTotalCountSelect(usersTableName, true, []string{}),
 						usersTableName,
-						true,
-						true,
-					),
-					buildCursorLimitClause(usersTableName),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "UpdateUserDetails",
-					Type: ExecRowsType,
+						avatarJoinClause,
+						usersTableName,
+						archivedAtColumn,
+						usersTableName,
+						usernameColumn,
+						buildILIKEForArgument(usernameColumn),
+						buildFilterConditions(
+							usersTableName,
+							true,
+							true,
+						),
+						buildCursorLimitClause(usersTableName),
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
+				{
+					Annotation: QueryAnnotation{
+						Name: "UpdateUserDetails",
+						Type: ExecRowsType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
 	%s = sqlc.arg(%s),
 	%s = sqlc.arg(%s),
 	%s = sqlc.arg(%s),
 	%s = %s
 WHERE %s IS NULL
 	AND %s = sqlc.arg(%s);`,
-					usersTableName,
-					firstNameColumn, firstNameColumn,
-					lastNameColumn, lastNameColumn,
-					birthdayColumn, birthdayColumn,
-					lastUpdatedAtColumn, currentTimeExpression,
-					archivedAtColumn,
-					idColumn, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "UpdateUserEmailAddress",
-					Type: ExecRowsType,
+						usersTableName,
+						firstNameColumn, firstNameColumn,
+						lastNameColumn, lastNameColumn,
+						birthdayColumn, birthdayColumn,
+						lastUpdatedAtColumn, currentTimeExpression,
+						archivedAtColumn,
+						idColumn, idColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
+				{
+					Annotation: QueryAnnotation{
+						Name: "UpdateUserEmailAddress",
+						Type: ExecRowsType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
 	%s = sqlc.arg(%s),
 	%s = NULL,
 	%s = %s
 WHERE %s IS NULL
 	AND %s = sqlc.arg(%s);`,
-					usersTableName,
-					emailAddressColumn, emailAddressColumn,
-					emailAddressVerifiedAtColumn,
-					lastUpdatedAtColumn,
-					currentTimeExpression,
-					archivedAtColumn,
-					idColumn, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "MarkUsersAsIndexed",
-					Type: ExecRowsType,
+						usersTableName,
+						emailAddressColumn, emailAddressColumn,
+						emailAddressVerifiedAtColumn,
+						lastUpdatedAtColumn,
+						currentTimeExpression,
+						archivedAtColumn,
+						idColumn, idColumn,
+					)),
 				},
-				// Bulk, and named for what querygen emits, so migrating this table to
-				// StandardCRUD deletes this declaration without renaming anything.
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
-	%s = %s
-WHERE %s = ANY(sqlc.arg(%s)::text[]);`,
-					usersTableName,
-					lastIndexedAtColumn,
-					currentTimeExpression,
-					idColumn,
-					idsArg,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "UpdateUserPassword",
-					Type: ExecRowsType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
+				{
+					Annotation: QueryAnnotation{
+						Name: "UpdateUserPassword",
+						Type: ExecRowsType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
 	%s = sqlc.arg(%s),
 	%s = FALSE,
 	%s = %s,
 	%s = %s
 WHERE %s IS NULL
 	AND %s = sqlc.arg(%s);`,
-					usersTableName,
-					hashedPasswordColumn, hashedPasswordColumn,
-					requiresPasswordChangeColumn,
-					passwordLastChangedAtColumn, currentTimeExpression,
-					lastUpdatedAtColumn, currentTimeExpression,
-					archivedAtColumn,
-					idColumn, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "UpdateUserTwoFactorSecret",
-					Type: ExecRowsType,
+						usersTableName,
+						hashedPasswordColumn, hashedPasswordColumn,
+						requiresPasswordChangeColumn,
+						passwordLastChangedAtColumn, currentTimeExpression,
+						lastUpdatedAtColumn, currentTimeExpression,
+						archivedAtColumn,
+						idColumn, idColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
+				{
+					Annotation: QueryAnnotation{
+						Name: "UpdateUserTwoFactorSecret",
+						Type: ExecRowsType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
 	%s = NULL,
 	%s = sqlc.arg(%s),
 	%s = %s
 WHERE %s IS NULL
 	AND %s = sqlc.arg(%s);`,
-					usersTableName,
-					twoFactorSecretVerifiedAtColumn,
-					twoFactorSecretColumn, twoFactorSecretColumn,
-					lastUpdatedAtColumn, currentTimeExpression,
-					archivedAtColumn,
-					idColumn, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "UpdateUserUsername",
-					Type: ExecRowsType,
+						usersTableName,
+						twoFactorSecretVerifiedAtColumn,
+						twoFactorSecretColumn, twoFactorSecretColumn,
+						lastUpdatedAtColumn, currentTimeExpression,
+						archivedAtColumn,
+						idColumn, idColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
+				{
+					Annotation: QueryAnnotation{
+						Name: "UpdateUserUsername",
+						Type: ExecRowsType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
 	%s = sqlc.arg(%s),
 	%s = %s
 WHERE %s IS NULL
 	AND %s = sqlc.arg(%s);`,
-					usersTableName,
-					usernameColumn, usernameColumn,
-					lastUpdatedAtColumn, currentTimeExpression,
-					archivedAtColumn,
-					idColumn, idColumn,
-				)),
+						usersTableName,
+						usernameColumn, usernameColumn,
+						lastUpdatedAtColumn, currentTimeExpression,
+						archivedAtColumn,
+						idColumn, idColumn,
+					)),
+				},
 			},
-		}
+		)
 	default:
 		return nil
 	}

--- a/backend/cmd/tools/codegen/queries/issuereports_issue_reports.go
+++ b/backend/cmd/tools/codegen/queries/issuereports_issue_reports.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"fmt"
+	"slices"
 	"strings"
+
+	"github.com/primandproper/platform-go/v11/database/querygen"
 
 	"github.com/cristalhq/builq"
 )
@@ -35,104 +38,57 @@ var issueReportsColumns = []string{
 func buildIssueReportsQueries(database string) []*Query {
 	switch database {
 	case postgres:
-		insertColumns := filterForInsert(issueReportsColumns)
 		fullSelectColumns := applyToEach(issueReportsColumns, func(_ int, s string) string {
 			return fullColumnName(issueReportsTableName, s)
 		})
 
-		return []*Query{
-			{
-				Annotation: QueryAnnotation{
-					Name: "CreateIssueReport",
-					Type: ExecType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`INSERT INTO %s (
-	%s
-) VALUES (
-	%s
-);`,
-					issueReportsTableName,
-					strings.Join(insertColumns, ",\n\t"),
-					strings.Join(applyToEach(insertColumns, func(_ int, s string) string {
-						return fmt.Sprintf("sqlc.arg(%s)", s)
-					}), ",\n\t"),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "UpdateIssueReport",
-					Type: ExecRowsType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
-	%s,
-	%s = %s
-WHERE %s IS NULL
-	AND %s = sqlc.arg(%s);`,
-					issueReportsTableName,
-					strings.Join(applyToEach(filterForUpdate(issueReportsColumns, createdByUserColumn, belongsToAccountColumn), func(_ int, s string) string {
-						return fmt.Sprintf("%s = sqlc.arg(%s)", s, s)
-					}), ",\n\t"),
-					lastUpdatedAtColumn, currentTimeExpression,
-					archivedAtColumn,
-					idColumn, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "ArchiveIssueReport",
-					Type: ExecRowsType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
+		return slices.Concat(
+			querygen.StandardCRUD(issueReportsTableName, issueReportsColumns,
+				querygen.WithEntity("IssueReport", "IssueReports"),
+				querygen.WithImmutable(createdByUserColumn, belongsToAccountColumn),
+				querygen.WithOmitted(querygen.ArchiveQuery, querygen.ExistsQuery, querygen.ListQuery),
+			),
+			[]*Query{
+				{
+					Annotation: QueryAnnotation{
+						Name: "ArchiveIssueReport",
+						Type: ExecRowsType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
 	%s = %s,
 	%s = %s
 WHERE %s IS NULL
 	AND %s = sqlc.arg(%s);`,
-					issueReportsTableName,
-					lastUpdatedAtColumn, currentTimeExpression,
-					archivedAtColumn, currentTimeExpression,
-					archivedAtColumn,
-					idColumn, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetIssueReport",
-					Type: OneType,
+						issueReportsTableName,
+						lastUpdatedAtColumn, currentTimeExpression,
+						archivedAtColumn, currentTimeExpression,
+						archivedAtColumn,
+						idColumn, idColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
-	%s
-FROM %s
-WHERE %s.%s IS NULL
-	AND %s.%s = sqlc.arg(%s);`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					issueReportsTableName,
-					issueReportsTableName, archivedAtColumn,
-					issueReportsTableName, idColumn, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CheckIssueReportExistence",
-					Type: OneType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT EXISTS(
+				{
+					Annotation: QueryAnnotation{
+						Name: "CheckIssueReportExistence",
+						Type: OneType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT EXISTS(
 	SELECT %s.%s
 	FROM %s
 	WHERE %s.%s IS NULL
 		AND %s.%s = sqlc.arg(%s)
 );`,
-					issueReportsTableName, idColumn,
-					issueReportsTableName,
-					issueReportsTableName, archivedAtColumn,
-					issueReportsTableName, idColumn, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetIssueReports",
-					Type: ManyType,
+						issueReportsTableName, idColumn,
+						issueReportsTableName,
+						issueReportsTableName, archivedAtColumn,
+						issueReportsTableName, idColumn, idColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetIssueReports",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s
@@ -140,45 +96,21 @@ FROM %s
 WHERE %s.%s IS NULL
 	%s
 %s;`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					buildFilterCountSelect(issueReportsTableName, true, true, nil),
-					buildTotalCountSelect(issueReportsTableName, true, nil),
-					issueReportsTableName,
-					issueReportsTableName, archivedAtColumn,
-					buildFilterConditions(issueReportsTableName, true, false),
-					buildCursorLimitClause(issueReportsTableName),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetIssueReportsForAccount",
-					Type: ManyType,
+						strings.Join(fullSelectColumns, ",\n\t"),
+						buildFilterCountSelect(issueReportsTableName, true, true, nil),
+						buildTotalCountSelect(issueReportsTableName, true, nil),
+						issueReportsTableName,
+						issueReportsTableName, archivedAtColumn,
+						buildFilterConditions(issueReportsTableName, true, false),
+						buildCursorLimitClause(issueReportsTableName),
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
-	%s,
-	%s,
-	%s
-FROM %s
-WHERE %s.%s IS NULL
-	AND %s.%s = sqlc.arg(%s)
-	%s
-%s;`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					buildFilterCountSelect(issueReportsTableName, true, true, nil, fmt.Sprintf("%s.%s = sqlc.arg(%s)", issueReportsTableName, belongsToAccountColumn, belongsToAccountColumn)),
-					buildTotalCountSelect(issueReportsTableName, true, nil, fmt.Sprintf("%s.%s = sqlc.arg(%s)", issueReportsTableName, belongsToAccountColumn, belongsToAccountColumn)),
-					issueReportsTableName,
-					issueReportsTableName, archivedAtColumn,
-					issueReportsTableName, belongsToAccountColumn, belongsToAccountColumn,
-					buildFilterConditions(issueReportsTableName, true, false, fmt.Sprintf("%s.%s = sqlc.arg(%s)", issueReportsTableName, belongsToAccountColumn, belongsToAccountColumn)),
-					buildCursorLimitClause(issueReportsTableName),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetIssueReportsForTable",
-					Type: ManyType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetIssueReportsForAccount",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s
@@ -187,22 +119,46 @@ WHERE %s.%s IS NULL
 	AND %s.%s = sqlc.arg(%s)
 	%s
 %s;`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					buildFilterCountSelect(issueReportsTableName, true, true, nil, fmt.Sprintf("%s.%s = sqlc.arg(%s)", issueReportsTableName, relevantTableColumn, relevantTableColumn)),
-					buildTotalCountSelect(issueReportsTableName, true, nil, fmt.Sprintf("%s.%s = sqlc.arg(%s)", issueReportsTableName, relevantTableColumn, relevantTableColumn)),
-					issueReportsTableName,
-					issueReportsTableName, archivedAtColumn,
-					issueReportsTableName, relevantTableColumn, relevantTableColumn,
-					buildFilterConditions(issueReportsTableName, true, false, fmt.Sprintf("%s.%s = sqlc.arg(%s)", issueReportsTableName, relevantTableColumn, relevantTableColumn)),
-					buildCursorLimitClause(issueReportsTableName),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetIssueReportsForRecord",
-					Type: ManyType,
+						strings.Join(fullSelectColumns, ",\n\t"),
+						buildFilterCountSelect(issueReportsTableName, true, true, nil, fmt.Sprintf("%s.%s = sqlc.arg(%s)", issueReportsTableName, belongsToAccountColumn, belongsToAccountColumn)),
+						buildTotalCountSelect(issueReportsTableName, true, nil, fmt.Sprintf("%s.%s = sqlc.arg(%s)", issueReportsTableName, belongsToAccountColumn, belongsToAccountColumn)),
+						issueReportsTableName,
+						issueReportsTableName, archivedAtColumn,
+						issueReportsTableName, belongsToAccountColumn, belongsToAccountColumn,
+						buildFilterConditions(issueReportsTableName, true, false, fmt.Sprintf("%s.%s = sqlc.arg(%s)", issueReportsTableName, belongsToAccountColumn, belongsToAccountColumn)),
+						buildCursorLimitClause(issueReportsTableName),
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetIssueReportsForTable",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+	%s,
+	%s,
+	%s
+FROM %s
+WHERE %s.%s IS NULL
+	AND %s.%s = sqlc.arg(%s)
+	%s
+%s;`,
+						strings.Join(fullSelectColumns, ",\n\t"),
+						buildFilterCountSelect(issueReportsTableName, true, true, nil, fmt.Sprintf("%s.%s = sqlc.arg(%s)", issueReportsTableName, relevantTableColumn, relevantTableColumn)),
+						buildTotalCountSelect(issueReportsTableName, true, nil, fmt.Sprintf("%s.%s = sqlc.arg(%s)", issueReportsTableName, relevantTableColumn, relevantTableColumn)),
+						issueReportsTableName,
+						issueReportsTableName, archivedAtColumn,
+						issueReportsTableName, relevantTableColumn, relevantTableColumn,
+						buildFilterConditions(issueReportsTableName, true, false, fmt.Sprintf("%s.%s = sqlc.arg(%s)", issueReportsTableName, relevantTableColumn, relevantTableColumn)),
+						buildCursorLimitClause(issueReportsTableName),
+					)),
+				},
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetIssueReportsForRecord",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s
@@ -212,24 +168,25 @@ WHERE %s.%s IS NULL
 	AND %s.%s = sqlc.arg(%s)
 	%s
 %s;`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					buildFilterCountSelect(issueReportsTableName, true, true, nil,
-						fmt.Sprintf("%s.%s = sqlc.arg(%s)", issueReportsTableName, relevantTableColumn, relevantTableColumn),
-						fmt.Sprintf("%s.%s = sqlc.arg(%s)", issueReportsTableName, relevantRecordIDColumn, relevantRecordIDColumn)),
-					buildTotalCountSelect(issueReportsTableName, true, nil,
-						fmt.Sprintf("%s.%s = sqlc.arg(%s)", issueReportsTableName, relevantTableColumn, relevantTableColumn),
-						fmt.Sprintf("%s.%s = sqlc.arg(%s)", issueReportsTableName, relevantRecordIDColumn, relevantRecordIDColumn)),
-					issueReportsTableName,
-					issueReportsTableName, archivedAtColumn,
-					issueReportsTableName, relevantTableColumn, relevantTableColumn,
-					issueReportsTableName, relevantRecordIDColumn, relevantRecordIDColumn,
-					buildFilterConditions(issueReportsTableName, true, false,
-						fmt.Sprintf("%s.%s = sqlc.arg(%s)", issueReportsTableName, relevantTableColumn, relevantTableColumn),
-						fmt.Sprintf("%s.%s = sqlc.arg(%s)", issueReportsTableName, relevantRecordIDColumn, relevantRecordIDColumn)),
-					buildCursorLimitClause(issueReportsTableName),
-				)),
+						strings.Join(fullSelectColumns, ",\n\t"),
+						buildFilterCountSelect(issueReportsTableName, true, true, nil,
+							fmt.Sprintf("%s.%s = sqlc.arg(%s)", issueReportsTableName, relevantTableColumn, relevantTableColumn),
+							fmt.Sprintf("%s.%s = sqlc.arg(%s)", issueReportsTableName, relevantRecordIDColumn, relevantRecordIDColumn)),
+						buildTotalCountSelect(issueReportsTableName, true, nil,
+							fmt.Sprintf("%s.%s = sqlc.arg(%s)", issueReportsTableName, relevantTableColumn, relevantTableColumn),
+							fmt.Sprintf("%s.%s = sqlc.arg(%s)", issueReportsTableName, relevantRecordIDColumn, relevantRecordIDColumn)),
+						issueReportsTableName,
+						issueReportsTableName, archivedAtColumn,
+						issueReportsTableName, relevantTableColumn, relevantTableColumn,
+						issueReportsTableName, relevantRecordIDColumn, relevantRecordIDColumn,
+						buildFilterConditions(issueReportsTableName, true, false,
+							fmt.Sprintf("%s.%s = sqlc.arg(%s)", issueReportsTableName, relevantTableColumn, relevantTableColumn),
+							fmt.Sprintf("%s.%s = sqlc.arg(%s)", issueReportsTableName, relevantRecordIDColumn, relevantRecordIDColumn)),
+						buildCursorLimitClause(issueReportsTableName),
+					)),
+				},
 			},
-		}
+		)
 	default:
 		return nil
 	}

--- a/backend/cmd/tools/codegen/queries/mealplanning_account_instrument_ownerships.go
+++ b/backend/cmd/tools/codegen/queries/mealplanning_account_instrument_ownerships.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"fmt"
+	"slices"
 	"strings"
+
+	"github.com/primandproper/platform-go/v11/database/querygen"
 
 	"github.com/cristalhq/builq"
 )
@@ -30,8 +33,6 @@ func buildAccountInstrumentOwnershipQueries(database string) []*Query {
 	switch database {
 	case postgres:
 
-		insertColumns := filterForInsert(accountInstrumentOwnershipsColumns)
-
 		fullSelectColumns := mergeColumns(
 			applyToEach(filterFromSlice(accountInstrumentOwnershipsColumns, validInstrumentIDColumn), func(i int, s string) string {
 				return fmt.Sprintf("%s.%s", accountInstrumentOwnershipsTableName, s)
@@ -42,67 +43,19 @@ func buildAccountInstrumentOwnershipQueries(database string) []*Query {
 			3,
 		)
 
-		return []*Query{
-			{
-				Annotation: QueryAnnotation{
-					Name: "ArchiveAccountInstrumentOwnership",
-					Type: ExecRowsType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
-	%s = %s
-WHERE %s IS NULL
-	AND %s = sqlc.arg(%s)
-	AND %s = sqlc.arg(%s);`,
-					accountInstrumentOwnershipsTableName,
-					archivedAtColumn, currentTimeExpression,
-					archivedAtColumn,
-					idColumn, idColumn,
-					belongsToAccountColumn, belongsToAccountColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CreateAccountInstrumentOwnership",
-					Type: ExecType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`INSERT INTO %s (
-	%s
-) VALUES (
-	%s
-);`,
-					accountInstrumentOwnershipsTableName,
-					strings.Join(insertColumns, ",\n\t"),
-					strings.Join(applyToEach(insertColumns, func(i int, s string) string {
-						return fmt.Sprintf("sqlc.arg(%s)", s)
-					}), ",\n\t"),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CheckAccountInstrumentOwnershipExistence",
-					Type: OneType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT EXISTS (
-	SELECT %s.id
-	FROM %s
-	WHERE %s.%s IS NULL
-		AND %s.%s = sqlc.arg(%s)
-		AND %s.%s = sqlc.arg(%s)
-);`,
-					accountInstrumentOwnershipsTableName,
-					accountInstrumentOwnershipsTableName,
-					accountInstrumentOwnershipsTableName,
-					archivedAtColumn,
-					accountInstrumentOwnershipsTableName, idColumn, idColumn,
-					accountInstrumentOwnershipsTableName, belongsToAccountColumn, belongsToAccountColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetAccountInstrumentOwnerships",
-					Type: ManyType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+		return slices.Concat(
+			querygen.StandardCRUD(accountInstrumentOwnershipsTableName, accountInstrumentOwnershipsColumns,
+				querygen.WithEntity("AccountInstrumentOwnership", "AccountInstrumentOwnerships"),
+				querygen.WithOwnership(belongsToAccountColumn),
+				querygen.WithOmitted(querygen.GetQuery, querygen.ListQuery),
+			),
+			[]*Query{
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetAccountInstrumentOwnerships",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s
@@ -115,62 +68,41 @@ GROUP BY
 	%s.%s,
 	%s.%s
 %s;`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					buildFilterCountSelect(accountInstrumentOwnershipsTableName, true, true, []string{}, "account_instrument_ownerships.belongs_to_account = sqlc.arg(account_id)"),
-					buildTotalCountSelect(accountInstrumentOwnershipsTableName, true, []string{}, "account_instrument_ownerships.belongs_to_account = sqlc.arg(account_id)"),
-					accountInstrumentOwnershipsTableName,
-					validInstrumentsTableName, accountInstrumentOwnershipsTableName, validInstrumentIDColumn, validInstrumentsTableName, idColumn,
-					accountInstrumentOwnershipsTableName, archivedAtColumn,
-					buildFilterConditions(accountInstrumentOwnershipsTableName, true, true, "account_instrument_ownerships.belongs_to_account = sqlc.arg(account_id)"),
-					accountInstrumentOwnershipsTableName, idColumn,
-					validInstrumentsTableName, idColumn,
-					buildCursorLimitClause(accountInstrumentOwnershipsTableName),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetAccountInstrumentOwnership",
-					Type: OneType,
+						strings.Join(fullSelectColumns, ",\n\t"),
+						buildFilterCountSelect(accountInstrumentOwnershipsTableName, true, true, []string{}, "account_instrument_ownerships.belongs_to_account = sqlc.arg(account_id)"),
+						buildTotalCountSelect(accountInstrumentOwnershipsTableName, true, []string{}, "account_instrument_ownerships.belongs_to_account = sqlc.arg(account_id)"),
+						accountInstrumentOwnershipsTableName,
+						validInstrumentsTableName, accountInstrumentOwnershipsTableName, validInstrumentIDColumn, validInstrumentsTableName, idColumn,
+						accountInstrumentOwnershipsTableName, archivedAtColumn,
+						buildFilterConditions(accountInstrumentOwnershipsTableName, true, true, "account_instrument_ownerships.belongs_to_account = sqlc.arg(account_id)"),
+						accountInstrumentOwnershipsTableName, idColumn,
+						validInstrumentsTableName, idColumn,
+						buildCursorLimitClause(accountInstrumentOwnershipsTableName),
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetAccountInstrumentOwnership",
+						Type: OneType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s
 FROM %s
 INNER JOIN %s ON %s.%s = %s.%s
 WHERE %s.%s IS NULL
 	AND %s.%s = sqlc.arg(%s)
 	AND %s.%s = sqlc.arg(%s);`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					accountInstrumentOwnershipsTableName,
-					validInstrumentsTableName, accountInstrumentOwnershipsTableName, validInstrumentIDColumn, validInstrumentsTableName, idColumn,
-					accountInstrumentOwnershipsTableName,
-					archivedAtColumn,
-					accountInstrumentOwnershipsTableName, idColumn, idColumn,
-					accountInstrumentOwnershipsTableName, belongsToAccountColumn, belongsToAccountColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "UpdateAccountInstrumentOwnership",
-					Type: ExecRowsType,
+						strings.Join(fullSelectColumns, ",\n\t"),
+						accountInstrumentOwnershipsTableName,
+						validInstrumentsTableName, accountInstrumentOwnershipsTableName, validInstrumentIDColumn, validInstrumentsTableName, idColumn,
+						accountInstrumentOwnershipsTableName,
+						archivedAtColumn,
+						accountInstrumentOwnershipsTableName, idColumn, idColumn,
+						accountInstrumentOwnershipsTableName, belongsToAccountColumn, belongsToAccountColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
-	%s,
-	%s = %s
-WHERE %s IS NULL
-	AND %s = sqlc.arg(%s)
-	AND %s.%s = sqlc.arg(%s);`,
-					accountInstrumentOwnershipsTableName,
-					strings.Join(applyToEach(filterForUpdate(accountInstrumentOwnershipsColumns, belongsToAccountColumn), func(i int, s string) string {
-						return fmt.Sprintf("%s = sqlc.arg(%s)", s, s)
-					}), ",\n\t"),
-					lastUpdatedAtColumn,
-					currentTimeExpression,
-					archivedAtColumn,
-					idColumn, idColumn,
-					accountInstrumentOwnershipsTableName, belongsToAccountColumn, belongsToAccountColumn,
-				)),
 			},
-		}
+		)
 	default:
 		return nil
 	}

--- a/backend/cmd/tools/codegen/queries/mealplanning_meal_components.go
+++ b/backend/cmd/tools/codegen/queries/mealplanning_meal_components.go
@@ -1,10 +1,7 @@
 package main
 
 import (
-	"fmt"
-	"strings"
-
-	"github.com/cristalhq/builq"
+	"github.com/primandproper/platform-go/v11/database/querygen"
 )
 
 const (
@@ -31,27 +28,10 @@ func buildMealComponentsQueries(database string) []*Query {
 	switch database {
 	case postgres:
 
-		insertColumns := filterForInsert(mealComponentsColumns)
-
-		return []*Query{
-			{
-				Annotation: QueryAnnotation{
-					Name: "CreateMealComponent",
-					Type: ExecType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`INSERT INTO %s (
-	%s
-) VALUES (
-	%s
-);`,
-					mealComponentsTableName,
-					strings.Join(insertColumns, ",\n\t"),
-					strings.Join(applyToEach(insertColumns, func(i int, s string) string {
-						return fmt.Sprintf("sqlc.arg(%s)", s)
-					}), ",\n\t"),
-				)),
-			},
-		}
+		return querygen.StandardCRUD(mealComponentsTableName, mealComponentsColumns,
+			querygen.WithEntity("MealComponent", "MealComponents"),
+			querygen.WithOmitted(querygen.ArchiveQuery, querygen.ExistsQuery, querygen.GetQuery, querygen.ListQuery, querygen.UpdateQuery),
+		)
 	default:
 		return nil
 	}

--- a/backend/cmd/tools/codegen/queries/mealplanning_meal_list_items.go
+++ b/backend/cmd/tools/codegen/queries/mealplanning_meal_list_items.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"fmt"
+	"slices"
 	"strings"
+
+	"github.com/primandproper/platform-go/v11/database/querygen"
 
 	"github.com/cristalhq/builq"
 )
@@ -31,64 +34,38 @@ func buildMealListItemsQueries(database string) []*Query {
 	switch database {
 	case postgres:
 
-		insertColumns := filterForInsert(mealListItemsColumns)
-
-		return []*Query{
-			{
-				Annotation: QueryAnnotation{
-					Name: "CheckMealInMealList",
-					Type: OneType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT EXISTS (
+		return slices.Concat(
+			querygen.StandardCRUD(mealListItemsTableName, mealListItemsColumns,
+				querygen.WithEntity("MealListItem", "MealListItems"),
+				querygen.WithOwnership("belongs_to_meal_list"),
+				querygen.WithOmitted(querygen.ExistsQuery, querygen.GetQuery, querygen.ListQuery),
+			),
+			[]*Query{
+				{
+					Annotation: QueryAnnotation{
+						Name: "CheckMealInMealList",
+						Type: OneType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT EXISTS (
 	SELECT %s.%s
 	FROM %s
 	WHERE %s.%s IS NULL
 		AND %s.belongs_to_meal_list = sqlc.arg(%s)
 		AND %s.%s = sqlc.arg(%s)
 );`,
-					mealListItemsTableName, idColumn,
-					mealListItemsTableName,
-					mealListItemsTableName, archivedAtColumn,
-					mealListItemsTableName, "belongs_to_meal_list",
-					mealListItemsTableName, mealIDColumn, mealIDColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "ArchiveMealListItem",
-					Type: ExecRowsType,
+						mealListItemsTableName, idColumn,
+						mealListItemsTableName,
+						mealListItemsTableName, archivedAtColumn,
+						mealListItemsTableName, "belongs_to_meal_list",
+						mealListItemsTableName, mealIDColumn, mealIDColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET %s = %s WHERE %s IS NULL AND %s = sqlc.arg(%s) AND %s = sqlc.arg(%s);`,
-					mealListItemsTableName,
-					archivedAtColumn, currentTimeExpression,
-					archivedAtColumn,
-					"belongs_to_meal_list", "belongs_to_meal_list",
-					idColumn, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CreateMealListItem",
-					Type: ExecType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`INSERT INTO %s (
-	%s
-) VALUES (
-	%s
-);`,
-					mealListItemsTableName,
-					strings.Join(insertColumns, ",\n\t"),
-					strings.Join(applyToEach(insertColumns, func(i int, s string) string {
-						return fmt.Sprintf("sqlc.arg(%s)", s)
-					}), ",\n\t"),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetMealListItems",
-					Type: ManyType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetMealListItems",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s
@@ -97,40 +74,20 @@ WHERE %s.%s IS NULL
 	%s
 	AND %s.belongs_to_meal_list = sqlc.arg(%s)
 %s;`,
-					strings.Join(applyToEach(mealListItemsColumns, func(i int, s string) string {
-						return fmt.Sprintf("%s.%s", mealListItemsTableName, s)
-					}), ",\n\t"),
-					buildFilterCountSelect(mealListItemsTableName, true, true, []string{}, fmt.Sprintf("%s.belongs_to_meal_list = sqlc.arg(%s)", mealListItemsTableName, mealListIDColumn), fmt.Sprintf("EXISTS (SELECT 1 FROM %s WHERE %s.%s = %s.belongs_to_meal_list AND %s.%s = sqlc.arg(%s))", mealListsTableName, mealListsTableName, idColumn, mealListItemsTableName, mealListsTableName, belongsToUserColumn, belongsToUserColumn)),
-					buildTotalCountSelect(mealListItemsTableName, true, []string{}),
-					mealListItemsTableName,
-					mealListItemsTableName, archivedAtColumn,
-					buildFilterConditions(mealListItemsTableName, true, false, fmt.Sprintf("%s.belongs_to_meal_list = sqlc.arg(%s)", mealListItemsTableName, mealListIDColumn), fmt.Sprintf("EXISTS (SELECT 1 FROM %s WHERE %s.%s = %s.belongs_to_meal_list AND %s.%s = sqlc.arg(%s))", mealListsTableName, mealListsTableName, idColumn, mealListItemsTableName, mealListsTableName, belongsToUserColumn, belongsToUserColumn)),
-					mealListItemsTableName, mealListIDColumn,
-					buildCursorLimitClause(mealListItemsTableName),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "UpdateMealListItem",
-					Type: ExecRowsType,
+						strings.Join(applyToEach(mealListItemsColumns, func(i int, s string) string {
+							return fmt.Sprintf("%s.%s", mealListItemsTableName, s)
+						}), ",\n\t"),
+						buildFilterCountSelect(mealListItemsTableName, true, true, []string{}, fmt.Sprintf("%s.belongs_to_meal_list = sqlc.arg(%s)", mealListItemsTableName, mealListIDColumn), fmt.Sprintf("EXISTS (SELECT 1 FROM %s WHERE %s.%s = %s.belongs_to_meal_list AND %s.%s = sqlc.arg(%s))", mealListsTableName, mealListsTableName, idColumn, mealListItemsTableName, mealListsTableName, belongsToUserColumn, belongsToUserColumn)),
+						buildTotalCountSelect(mealListItemsTableName, true, []string{}),
+						mealListItemsTableName,
+						mealListItemsTableName, archivedAtColumn,
+						buildFilterConditions(mealListItemsTableName, true, false, fmt.Sprintf("%s.belongs_to_meal_list = sqlc.arg(%s)", mealListItemsTableName, mealListIDColumn), fmt.Sprintf("EXISTS (SELECT 1 FROM %s WHERE %s.%s = %s.belongs_to_meal_list AND %s.%s = sqlc.arg(%s))", mealListsTableName, mealListsTableName, idColumn, mealListItemsTableName, mealListsTableName, belongsToUserColumn, belongsToUserColumn)),
+						mealListItemsTableName, mealListIDColumn,
+						buildCursorLimitClause(mealListItemsTableName),
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
-	%s,
-	%s = %s
-WHERE %s IS NULL
-	AND %s = sqlc.arg(%s)
-	AND %s = sqlc.arg(%s);`,
-					mealListItemsTableName,
-					strings.Join(applyToEach(filterForUpdate(mealListItemsColumns, "belongs_to_meal_list"), func(i int, s string) string {
-						return fmt.Sprintf("%s = sqlc.arg(%s)", s, s)
-					}), ",\n\t"),
-					lastUpdatedAtColumn, currentTimeExpression,
-					archivedAtColumn,
-					"belongs_to_meal_list", "belongs_to_meal_list",
-					idColumn, idColumn,
-				)),
 			},
-		}
+		)
 	default:
 		return nil
 	}

--- a/backend/cmd/tools/codegen/queries/mealplanning_meal_lists.go
+++ b/backend/cmd/tools/codegen/queries/mealplanning_meal_lists.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"fmt"
+	"slices"
 	"strings"
+
+	"github.com/primandproper/platform-go/v11/database/querygen"
 
 	"github.com/cristalhq/builq"
 )
@@ -29,7 +32,6 @@ func buildMealListsQueries(database string) []*Query {
 	switch database {
 	case postgres:
 
-		insertColumns := filterForInsert(mealListsColumns)
 		fullSelectColumns := mergeColumns(
 			applyToEach(mealListsColumns, func(i int, s string) string {
 				return fmt.Sprintf("%s.%s", mealListsTableName, s)
@@ -40,43 +42,19 @@ func buildMealListsQueries(database string) []*Query {
 			2,
 		)
 
-		return []*Query{
-			{
-				Annotation: QueryAnnotation{
-					Name: "ArchiveMealList",
-					Type: ExecRowsType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET %s = %s WHERE %s IS NULL AND %s = sqlc.arg(%s) AND %s = sqlc.arg(%s);`,
-					mealListsTableName,
-					archivedAtColumn, currentTimeExpression,
-					archivedAtColumn,
-					belongsToUserColumn, belongsToUserColumn,
-					idColumn, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CreateMealList",
-					Type: ExecType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`INSERT INTO %s (
-	%s
-) VALUES (
-	%s
-);`,
-					mealListsTableName,
-					strings.Join(insertColumns, ",\n\t"),
-					strings.Join(applyToEach(insertColumns, func(i int, s string) string {
-						return fmt.Sprintf("sqlc.arg(%s)", s)
-					}), ",\n\t"),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetMealLists",
-					Type: ManyType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+		return slices.Concat(
+			querygen.StandardCRUD(mealListsTableName, mealListsColumns,
+				querygen.WithEntity("MealList", "MealLists"),
+				querygen.WithOwnership(belongsToUserColumn),
+				querygen.WithOmitted(querygen.ExistsQuery, querygen.GetQuery, querygen.ListQuery),
+			),
+			[]*Query{
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetMealLists",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s
@@ -85,38 +63,18 @@ FROM %s
 	WHERE %s.%s IS NULL
 	%s
 %s;`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					buildFilterCountSelect(mealListsTableName, true, true, []string{}, fmt.Sprintf("%s.%s = sqlc.arg(%s)", mealListsTableName, belongsToUserColumn, belongsToUserColumn)),
-					buildTotalCountSelect(mealListsTableName, true, []string{}, fmt.Sprintf("%s.%s = sqlc.arg(%s)", mealListsTableName, belongsToUserColumn, belongsToUserColumn)),
-					mealListsTableName,
-					mealListItemsTableName, mealListItemsTableName, "belongs_to_meal_list", mealListsTableName, idColumn, mealListItemsTableName, archivedAtColumn,
-					mealListsTableName, archivedAtColumn,
-					buildFilterConditions(mealListsTableName, true, false, fmt.Sprintf("%s.%s = sqlc.arg(%s)", mealListsTableName, belongsToUserColumn, belongsToUserColumn)),
-					buildCursorLimitClause(mealListsTableName),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "UpdateMealList",
-					Type: ExecRowsType,
+						strings.Join(fullSelectColumns, ",\n\t"),
+						buildFilterCountSelect(mealListsTableName, true, true, []string{}, fmt.Sprintf("%s.%s = sqlc.arg(%s)", mealListsTableName, belongsToUserColumn, belongsToUserColumn)),
+						buildTotalCountSelect(mealListsTableName, true, []string{}, fmt.Sprintf("%s.%s = sqlc.arg(%s)", mealListsTableName, belongsToUserColumn, belongsToUserColumn)),
+						mealListsTableName,
+						mealListItemsTableName, mealListItemsTableName, "belongs_to_meal_list", mealListsTableName, idColumn, mealListItemsTableName, archivedAtColumn,
+						mealListsTableName, archivedAtColumn,
+						buildFilterConditions(mealListsTableName, true, false, fmt.Sprintf("%s.%s = sqlc.arg(%s)", mealListsTableName, belongsToUserColumn, belongsToUserColumn)),
+						buildCursorLimitClause(mealListsTableName),
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
-	%s,
-	%s = %s
-WHERE %s IS NULL
-	AND %s = sqlc.arg(%s)
-	AND %s = sqlc.arg(%s);`,
-					mealListsTableName,
-					strings.Join(applyToEach(filterForUpdate(mealListsColumns, belongsToUserColumn), func(i int, s string) string {
-						return fmt.Sprintf("%s = sqlc.arg(%s)", s, s)
-					}), ",\n\t"),
-					lastUpdatedAtColumn, currentTimeExpression,
-					archivedAtColumn,
-					belongsToUserColumn, belongsToUserColumn,
-					idColumn, idColumn,
-				)),
 			},
-		}
+		)
 	default:
 		return nil
 	}

--- a/backend/cmd/tools/codegen/queries/mealplanning_meal_plan_events.go
+++ b/backend/cmd/tools/codegen/queries/mealplanning_meal_plan_events.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"fmt"
+	"slices"
 	"strings"
+
+	"github.com/primandproper/platform-go/v11/database/querygen"
 
 	"github.com/cristalhq/builq"
 )
@@ -35,48 +38,19 @@ func buildMealPlanEventsQueries(database string) []*Query {
 	switch database {
 	case postgres:
 
-		insertColumns := filterForInsert(mealPlanEventsColumns)
-
-		return []*Query{
-			{
-				Annotation: QueryAnnotation{
-					Name: "ArchiveMealPlanEvent",
-					Type: ExecRowsType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET %s = %s WHERE %s IS NULL AND %s = sqlc.arg(%s) AND %s = sqlc.arg(%s);`,
-					mealPlanEventsTableName,
-					archivedAtColumn,
-					currentTimeExpression,
-					archivedAtColumn,
-					idColumn,
-					idColumn,
-					belongsToMealPlanColumn,
-					belongsToMealPlanColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CreateMealPlanEvent",
-					Type: ExecType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`INSERT INTO %s (
-	%s
-) VALUES (
-	%s
-);`,
-					mealPlanEventsTableName,
-					strings.Join(insertColumns, ",\n\t"),
-					strings.Join(applyToEach(insertColumns, func(i int, s string) string {
-						return fmt.Sprintf("sqlc.arg(%s)", s)
-					}), ",\n\t"),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "MealPlanEventIsEligibleForVoting",
-					Type: OneType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT EXISTS (
+		return slices.Concat(
+			querygen.StandardCRUD(mealPlanEventsTableName, mealPlanEventsColumns,
+				querygen.WithEntity("MealPlanEvent", "MealPlanEvents"),
+				querygen.WithOwnership(belongsToMealPlanColumn),
+				querygen.WithOmitted(querygen.ExistsQuery, querygen.ListQuery, querygen.UpdateQuery),
+			),
+			[]*Query{
+				{
+					Annotation: QueryAnnotation{
+						Name: "MealPlanEventIsEligibleForVoting",
+						Type: OneType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT EXISTS (
 	SELECT %s.%s
 	FROM %s
 		JOIN %s ON %s.%s = %s.%s
@@ -88,42 +62,42 @@ func buildMealPlanEventsQueries(database string) []*Query {
 		AND %s.%s = sqlc.arg(%s)
 		AND %s.%s IS NULL
 );`,
-					mealPlanEventsTableName, idColumn,
-					mealPlanEventsTableName,
-					mealPlansTableName, mealPlanEventsTableName, belongsToMealPlanColumn, mealPlansTableName, idColumn,
-					mealPlanEventsTableName, archivedAtColumn,
-					mealPlansTableName, idColumn, mealPlanIDColumn,
-					mealPlansTableName, mealPlanStatusColumn,
-					mealPlansTableName, archivedAtColumn,
-					mealPlanEventsTableName, idColumn, mealPlanEventIDColumn,
-					mealPlanEventsTableName, archivedAtColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CheckMealPlanEventExistence",
-					Type: OneType,
+						mealPlanEventsTableName, idColumn,
+						mealPlanEventsTableName,
+						mealPlansTableName, mealPlanEventsTableName, belongsToMealPlanColumn, mealPlansTableName, idColumn,
+						mealPlanEventsTableName, archivedAtColumn,
+						mealPlansTableName, idColumn, mealPlanIDColumn,
+						mealPlansTableName, mealPlanStatusColumn,
+						mealPlansTableName, archivedAtColumn,
+						mealPlanEventsTableName, idColumn, mealPlanEventIDColumn,
+						mealPlanEventsTableName, archivedAtColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT EXISTS (
+				{
+					Annotation: QueryAnnotation{
+						Name: "CheckMealPlanEventExistence",
+						Type: OneType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT EXISTS (
 	SELECT %s.%s
 	FROM %s
 	WHERE %s.%s IS NULL
 		AND %s.%s = sqlc.arg(%s)
 		AND %s.%s = sqlc.arg(%s)
 );`,
-					mealPlanEventsTableName, idColumn,
-					mealPlanEventsTableName,
-					mealPlanEventsTableName, archivedAtColumn,
-					mealPlanEventsTableName, idColumn, idColumn,
-					mealPlanEventsTableName, belongsToMealPlanColumn, mealPlanIDColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetMealPlanEvents",
-					Type: ManyType,
+						mealPlanEventsTableName, idColumn,
+						mealPlanEventsTableName,
+						mealPlanEventsTableName, archivedAtColumn,
+						mealPlanEventsTableName, idColumn, idColumn,
+						mealPlanEventsTableName, belongsToMealPlanColumn, mealPlanIDColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetMealPlanEvents",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s
@@ -133,79 +107,60 @@ WHERE
 	%s
 GROUP BY %s.%s
 %s;`,
-					strings.Join(applyToEach(mealPlanEventsColumns, func(i int, s string) string {
-						return fmt.Sprintf("%s.%s", mealPlanEventsTableName, s)
-					}), ",\n\t"),
-					buildFilterCountSelect(mealPlanEventsTableName, true, true, []string{}, fmt.Sprintf("%s.%s = sqlc.arg(%s)", mealPlanEventsTableName, belongsToMealPlanColumn, mealPlanIDColumn)),
-					buildTotalCountSelect(mealPlanEventsTableName, true, []string{}, fmt.Sprintf("%s.%s = sqlc.arg(%s)", mealPlanEventsTableName, belongsToMealPlanColumn, mealPlanIDColumn)),
-					mealPlanEventsTableName,
-					mealPlanEventsTableName, archivedAtColumn,
-					buildFilterConditions(mealPlanEventsTableName, true, true, fmt.Sprintf("%s.%s = sqlc.arg(%s)", mealPlanEventsTableName, belongsToMealPlanColumn, mealPlanIDColumn)),
-					mealPlanEventsTableName, idColumn,
-					buildCursorLimitClause(mealPlanEventsTableName),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetAllMealPlanEventsForMealPlan",
-					Type: ManyType,
+						strings.Join(applyToEach(mealPlanEventsColumns, func(i int, s string) string {
+							return fmt.Sprintf("%s.%s", mealPlanEventsTableName, s)
+						}), ",\n\t"),
+						buildFilterCountSelect(mealPlanEventsTableName, true, true, []string{}, fmt.Sprintf("%s.%s = sqlc.arg(%s)", mealPlanEventsTableName, belongsToMealPlanColumn, mealPlanIDColumn)),
+						buildTotalCountSelect(mealPlanEventsTableName, true, []string{}, fmt.Sprintf("%s.%s = sqlc.arg(%s)", mealPlanEventsTableName, belongsToMealPlanColumn, mealPlanIDColumn)),
+						mealPlanEventsTableName,
+						mealPlanEventsTableName, archivedAtColumn,
+						buildFilterConditions(mealPlanEventsTableName, true, true, fmt.Sprintf("%s.%s = sqlc.arg(%s)", mealPlanEventsTableName, belongsToMealPlanColumn, mealPlanIDColumn)),
+						mealPlanEventsTableName, idColumn,
+						buildCursorLimitClause(mealPlanEventsTableName),
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetAllMealPlanEventsForMealPlan",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s
 FROM %s
 WHERE
 	%s.%s IS NULL
 	AND %s.%s = sqlc.arg(%s);`,
-					strings.Join(applyToEach(mealPlanEventsColumns, func(i int, s string) string {
-						return fmt.Sprintf("%s.%s", mealPlanEventsTableName, s)
-					}), ",\n\t"),
-					mealPlanEventsTableName,
-					mealPlanEventsTableName, archivedAtColumn,
-					mealPlanEventsTableName, belongsToMealPlanColumn, mealPlanIDColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetMealPlanEvent",
-					Type: OneType,
+						strings.Join(applyToEach(mealPlanEventsColumns, func(i int, s string) string {
+							return fmt.Sprintf("%s.%s", mealPlanEventsTableName, s)
+						}), ",\n\t"),
+						mealPlanEventsTableName,
+						mealPlanEventsTableName, archivedAtColumn,
+						mealPlanEventsTableName, belongsToMealPlanColumn, mealPlanIDColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
-	%s
-FROM %s
-WHERE %s.%s IS NULL
-	AND %s.%s = sqlc.arg(%s)
-	AND %s.%s = sqlc.arg(%s);`,
-					strings.Join(applyToEach(mealPlanEventsColumns, func(i int, s string) string {
-						return fmt.Sprintf("%s.%s", mealPlanEventsTableName, s)
-					}), ",\n\t"),
-					mealPlanEventsTableName,
-					mealPlanEventsTableName, archivedAtColumn,
-					mealPlanEventsTableName, idColumn, idColumn,
-					mealPlanEventsTableName, belongsToMealPlanColumn, belongsToMealPlanColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "UpdateMealPlanEvent",
-					Type: ExecRowsType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
+				{
+					Annotation: QueryAnnotation{
+						Name: "UpdateMealPlanEvent",
+						Type: ExecRowsType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
 	%s,
 	%s = %s
 WHERE %s IS NULL
 	AND %s = sqlc.arg(%s);`,
-					mealPlanEventsTableName,
-					strings.Join(applyToEach(filterForUpdate(mealPlanEventsColumns), func(i int, s string) string {
-						return fmt.Sprintf("%s = sqlc.arg(%s)", s, s)
-					}), ",\n\t"),
-					lastUpdatedAtColumn,
-					currentTimeExpression,
-					archivedAtColumn,
-					idColumn,
-					idColumn,
-				)),
+						mealPlanEventsTableName,
+						strings.Join(applyToEach(filterForUpdate(mealPlanEventsColumns), func(i int, s string) string {
+							return fmt.Sprintf("%s = sqlc.arg(%s)", s, s)
+						}), ",\n\t"),
+						lastUpdatedAtColumn,
+						currentTimeExpression,
+						archivedAtColumn,
+						idColumn,
+						idColumn,
+					)),
+				},
 			},
-		}
+		)
 	default:
 		return nil
 	}

--- a/backend/cmd/tools/codegen/queries/mealplanning_meal_plan_grocery_list_items.go
+++ b/backend/cmd/tools/codegen/queries/mealplanning_meal_plan_grocery_list_items.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"fmt"
+	"slices"
 	"strings"
+
+	"github.com/primandproper/platform-go/v11/database/querygen"
 
 	"github.com/cristalhq/builq"
 )
@@ -44,8 +47,6 @@ func buildMealPlanGroceryListItemsQueries(database string) []*Query {
 	switch database {
 	case postgres:
 
-		insertColumns := filterForInsert(mealPlanGroceryListItemsColumns)
-
 		fullSelectColumns := mergeColumns(
 			applyToEach(filterFromSlice(mealPlanGroceryListItemsColumns, validIngredientColumn, validMeasurementUnitColumn), func(i int, s string) string {
 				return fmt.Sprintf("%s.%s", mealPlanGroceryListItemsTableName, s)
@@ -61,80 +62,54 @@ func buildMealPlanGroceryListItemsQueries(database string) []*Query {
 			2,
 		)
 
-		return []*Query{
-			{
-				// Compensation for the finalization saga's grocery list step. Deleting rather
-				// than archiving, for the same reason as DeleteMealPlanTasks: the step
-				// regenerates the whole list when it runs again, and an archived row would
-				// leave a tombstone beside every regenerated item forever.
-				//
-				// The IDs come from the saga's own state, so a user's own additions to the
-				// list — which the saga never recorded — are untouched.
-				Annotation: QueryAnnotation{
-					Name: "DeleteMealPlanGroceryListItems",
-					Type: ExecType,
+		return slices.Concat(
+			querygen.StandardCRUD(mealPlanGroceryListItemsTableName, mealPlanGroceryListItemsColumns,
+				querygen.WithEntity("MealPlanGroceryListItem", "MealPlanGroceryListItems"),
+				querygen.WithOmitted(querygen.ExistsQuery, querygen.GetQuery, querygen.ListQuery),
+			),
+			[]*Query{
+				{
+					// Compensation for the finalization saga's grocery list step. Deleting rather
+					// than archiving, for the same reason as DeleteMealPlanTasks: the step
+					// regenerates the whole list when it runs again, and an archived row would
+					// leave a tombstone beside every regenerated item forever.
+					//
+					// The IDs come from the saga's own state, so a user's own additions to the
+					// list — which the saga never recorded — are untouched.
+					Annotation: QueryAnnotation{
+						Name: "DeleteMealPlanGroceryListItems",
+						Type: ExecType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`DELETE FROM %s WHERE %s = ANY(sqlc.arg(ids)::text[]);`,
+						mealPlanGroceryListItemsTableName,
+						idColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`DELETE FROM %s WHERE %s = ANY(sqlc.arg(ids)::text[]);`,
-					mealPlanGroceryListItemsTableName,
-					idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "ArchiveMealPlanGroceryListItem",
-					Type: ExecRowsType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET %s = %s WHERE %s IS NULL AND %s = sqlc.arg(%s);`,
-					mealPlanGroceryListItemsTableName,
-					archivedAtColumn,
-					currentTimeExpression,
-					archivedAtColumn,
-					idColumn,
-					idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CreateMealPlanGroceryListItem",
-					Type: ExecType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`INSERT INTO %s (
-	%s
-) VALUES (
-	%s
-);`,
-					mealPlanGroceryListItemsTableName,
-					strings.Join(insertColumns, ",\n\t"),
-					strings.Join(applyToEach(insertColumns, func(i int, s string) string {
-						return fmt.Sprintf("sqlc.arg(%s)", s)
-					}), ",\n\t"),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CheckMealPlanGroceryListItemExistence",
-					Type: OneType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT EXISTS (
+				{
+					Annotation: QueryAnnotation{
+						Name: "CheckMealPlanGroceryListItemExistence",
+						Type: OneType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT EXISTS (
 	SELECT %s.%s
 	FROM %s
 	WHERE %s.%s IS NULL
 		AND %s.%s = sqlc.arg(%s)
 		AND %s.%s = sqlc.arg(%s)
 );`,
-					mealPlanGroceryListItemsTableName, idColumn,
-					mealPlanGroceryListItemsTableName,
-					mealPlanGroceryListItemsTableName, archivedAtColumn,
-					mealPlanGroceryListItemsTableName, idColumn, mealPlanGroceryListItemIDColumn,
-					mealPlanGroceryListItemsTableName, belongsToMealPlanColumn, mealPlanIDColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetMealPlanGroceryListItemsForMealPlan",
-					Type: ManyType,
+						mealPlanGroceryListItemsTableName, idColumn,
+						mealPlanGroceryListItemsTableName,
+						mealPlanGroceryListItemsTableName, archivedAtColumn,
+						mealPlanGroceryListItemsTableName, idColumn, mealPlanGroceryListItemIDColumn,
+						mealPlanGroceryListItemsTableName, belongsToMealPlanColumn, mealPlanIDColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetMealPlanGroceryListItemsForMealPlan",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s
@@ -149,64 +124,64 @@ GROUP BY %s.%s,
 	%s.%s,
 	%s.%s
 %s;`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					buildFilterCountSelect(
+						strings.Join(fullSelectColumns, ",\n\t"),
+						buildFilterCountSelect(
+							mealPlanGroceryListItemsTableName,
+							true,
+							true,
+							[]string{
+								fmt.Sprintf("%s ON %s.%s = %s.%s", mealPlansTableName, mealPlanGroceryListItemsTableName, belongsToMealPlanColumn, mealPlansTableName, idColumn),
+								fmt.Sprintf("%s ON %s.%s = %s.%s", validIngredientsTableName, mealPlanGroceryListItemsTableName, validIngredientColumn, validIngredientsTableName, idColumn),
+								fmt.Sprintf("%s ON %s.%s = %s.%s", validMeasurementUnitsTableName, mealPlanGroceryListItemsTableName, validMeasurementUnitColumn, validMeasurementUnitsTableName, idColumn),
+							},
+							fmt.Sprintf("%s.%s IS NULL", validMeasurementUnitsTableName, archivedAtColumn),
+							fmt.Sprintf("%s.%s IS NULL", validIngredientsTableName, archivedAtColumn),
+							fmt.Sprintf("%s.%s IS NULL", mealPlansTableName, archivedAtColumn),
+							fmt.Sprintf("%s.%s = sqlc.arg(%s)", mealPlanGroceryListItemsTableName, belongsToMealPlanColumn, mealPlanIDColumn),
+							"(meal_plan_grocery_list_items.belongs_to_meal_plan_option IS NULL OR NOT EXISTS (SELECT 1 FROM meal_plan_options o JOIN meal_plan_events e ON o.belongs_to_meal_plan_event = e.id WHERE o.id = meal_plan_grocery_list_items.belongs_to_meal_plan_option AND e.archived_at IS NOT NULL))",
+						),
+						buildTotalCountSelect(
+							mealPlanGroceryListItemsTableName,
+							true,
+							[]string{
+								fmt.Sprintf("%s ON %s.%s = %s.%s", mealPlansTableName, mealPlanGroceryListItemsTableName, belongsToMealPlanColumn, mealPlansTableName, idColumn),
+								fmt.Sprintf("%s ON %s.%s = %s.%s", validIngredientsTableName, mealPlanGroceryListItemsTableName, validIngredientColumn, validIngredientsTableName, idColumn),
+								fmt.Sprintf("%s ON %s.%s = %s.%s", validMeasurementUnitsTableName, mealPlanGroceryListItemsTableName, validMeasurementUnitColumn, validMeasurementUnitsTableName, idColumn),
+							},
+							fmt.Sprintf("%s.%s IS NULL", validMeasurementUnitsTableName, archivedAtColumn),
+							fmt.Sprintf("%s.%s IS NULL", validIngredientsTableName, archivedAtColumn),
+							fmt.Sprintf("%s.%s IS NULL", mealPlansTableName, archivedAtColumn),
+							fmt.Sprintf("%s.%s = sqlc.arg(%s)", mealPlanGroceryListItemsTableName, belongsToMealPlanColumn, mealPlanIDColumn),
+							"(meal_plan_grocery_list_items.belongs_to_meal_plan_option IS NULL OR NOT EXISTS (SELECT 1 FROM meal_plan_options o JOIN meal_plan_events e ON o.belongs_to_meal_plan_event = e.id WHERE o.id = meal_plan_grocery_list_items.belongs_to_meal_plan_option AND e.archived_at IS NOT NULL))",
+						),
 						mealPlanGroceryListItemsTableName,
-						true,
-						true,
-						[]string{
-							fmt.Sprintf("%s ON %s.%s = %s.%s", mealPlansTableName, mealPlanGroceryListItemsTableName, belongsToMealPlanColumn, mealPlansTableName, idColumn),
-							fmt.Sprintf("%s ON %s.%s = %s.%s", validIngredientsTableName, mealPlanGroceryListItemsTableName, validIngredientColumn, validIngredientsTableName, idColumn),
-							fmt.Sprintf("%s ON %s.%s = %s.%s", validMeasurementUnitsTableName, mealPlanGroceryListItemsTableName, validMeasurementUnitColumn, validMeasurementUnitsTableName, idColumn),
-						},
-						fmt.Sprintf("%s.%s IS NULL", validMeasurementUnitsTableName, archivedAtColumn),
-						fmt.Sprintf("%s.%s IS NULL", validIngredientsTableName, archivedAtColumn),
-						fmt.Sprintf("%s.%s IS NULL", mealPlansTableName, archivedAtColumn),
-						fmt.Sprintf("%s.%s = sqlc.arg(%s)", mealPlanGroceryListItemsTableName, belongsToMealPlanColumn, mealPlanIDColumn),
-						"(meal_plan_grocery_list_items.belongs_to_meal_plan_option IS NULL OR NOT EXISTS (SELECT 1 FROM meal_plan_options o JOIN meal_plan_events e ON o.belongs_to_meal_plan_event = e.id WHERE o.id = meal_plan_grocery_list_items.belongs_to_meal_plan_option AND e.archived_at IS NOT NULL))",
-					),
-					buildTotalCountSelect(
-						mealPlanGroceryListItemsTableName,
-						true,
-						[]string{
-							fmt.Sprintf("%s ON %s.%s = %s.%s", mealPlansTableName, mealPlanGroceryListItemsTableName, belongsToMealPlanColumn, mealPlansTableName, idColumn),
-							fmt.Sprintf("%s ON %s.%s = %s.%s", validIngredientsTableName, mealPlanGroceryListItemsTableName, validIngredientColumn, validIngredientsTableName, idColumn),
-							fmt.Sprintf("%s ON %s.%s = %s.%s", validMeasurementUnitsTableName, mealPlanGroceryListItemsTableName, validMeasurementUnitColumn, validMeasurementUnitsTableName, idColumn),
-						},
-						fmt.Sprintf("%s.%s IS NULL", validMeasurementUnitsTableName, archivedAtColumn),
-						fmt.Sprintf("%s.%s IS NULL", validIngredientsTableName, archivedAtColumn),
-						fmt.Sprintf("%s.%s IS NULL", mealPlansTableName, archivedAtColumn),
-						fmt.Sprintf("%s.%s = sqlc.arg(%s)", mealPlanGroceryListItemsTableName, belongsToMealPlanColumn, mealPlanIDColumn),
-						"(meal_plan_grocery_list_items.belongs_to_meal_plan_option IS NULL OR NOT EXISTS (SELECT 1 FROM meal_plan_options o JOIN meal_plan_events e ON o.belongs_to_meal_plan_event = e.id WHERE o.id = meal_plan_grocery_list_items.belongs_to_meal_plan_option AND e.archived_at IS NOT NULL))",
-					),
-					mealPlanGroceryListItemsTableName,
-					mealPlansTableName, mealPlanGroceryListItemsTableName, belongsToMealPlanColumn, mealPlansTableName, idColumn,
-					validIngredientsTableName, mealPlanGroceryListItemsTableName, validIngredientColumn, validIngredientsTableName, idColumn,
-					validMeasurementUnitsTableName, mealPlanGroceryListItemsTableName, validMeasurementUnitColumn, validMeasurementUnitsTableName, idColumn,
-					mealPlanGroceryListItemsTableName, archivedAtColumn,
-					buildFilterConditions(
-						mealPlanGroceryListItemsTableName,
-						true,
-						true,
-						fmt.Sprintf("%s.%s = sqlc.arg(%s)", mealPlanGroceryListItemsTableName, belongsToMealPlanColumn, mealPlanIDColumn),
-						fmt.Sprintf("%s.%s IS NULL", validMeasurementUnitsTableName, archivedAtColumn),
-						fmt.Sprintf("%s.%s IS NULL", validIngredientsTableName, archivedAtColumn),
-						fmt.Sprintf("%s.%s IS NULL", mealPlansTableName, archivedAtColumn),
-						"(meal_plan_grocery_list_items.belongs_to_meal_plan_option IS NULL OR NOT EXISTS (SELECT 1 FROM meal_plan_options o JOIN meal_plan_events e ON o.belongs_to_meal_plan_event = e.id WHERE o.id = meal_plan_grocery_list_items.belongs_to_meal_plan_option AND e.archived_at IS NOT NULL))",
-					),
-					mealPlanGroceryListItemsTableName, idColumn,
-					validIngredientsTableName, idColumn,
-					validMeasurementUnitsTableName, idColumn,
-					mealPlansTableName, idColumn,
-					buildCursorLimitClause(mealPlanGroceryListItemsTableName),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetMealPlanGroceryListItem",
-					Type: OneType,
+						mealPlansTableName, mealPlanGroceryListItemsTableName, belongsToMealPlanColumn, mealPlansTableName, idColumn,
+						validIngredientsTableName, mealPlanGroceryListItemsTableName, validIngredientColumn, validIngredientsTableName, idColumn,
+						validMeasurementUnitsTableName, mealPlanGroceryListItemsTableName, validMeasurementUnitColumn, validMeasurementUnitsTableName, idColumn,
+						mealPlanGroceryListItemsTableName, archivedAtColumn,
+						buildFilterConditions(
+							mealPlanGroceryListItemsTableName,
+							true,
+							true,
+							fmt.Sprintf("%s.%s = sqlc.arg(%s)", mealPlanGroceryListItemsTableName, belongsToMealPlanColumn, mealPlanIDColumn),
+							fmt.Sprintf("%s.%s IS NULL", validMeasurementUnitsTableName, archivedAtColumn),
+							fmt.Sprintf("%s.%s IS NULL", validIngredientsTableName, archivedAtColumn),
+							fmt.Sprintf("%s.%s IS NULL", mealPlansTableName, archivedAtColumn),
+							"(meal_plan_grocery_list_items.belongs_to_meal_plan_option IS NULL OR NOT EXISTS (SELECT 1 FROM meal_plan_options o JOIN meal_plan_events e ON o.belongs_to_meal_plan_event = e.id WHERE o.id = meal_plan_grocery_list_items.belongs_to_meal_plan_option AND e.archived_at IS NOT NULL))",
+						),
+						mealPlanGroceryListItemsTableName, idColumn,
+						validIngredientsTableName, idColumn,
+						validMeasurementUnitsTableName, idColumn,
+						mealPlansTableName, idColumn,
+						buildCursorLimitClause(mealPlanGroceryListItemsTableName),
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetMealPlanGroceryListItem",
+						Type: OneType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s
 FROM %s
 	JOIN %s ON %s.%s=%s.%s
@@ -217,38 +192,20 @@ WHERE %s.%s IS NULL
 	AND %s.%s IS NULL
 	AND %s.%s = sqlc.arg(%s)
 	AND %s.%s = sqlc.arg(%s);`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					mealPlanGroceryListItemsTableName,
-					mealPlansTableName, mealPlanGroceryListItemsTableName, belongsToMealPlanColumn, mealPlansTableName, idColumn,
-					validIngredientsTableName, mealPlanGroceryListItemsTableName, validIngredientColumn, validIngredientsTableName, idColumn,
-					validMeasurementUnitsTableName, mealPlanGroceryListItemsTableName, validMeasurementUnitColumn, validMeasurementUnitsTableName, idColumn,
-					mealPlanGroceryListItemsTableName, archivedAtColumn,
-					validMeasurementUnitsTableName, archivedAtColumn,
-					validIngredientsTableName, archivedAtColumn,
-					mealPlanGroceryListItemsTableName, idColumn, mealPlanGroceryListItemIDColumn,
-					mealPlanGroceryListItemsTableName, belongsToMealPlanColumn, mealPlanIDColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "UpdateMealPlanGroceryListItem",
-					Type: ExecRowsType,
+						strings.Join(fullSelectColumns, ",\n\t"),
+						mealPlanGroceryListItemsTableName,
+						mealPlansTableName, mealPlanGroceryListItemsTableName, belongsToMealPlanColumn, mealPlansTableName, idColumn,
+						validIngredientsTableName, mealPlanGroceryListItemsTableName, validIngredientColumn, validIngredientsTableName, idColumn,
+						validMeasurementUnitsTableName, mealPlanGroceryListItemsTableName, validMeasurementUnitColumn, validMeasurementUnitsTableName, idColumn,
+						mealPlanGroceryListItemsTableName, archivedAtColumn,
+						validMeasurementUnitsTableName, archivedAtColumn,
+						validIngredientsTableName, archivedAtColumn,
+						mealPlanGroceryListItemsTableName, idColumn, mealPlanGroceryListItemIDColumn,
+						mealPlanGroceryListItemsTableName, belongsToMealPlanColumn, mealPlanIDColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
-	%s,
-	%s = %s
-WHERE %s IS NULL
-	AND %s = sqlc.arg(%s);`,
-					mealPlanGroceryListItemsTableName,
-					strings.Join(applyToEach(filterForUpdate(mealPlanGroceryListItemsColumns, belongsToUserColumn), func(i int, s string) string {
-						return fmt.Sprintf("%s = sqlc.arg(%s)", s, s)
-					}), ",\n\t"),
-					lastUpdatedAtColumn, currentTimeExpression,
-					archivedAtColumn,
-					idColumn, idColumn,
-				)),
 			},
-		}
+		)
 	default:
 		return nil
 	}

--- a/backend/cmd/tools/codegen/queries/mealplanning_meal_plan_option_votes.go
+++ b/backend/cmd/tools/codegen/queries/mealplanning_meal_plan_option_votes.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"fmt"
+	"slices"
 	"strings"
+
+	"github.com/primandproper/platform-go/v11/database/querygen"
 
 	"github.com/cristalhq/builq"
 )
@@ -34,48 +37,19 @@ func buildMealPlanOptionVotesQueries(database string) []*Query {
 	switch database {
 	case postgres:
 
-		insertColumns := filterForInsert(mealPlanOptionVotesColumns)
-
-		return []*Query{
-			{
-				Annotation: QueryAnnotation{
-					Name: "ArchiveMealPlanOptionVote",
-					Type: ExecRowsType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET %s = %s WHERE %s IS NULL AND %s = sqlc.arg(%s) AND %s = sqlc.arg(%s);`,
-					mealPlanOptionVotesTableName,
-					archivedAtColumn,
-					currentTimeExpression,
-					archivedAtColumn,
-					belongsToMealPlanOptionColumn,
-					belongsToMealPlanOptionColumn,
-					idColumn,
-					idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CreateMealPlanOptionVote",
-					Type: ExecType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`INSERT INTO %s (
-	%s
-) VALUES (
-	%s
-);`,
-					mealPlanOptionVotesTableName,
-					strings.Join(insertColumns, ",\n\t"),
-					strings.Join(applyToEach(insertColumns, func(i int, s string) string {
-						return fmt.Sprintf("sqlc.arg(%s)", s)
-					}), ",\n\t"),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CheckMealPlanOptionVoteExistence",
-					Type: OneType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT EXISTS (
+		return slices.Concat(
+			querygen.StandardCRUD(mealPlanOptionVotesTableName, mealPlanOptionVotesColumns,
+				querygen.WithEntity("MealPlanOptionVote", "MealPlanOptionVotes"),
+				querygen.WithOwnership(belongsToMealPlanOptionColumn),
+				querygen.WithOmitted(querygen.ExistsQuery, querygen.GetQuery, querygen.ListQuery),
+			),
+			[]*Query{
+				{
+					Annotation: QueryAnnotation{
+						Name: "CheckMealPlanOptionVoteExistence",
+						Type: OneType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT EXISTS (
 	SELECT %s.%s
 	FROM %s
 		JOIN %s ON %s.%s=%s.%s
@@ -92,29 +66,29 @@ func buildMealPlanOptionVotesQueries(database string) []*Query {
 		AND %s.%s IS NULL
 		AND %s.%s = sqlc.arg(%s)
 );`,
-					mealPlanOptionVotesTableName, idColumn,
-					mealPlanOptionVotesTableName,
-					mealPlanOptionsTableName, mealPlanOptionVotesTableName, belongsToMealPlanOptionColumn, mealPlanOptionsTableName, idColumn,
-					mealPlanEventsTableName, mealPlanOptionsTableName, belongsToMealPlanEventColumn, mealPlanEventsTableName, idColumn,
-					mealPlansTableName, mealPlanEventsTableName, belongsToMealPlanColumn, mealPlansTableName, idColumn,
-					mealPlanOptionVotesTableName, archivedAtColumn,
-					mealPlanOptionVotesTableName, belongsToMealPlanOptionColumn, mealPlanOptionIDColumn,
-					mealPlanOptionVotesTableName, idColumn, mealPlanOptionVoteIDColumn,
-					mealPlanOptionsTableName, archivedAtColumn,
-					mealPlanOptionsTableName, belongsToMealPlanEventColumn, mealPlanEventIDColumn,
-					mealPlanEventsTableName, archivedAtColumn,
-					mealPlanEventsTableName, belongsToMealPlanColumn, mealPlanIDColumn,
-					mealPlanOptionsTableName, idColumn, mealPlanOptionIDColumn,
-					mealPlansTableName, archivedAtColumn,
-					mealPlansTableName, idColumn, mealPlanIDColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetMealPlanOptionVotesForMealPlanOption",
-					Type: ManyType,
+						mealPlanOptionVotesTableName, idColumn,
+						mealPlanOptionVotesTableName,
+						mealPlanOptionsTableName, mealPlanOptionVotesTableName, belongsToMealPlanOptionColumn, mealPlanOptionsTableName, idColumn,
+						mealPlanEventsTableName, mealPlanOptionsTableName, belongsToMealPlanEventColumn, mealPlanEventsTableName, idColumn,
+						mealPlansTableName, mealPlanEventsTableName, belongsToMealPlanColumn, mealPlansTableName, idColumn,
+						mealPlanOptionVotesTableName, archivedAtColumn,
+						mealPlanOptionVotesTableName, belongsToMealPlanOptionColumn, mealPlanOptionIDColumn,
+						mealPlanOptionVotesTableName, idColumn, mealPlanOptionVoteIDColumn,
+						mealPlanOptionsTableName, archivedAtColumn,
+						mealPlanOptionsTableName, belongsToMealPlanEventColumn, mealPlanEventIDColumn,
+						mealPlanEventsTableName, archivedAtColumn,
+						mealPlanEventsTableName, belongsToMealPlanColumn, mealPlanIDColumn,
+						mealPlanOptionsTableName, idColumn, mealPlanOptionIDColumn,
+						mealPlansTableName, archivedAtColumn,
+						mealPlansTableName, idColumn, mealPlanIDColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetMealPlanOptionVotesForMealPlanOption",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s
 FROM %s
 	JOIN %s ON %s.%s=%s.%s
@@ -130,31 +104,31 @@ WHERE %s.%s IS NULL
 	AND %s.%s = sqlc.arg(%s)
 	AND %s.%s IS NULL
 	AND %s.%s = sqlc.arg(%s);`,
-					strings.Join(applyToEach(mealPlanOptionVotesColumns, func(i int, s string) string {
-						return fmt.Sprintf("%s.%s", mealPlanOptionVotesTableName, s)
-					}), ",\n\t"),
-					mealPlanOptionVotesTableName,
-					mealPlanOptionsTableName, mealPlanOptionVotesTableName, belongsToMealPlanOptionColumn, mealPlanOptionsTableName, idColumn,
-					mealPlanEventsTableName, mealPlanOptionsTableName, belongsToMealPlanEventColumn, mealPlanEventsTableName, idColumn,
-					mealPlansTableName, mealPlanEventsTableName, belongsToMealPlanColumn, mealPlansTableName, idColumn,
-					mealPlanOptionVotesTableName, archivedAtColumn,
-					mealPlanOptionVotesTableName, belongsToMealPlanOptionColumn, mealPlanOptionIDColumn,
-					mealPlanOptionsTableName, archivedAtColumn,
-					mealPlanOptionsTableName, belongsToMealPlanEventColumn, mealPlanEventIDColumn,
-					mealPlanOptionsTableName, idColumn, mealPlanOptionIDColumn,
-					mealPlanEventsTableName, archivedAtColumn,
-					mealPlanEventsTableName, belongsToMealPlanColumn, mealPlanIDColumn,
-					mealPlanEventsTableName, idColumn, mealPlanEventIDColumn,
-					mealPlansTableName, archivedAtColumn,
-					mealPlansTableName, idColumn, mealPlanIDColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetMealPlanOptionVotes",
-					Type: ManyType,
+						strings.Join(applyToEach(mealPlanOptionVotesColumns, func(i int, s string) string {
+							return fmt.Sprintf("%s.%s", mealPlanOptionVotesTableName, s)
+						}), ",\n\t"),
+						mealPlanOptionVotesTableName,
+						mealPlanOptionsTableName, mealPlanOptionVotesTableName, belongsToMealPlanOptionColumn, mealPlanOptionsTableName, idColumn,
+						mealPlanEventsTableName, mealPlanOptionsTableName, belongsToMealPlanEventColumn, mealPlanEventsTableName, idColumn,
+						mealPlansTableName, mealPlanEventsTableName, belongsToMealPlanColumn, mealPlansTableName, idColumn,
+						mealPlanOptionVotesTableName, archivedAtColumn,
+						mealPlanOptionVotesTableName, belongsToMealPlanOptionColumn, mealPlanOptionIDColumn,
+						mealPlanOptionsTableName, archivedAtColumn,
+						mealPlanOptionsTableName, belongsToMealPlanEventColumn, mealPlanEventIDColumn,
+						mealPlanOptionsTableName, idColumn, mealPlanOptionIDColumn,
+						mealPlanEventsTableName, archivedAtColumn,
+						mealPlanEventsTableName, belongsToMealPlanColumn, mealPlanIDColumn,
+						mealPlanEventsTableName, idColumn, mealPlanEventIDColumn,
+						mealPlansTableName, archivedAtColumn,
+						mealPlansTableName, idColumn, mealPlanIDColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT 
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetMealPlanOptionVotes",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT 
 	%s,
 	%s,
 	%s
@@ -179,39 +153,39 @@ GROUP BY
 	%s.%s,
 	%s.%s
 %s;`,
-					strings.Join(applyToEach(mealPlanOptionVotesColumns, func(i int, s string) string {
-						return fmt.Sprintf("%s.%s", mealPlanOptionVotesTableName, s)
-					}), ",\n\t"),
-					buildFilterCountSelect(mealPlanOptionVotesTableName, true, true, []string{}, "meal_plan_option_votes.belongs_to_meal_plan_option = sqlc.arg(meal_plan_option_id)"),
-					buildTotalCountSelect(mealPlanOptionVotesTableName, true, []string{}),
-					mealPlanOptionVotesTableName,
-					mealPlanOptionsTableName, mealPlanOptionVotesTableName, belongsToMealPlanOptionColumn, mealPlanOptionsTableName, idColumn,
-					mealPlanEventsTableName, mealPlanOptionsTableName, belongsToMealPlanEventColumn, mealPlanEventsTableName, idColumn,
-					mealPlansTableName, mealPlanEventsTableName, belongsToMealPlanColumn, mealPlansTableName, idColumn,
-					mealPlanOptionVotesTableName, archivedAtColumn,
-					mealPlanOptionVotesTableName, belongsToMealPlanOptionColumn, mealPlanOptionIDColumn,
-					mealPlanOptionsTableName, archivedAtColumn,
-					mealPlanOptionsTableName, belongsToMealPlanEventColumn, mealPlanEventIDColumn,
-					mealPlanOptionsTableName, idColumn, mealPlanOptionIDColumn,
-					mealPlanEventsTableName, archivedAtColumn,
-					mealPlanEventsTableName, belongsToMealPlanColumn, mealPlanIDColumn,
-					mealPlanEventsTableName, idColumn, mealPlanEventIDColumn,
-					mealPlansTableName, archivedAtColumn,
-					mealPlansTableName, idColumn, mealPlanIDColumn,
-					buildFilterConditions(mealPlanOptionVotesTableName, true, false),
-					mealPlanOptionVotesTableName, idColumn,
-					mealPlanOptionsTableName, idColumn,
-					mealPlanEventsTableName, idColumn,
-					mealPlansTableName, idColumn,
-					buildCursorLimitClause(mealPlanOptionVotesTableName),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetMealPlanOptionVote",
-					Type: OneType,
+						strings.Join(applyToEach(mealPlanOptionVotesColumns, func(i int, s string) string {
+							return fmt.Sprintf("%s.%s", mealPlanOptionVotesTableName, s)
+						}), ",\n\t"),
+						buildFilterCountSelect(mealPlanOptionVotesTableName, true, true, []string{}, "meal_plan_option_votes.belongs_to_meal_plan_option = sqlc.arg(meal_plan_option_id)"),
+						buildTotalCountSelect(mealPlanOptionVotesTableName, true, []string{}),
+						mealPlanOptionVotesTableName,
+						mealPlanOptionsTableName, mealPlanOptionVotesTableName, belongsToMealPlanOptionColumn, mealPlanOptionsTableName, idColumn,
+						mealPlanEventsTableName, mealPlanOptionsTableName, belongsToMealPlanEventColumn, mealPlanEventsTableName, idColumn,
+						mealPlansTableName, mealPlanEventsTableName, belongsToMealPlanColumn, mealPlansTableName, idColumn,
+						mealPlanOptionVotesTableName, archivedAtColumn,
+						mealPlanOptionVotesTableName, belongsToMealPlanOptionColumn, mealPlanOptionIDColumn,
+						mealPlanOptionsTableName, archivedAtColumn,
+						mealPlanOptionsTableName, belongsToMealPlanEventColumn, mealPlanEventIDColumn,
+						mealPlanOptionsTableName, idColumn, mealPlanOptionIDColumn,
+						mealPlanEventsTableName, archivedAtColumn,
+						mealPlanEventsTableName, belongsToMealPlanColumn, mealPlanIDColumn,
+						mealPlanEventsTableName, idColumn, mealPlanEventIDColumn,
+						mealPlansTableName, archivedAtColumn,
+						mealPlansTableName, idColumn, mealPlanIDColumn,
+						buildFilterConditions(mealPlanOptionVotesTableName, true, false),
+						mealPlanOptionVotesTableName, idColumn,
+						mealPlanOptionsTableName, idColumn,
+						mealPlanEventsTableName, idColumn,
+						mealPlansTableName, idColumn,
+						buildCursorLimitClause(mealPlanOptionVotesTableName),
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetMealPlanOptionVote",
+						Type: OneType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s
 FROM %s
 	JOIN %s ON %s.%s=%s.%s
@@ -227,49 +201,27 @@ WHERE %s.%s IS NULL
 	AND %s.%s = sqlc.arg(%s)
 	AND %s.%s IS NULL
 	AND %s.%s = sqlc.arg(%s);`,
-					strings.Join(applyToEach(mealPlanOptionVotesColumns, func(i int, s string) string {
-						return fmt.Sprintf("%s.%s", mealPlanOptionVotesTableName, s)
-					}), ",\n\t"),
-					mealPlanOptionVotesTableName,
-					mealPlanOptionsTableName, mealPlanOptionVotesTableName, belongsToMealPlanOptionColumn, mealPlanOptionsTableName, idColumn,
-					mealPlanEventsTableName, mealPlanOptionsTableName, belongsToMealPlanEventColumn, mealPlanEventsTableName, idColumn,
-					mealPlansTableName, mealPlanEventsTableName, belongsToMealPlanColumn, mealPlansTableName, idColumn,
-					mealPlanOptionVotesTableName, archivedAtColumn,
-					mealPlanOptionVotesTableName, belongsToMealPlanOptionColumn, mealPlanOptionIDColumn,
-					mealPlanOptionVotesTableName, idColumn, mealPlanOptionVoteIDColumn,
-					mealPlanOptionsTableName, archivedAtColumn,
-					mealPlanOptionsTableName, belongsToMealPlanEventColumn, mealPlanEventIDColumn,
-					mealPlanEventsTableName, archivedAtColumn,
-					mealPlanEventsTableName, belongsToMealPlanColumn, mealPlanIDColumn,
-					mealPlanOptionsTableName, idColumn, mealPlanOptionIDColumn,
-					mealPlansTableName, archivedAtColumn,
-					mealPlansTableName, idColumn, mealPlanIDColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "UpdateMealPlanOptionVote",
-					Type: ExecRowsType,
+						strings.Join(applyToEach(mealPlanOptionVotesColumns, func(i int, s string) string {
+							return fmt.Sprintf("%s.%s", mealPlanOptionVotesTableName, s)
+						}), ",\n\t"),
+						mealPlanOptionVotesTableName,
+						mealPlanOptionsTableName, mealPlanOptionVotesTableName, belongsToMealPlanOptionColumn, mealPlanOptionsTableName, idColumn,
+						mealPlanEventsTableName, mealPlanOptionsTableName, belongsToMealPlanEventColumn, mealPlanEventsTableName, idColumn,
+						mealPlansTableName, mealPlanEventsTableName, belongsToMealPlanColumn, mealPlansTableName, idColumn,
+						mealPlanOptionVotesTableName, archivedAtColumn,
+						mealPlanOptionVotesTableName, belongsToMealPlanOptionColumn, mealPlanOptionIDColumn,
+						mealPlanOptionVotesTableName, idColumn, mealPlanOptionVoteIDColumn,
+						mealPlanOptionsTableName, archivedAtColumn,
+						mealPlanOptionsTableName, belongsToMealPlanEventColumn, mealPlanEventIDColumn,
+						mealPlanEventsTableName, archivedAtColumn,
+						mealPlanEventsTableName, belongsToMealPlanColumn, mealPlanIDColumn,
+						mealPlanOptionsTableName, idColumn, mealPlanOptionIDColumn,
+						mealPlansTableName, archivedAtColumn,
+						mealPlansTableName, idColumn, mealPlanIDColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
-	%s,
-	%s = %s
-WHERE %s IS NULL
-	AND %s = sqlc.arg(%s)
-	AND %s = sqlc.arg(%s);`,
-					mealPlanOptionVotesTableName,
-					strings.Join(applyToEach(filterForUpdate(mealPlanOptionVotesColumns, belongsToMealPlanOptionColumn), func(i int, s string) string {
-						return fmt.Sprintf("%s = sqlc.arg(%s)", s, s)
-					}), ",\n\t"),
-					lastUpdatedAtColumn,
-					currentTimeExpression,
-					archivedAtColumn,
-					belongsToMealPlanOptionColumn, belongsToMealPlanOptionColumn,
-					idColumn,
-					idColumn,
-				)),
 			},
-		}
+		)
 	default:
 		return nil
 	}

--- a/backend/cmd/tools/codegen/queries/mealplanning_meal_plan_options.go
+++ b/backend/cmd/tools/codegen/queries/mealplanning_meal_plan_options.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"fmt"
+	"slices"
 	"strings"
+
+	"github.com/primandproper/platform-go/v11/database/querygen"
 
 	"github.com/cristalhq/builq"
 )
@@ -39,10 +42,6 @@ func buildMealPlanOptionsQueries(database string) []*Query {
 	switch database {
 	case postgres:
 
-		insertColumns := filterForInsert(mealPlanOptionsColumns,
-			mealPlanOptionsTiebrokenColumn,
-		)
-
 		fullSelectColumns := append(
 			applyToEach(mealPlanOptionsColumns, func(i int, s string) string {
 				return fmt.Sprintf("%s.%s", mealPlanOptionsTableName, s)
@@ -52,66 +51,39 @@ func buildMealPlanOptionsQueries(database string) []*Query {
 			})...,
 		)
 
-		return []*Query{
-			{
-				Annotation: QueryAnnotation{
-					Name: "CheckMealInMealPlanEvent",
-					Type: OneType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT EXISTS (
+		return slices.Concat(
+			querygen.StandardCRUD(mealPlanOptionsTableName, mealPlanOptionsColumns,
+				querygen.WithEntity("MealPlanOption", "MealPlanOptions"),
+				querygen.WithOwnership(belongsToMealPlanEventColumn),
+				querygen.WithDatabaseOwned(mealPlanOptionsTiebrokenColumn),
+				querygen.WithOmitted(querygen.ExistsQuery, querygen.GetQuery, querygen.ListQuery, querygen.UpdateQuery),
+			),
+			[]*Query{
+				{
+					Annotation: QueryAnnotation{
+						Name: "CheckMealInMealPlanEvent",
+						Type: OneType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT EXISTS (
 	SELECT %s.%s
 	FROM %s
 	WHERE %s.%s IS NULL
 		AND %s.%s = sqlc.arg(%s)
 		AND %s.%s = sqlc.arg(%s)
 );`,
-					mealPlanOptionsTableName, idColumn,
-					mealPlanOptionsTableName,
-					mealPlanOptionsTableName, archivedAtColumn,
-					mealPlanOptionsTableName, belongsToMealPlanEventColumn, belongsToMealPlanEventColumn,
-					mealPlanOptionsTableName, mealIDColumn, mealIDColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "ArchiveMealPlanOption",
-					Type: ExecRowsType,
+						mealPlanOptionsTableName, idColumn,
+						mealPlanOptionsTableName,
+						mealPlanOptionsTableName, archivedAtColumn,
+						mealPlanOptionsTableName, belongsToMealPlanEventColumn, belongsToMealPlanEventColumn,
+						mealPlanOptionsTableName, mealIDColumn, mealIDColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
-	%s = %s
-WHERE %s IS NULL
-	AND %s = sqlc.arg(%s)
-	AND %s = sqlc.arg(%s);`,
-					mealPlanOptionsTableName,
-					archivedAtColumn, currentTimeExpression,
-					archivedAtColumn,
-					belongsToMealPlanEventColumn, belongsToMealPlanEventColumn,
-					idColumn, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CreateMealPlanOption",
-					Type: ExecType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`INSERT INTO %s (
-	%s
-) VALUES (
-	%s
-);`,
-					mealPlanOptionsTableName,
-					strings.Join(insertColumns, ",\n\t"),
-					strings.Join(applyToEach(insertColumns, func(i int, s string) string {
-						return fmt.Sprintf("sqlc.arg(%s)", s)
-					}), ",\n\t"),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CheckMealPlanOptionExistence",
-					Type: OneType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT EXISTS (
+				{
+					Annotation: QueryAnnotation{
+						Name: "CheckMealPlanOptionExistence",
+						Type: OneType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT EXISTS (
 	SELECT %s.%s
 	FROM %s
 		JOIN meal_plan_events ON meal_plan_options.belongs_to_meal_plan_event = meal_plan_events.id
@@ -125,17 +97,17 @@ WHERE %s IS NULL
 		AND meal_plans.archived_at IS NULL
 		AND meal_plans.id = sqlc.arg(meal_plan_id)
 );`,
-					mealPlanOptionsTableName, idColumn,
-					mealPlanOptionsTableName,
-					mealPlanOptionsTableName, archivedAtColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CheckMealPlanOptionBelongsToAccount",
-					Type: OneType,
+						mealPlanOptionsTableName, idColumn,
+						mealPlanOptionsTableName,
+						mealPlanOptionsTableName, archivedAtColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT EXISTS (
+				{
+					Annotation: QueryAnnotation{
+						Name: "CheckMealPlanOptionBelongsToAccount",
+						Type: OneType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT EXISTS (
 	SELECT %s.%s
 	FROM %s
 		JOIN meal_plan_events ON meal_plan_options.belongs_to_meal_plan_event = meal_plan_events.id
@@ -145,36 +117,36 @@ WHERE %s IS NULL
 		AND meal_plans.archived_at IS NULL
 		AND meal_plans.belongs_to_account = sqlc.arg(belongs_to_account)
 );`,
-					mealPlanOptionsTableName, idColumn,
-					mealPlanOptionsTableName,
-					mealPlanOptionsTableName, archivedAtColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "FinalizeMealPlanOption",
-					Type: ExecType,
+						mealPlanOptionsTableName, idColumn,
+						mealPlanOptionsTableName,
+						mealPlanOptionsTableName, archivedAtColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
+				{
+					Annotation: QueryAnnotation{
+						Name: "FinalizeMealPlanOption",
+						Type: ExecType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
 	%s = (%s = sqlc.arg(%s) AND %s = sqlc.arg(%s)),
 	%s = sqlc.arg(%s)
 WHERE %s IS NULL
 	AND %s = sqlc.arg(%s)
 	AND %s = sqlc.arg(%s);`,
-					mealPlanOptionsTableName,
-					mealPlanOptionsChosenColumn, belongsToMealPlanEventColumn, mealPlanEventIDColumn, idColumn, idColumn,
-					mealPlanOptionsTiebrokenColumn, mealPlanOptionsTiebrokenColumn,
-					archivedAtColumn,
-					belongsToMealPlanEventColumn, mealPlanEventIDColumn,
-					idColumn, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetAllMealPlanOptionsForMealPlanEvent",
-					Type: ManyType,
+						mealPlanOptionsTableName,
+						mealPlanOptionsChosenColumn, belongsToMealPlanEventColumn, mealPlanEventIDColumn, idColumn, idColumn,
+						mealPlanOptionsTiebrokenColumn, mealPlanOptionsTiebrokenColumn,
+						archivedAtColumn,
+						belongsToMealPlanEventColumn, mealPlanEventIDColumn,
+						idColumn, idColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetAllMealPlanOptionsForMealPlanEvent",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s
 FROM %s
 	JOIN meal_plan_events ON meal_plan_options.belongs_to_meal_plan_event = meal_plan_events.id
@@ -187,16 +159,16 @@ WHERE
 	AND meal_plan_events.belongs_to_meal_plan = sqlc.arg(meal_plan_id)
 	AND meal_plans.archived_at IS NULL
 	AND meal_plans.id = sqlc.arg(meal_plan_id);`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					mealPlanOptionsTableName,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetMealPlanOptions",
-					Type: ManyType,
+						strings.Join(fullSelectColumns, ",\n\t"),
+						mealPlanOptionsTableName,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetMealPlanOptions",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s
@@ -213,19 +185,19 @@ WHERE
 	AND meal_plans.id = sqlc.arg(meal_plan_id)
 	%s
 %s;`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					buildFilterCountSelect(mealPlanOptionsTableName, true, true, []string{}, "meal_plan_options.belongs_to_meal_plan_event = sqlc.arg(meal_plan_event_id)"),
-					buildTotalCountSelect(mealPlanOptionsTableName, true, []string{}),
-					buildFilterConditions(mealPlanOptionsTableName, true, false, "meal_plan_options.belongs_to_meal_plan_event = sqlc.arg(meal_plan_event_id)"),
-					buildCursorLimitClause(mealPlanOptionsTableName),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetMealPlanOption",
-					Type: OneType,
+						strings.Join(fullSelectColumns, ",\n\t"),
+						buildFilterCountSelect(mealPlanOptionsTableName, true, true, []string{}, "meal_plan_options.belongs_to_meal_plan_event = sqlc.arg(meal_plan_event_id)"),
+						buildTotalCountSelect(mealPlanOptionsTableName, true, []string{}),
+						buildFilterConditions(mealPlanOptionsTableName, true, false, "meal_plan_options.belongs_to_meal_plan_event = sqlc.arg(meal_plan_event_id)"),
+						buildCursorLimitClause(mealPlanOptionsTableName),
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetMealPlanOption",
+						Type: OneType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s
 FROM %s
 	JOIN %s ON %s.%s = %s.%s
@@ -238,27 +210,27 @@ WHERE %s.%s IS NULL
 	AND %s.%s = sqlc.arg(%s)
 	AND %s.%s IS NULL
 	AND %s.%s = sqlc.arg(%s);`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					mealPlanOptionsTableName,
-					mealPlanEventsTableName, mealPlanOptionsTableName, belongsToMealPlanEventColumn, mealPlanEventsTableName, idColumn,
-					mealPlansTableName, mealPlanEventsTableName, belongsToMealPlanColumn, mealPlansTableName, idColumn,
-					mealsTableName, mealPlanOptionsTableName, mealIDColumn, mealsTableName, idColumn,
-					mealPlanOptionsTableName, archivedAtColumn,
+						strings.Join(fullSelectColumns, ",\n\t"),
+						mealPlanOptionsTableName,
+						mealPlanEventsTableName, mealPlanOptionsTableName, belongsToMealPlanEventColumn, mealPlanEventsTableName, idColumn,
+						mealPlansTableName, mealPlanEventsTableName, belongsToMealPlanColumn, mealPlansTableName, idColumn,
+						mealsTableName, mealPlanOptionsTableName, mealIDColumn, mealsTableName, idColumn,
+						mealPlanOptionsTableName, archivedAtColumn,
 
-					mealPlanOptionsTableName, belongsToMealPlanEventColumn, mealPlanEventIDColumn,
-					mealPlanOptionsTableName, idColumn, mealPlanOptionIDColumn,
-					mealPlanEventsTableName, idColumn, mealPlanEventIDColumn,
-					mealPlanEventsTableName, belongsToMealPlanColumn, mealPlanIDColumn,
-					mealPlansTableName, archivedAtColumn,
-					mealPlansTableName, idColumn, mealPlanIDColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetMealPlanOptionByID",
-					Type: OneType,
+						mealPlanOptionsTableName, belongsToMealPlanEventColumn, mealPlanEventIDColumn,
+						mealPlanOptionsTableName, idColumn, mealPlanOptionIDColumn,
+						mealPlanEventsTableName, idColumn, mealPlanEventIDColumn,
+						mealPlanEventsTableName, belongsToMealPlanColumn, mealPlanIDColumn,
+						mealPlansTableName, archivedAtColumn,
+						mealPlansTableName, idColumn, mealPlanIDColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetMealPlanOptionByID",
+						Type: OneType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s
 FROM %s
 	JOIN %s ON %s.%s = %s.%s
@@ -266,38 +238,39 @@ FROM %s
 	JOIN %s ON %s.%s = %s.%s
 WHERE %s.%s IS NULL
 	AND %s.%s = sqlc.arg(%s);`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					mealPlanOptionsTableName,
-					mealPlanEventsTableName, mealPlanOptionsTableName, belongsToMealPlanEventColumn, mealPlanEventsTableName, idColumn,
-					mealPlansTableName, mealPlanEventsTableName, belongsToMealPlanColumn, mealPlansTableName, idColumn,
-					mealsTableName, mealPlanOptionsTableName, mealIDColumn, mealsTableName, idColumn,
-					mealPlanOptionsTableName, archivedAtColumn,
-					mealPlanOptionsTableName, idColumn, mealPlanOptionIDColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "UpdateMealPlanOption",
-					Type: ExecRowsType,
+						strings.Join(fullSelectColumns, ",\n\t"),
+						mealPlanOptionsTableName,
+						mealPlanEventsTableName, mealPlanOptionsTableName, belongsToMealPlanEventColumn, mealPlanEventsTableName, idColumn,
+						mealPlansTableName, mealPlanEventsTableName, belongsToMealPlanColumn, mealPlansTableName, idColumn,
+						mealsTableName, mealPlanOptionsTableName, mealIDColumn, mealsTableName, idColumn,
+						mealPlanOptionsTableName, archivedAtColumn,
+						mealPlanOptionsTableName, idColumn, mealPlanOptionIDColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
+				{
+					Annotation: QueryAnnotation{
+						Name: "UpdateMealPlanOption",
+						Type: ExecRowsType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
 	%s,
 	%s = %s
 WHERE %s IS NULL
 	AND %s = sqlc.arg(%s)
 	AND %s = sqlc.arg(%s);`,
-					mealPlanOptionsTableName,
-					strings.Join(applyToEach(filterForUpdate(mealPlanOptionsColumns, mealPlanOptionsChosenColumn, mealPlanOptionsTiebrokenColumn, belongsToMealPlanEventColumn), func(i int, s string) string {
-						return fmt.Sprintf("%s = sqlc.arg(%s)", s, s)
-					}), ",\n\t"),
-					lastUpdatedAtColumn,
-					currentTimeExpression,
-					archivedAtColumn,
-					belongsToMealPlanEventColumn, mealPlanEventIDColumn,
-					idColumn, mealPlanOptionIDColumn,
-				)),
+						mealPlanOptionsTableName,
+						strings.Join(applyToEach(filterForUpdate(mealPlanOptionsColumns, mealPlanOptionsChosenColumn, mealPlanOptionsTiebrokenColumn, belongsToMealPlanEventColumn), func(i int, s string) string {
+							return fmt.Sprintf("%s = sqlc.arg(%s)", s, s)
+						}), ",\n\t"),
+						lastUpdatedAtColumn,
+						currentTimeExpression,
+						archivedAtColumn,
+						belongsToMealPlanEventColumn, mealPlanEventIDColumn,
+						idColumn, mealPlanOptionIDColumn,
+					)),
+				},
 			},
-		}
+		)
 	default:
 		return nil
 	}

--- a/backend/cmd/tools/codegen/queries/mealplanning_meal_plan_tasks.go
+++ b/backend/cmd/tools/codegen/queries/mealplanning_meal_plan_tasks.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"fmt"
+	"slices"
 	"strings"
+
+	"github.com/primandproper/platform-go/v11/database/querygen"
 
 	"github.com/cristalhq/builq"
 )
@@ -38,8 +41,6 @@ var mealPlanTasksColumns = []string{
 func buildMealPlanTasksQueries(database string) []*Query {
 	switch database {
 	case postgres:
-
-		insertColumns := filterForInsert(mealPlanTasksColumns, mealPlanTaskCompletedAtColumn, mealPlanTaskNotificationSentAtColumn)
 
 		fullSelectColumns := mergeColumns(
 			applyToEach(mealPlanTasksColumns, func(i int, s string) string {
@@ -87,64 +88,53 @@ func buildMealPlanTasksQueries(database string) []*Query {
 			1,
 		)
 
-		return []*Query{
-			{
-				// Compensation for the finalization saga's task creation step. It deletes
-				// rather than archives because this table has no archived_at: a task is
-				// derived from the plan's chosen options and is regenerated wholesale when
-				// the step runs again, so a tombstone would be a row nothing could ever read.
-				//
-				// The IDs come from the saga's own state, so it only ever removes what that
-				// instance created — not whatever else happens to hang off the plan.
-				Annotation: QueryAnnotation{
-					Name: "DeleteMealPlanTasks",
-					Type: ExecType,
+		return slices.Concat(
+			querygen.StandardCRUD(mealPlanTasksTableName, mealPlanTasksColumns,
+				querygen.WithEntity("MealPlanTask", "MealPlanTasks"),
+				querygen.WithDatabaseOwned(mealPlanTaskCompletedAtColumn, mealPlanTaskNotificationSentAtColumn),
+				querygen.WithOmitted(querygen.ExistsQuery, querygen.GetQuery, querygen.ListQuery, querygen.UpdateQuery),
+			),
+			[]*Query{
+				{
+					// Compensation for the finalization saga's task creation step. It deletes
+					// rather than archives because this table has no archived_at: a task is
+					// derived from the plan's chosen options and is regenerated wholesale when
+					// the step runs again, so a tombstone would be a row nothing could ever read.
+					//
+					// The IDs come from the saga's own state, so it only ever removes what that
+					// instance created — not whatever else happens to hang off the plan.
+					Annotation: QueryAnnotation{
+						Name: "DeleteMealPlanTasks",
+						Type: ExecType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`DELETE FROM %s WHERE %s = ANY(sqlc.arg(ids)::text[]);`,
+						mealPlanTasksTableName,
+						idColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`DELETE FROM %s WHERE %s = ANY(sqlc.arg(ids)::text[]);`,
-					mealPlanTasksTableName,
-					idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "ChangeMealPlanTaskStatus",
-					Type: ExecType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
+				{
+					Annotation: QueryAnnotation{
+						Name: "ChangeMealPlanTaskStatus",
+						Type: ExecType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
 	%s = sqlc.arg(%s),
 	%s = sqlc.arg(%s),
 	%s = sqlc.arg(%s)
 WHERE %s = sqlc.arg(%s);`,
-					mealPlanTasksTableName,
-					mealPlanTaskCompletedAtColumn, mealPlanTaskCompletedAtColumn,
-					mealPlanTaskStatusExplanationColumn, mealPlanTaskStatusExplanationColumn,
-					mealPlanTaskStatusColumn, mealPlanTaskStatusColumn,
-					idColumn, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CreateMealPlanTask",
-					Type: ExecType,
+						mealPlanTasksTableName,
+						mealPlanTaskCompletedAtColumn, mealPlanTaskCompletedAtColumn,
+						mealPlanTaskStatusExplanationColumn, mealPlanTaskStatusExplanationColumn,
+						mealPlanTaskStatusColumn, mealPlanTaskStatusColumn,
+						idColumn, idColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`INSERT INTO %s (
-	%s
-) VALUES (
-	%s
-);`,
-					mealPlanTasksTableName,
-					strings.Join(insertColumns, ",\n\t"),
-					strings.Join(applyToEach(insertColumns, func(i int, s string) string {
-						return fmt.Sprintf("sqlc.arg(%s)", s)
-					}), ",\n\t"),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CheckMealPlanTaskExistence",
-					Type: OneType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT EXISTS (
+				{
+					Annotation: QueryAnnotation{
+						Name: "CheckMealPlanTaskExistence",
+						Type: OneType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT EXISTS (
 	SELECT %s.%s
 	FROM %s
 		FULL OUTER JOIN %s ON %s.%s=%s.%s
@@ -155,23 +145,23 @@ WHERE %s = sqlc.arg(%s);`,
 		AND %s.%s IS NULL
 		AND %s.%s = sqlc.arg(%s)
 );`,
-					mealPlanTasksTableName, idColumn,
-					mealPlanTasksTableName,
-					mealPlanOptionsTableName, mealPlanTasksTableName, belongsToMealPlanOptionColumn, mealPlanOptionsTableName, idColumn,
-					mealPlanEventsTableName, mealPlanOptionsTableName, belongsToMealPlanEventColumn, mealPlanEventsTableName, idColumn,
-					mealPlansTableName, mealPlanEventsTableName, belongsToMealPlanColumn, mealPlansTableName, idColumn,
-					mealPlanTasksTableName, mealPlanTaskCompletedAtColumn,
-					mealPlansTableName, idColumn, mealPlanIDColumn,
-					mealPlansTableName, archivedAtColumn,
-					mealPlanTasksTableName, idColumn, mealPlanTaskIDColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetMealPlanTask",
-					Type: OneType,
+						mealPlanTasksTableName, idColumn,
+						mealPlanTasksTableName,
+						mealPlanOptionsTableName, mealPlanTasksTableName, belongsToMealPlanOptionColumn, mealPlanOptionsTableName, idColumn,
+						mealPlanEventsTableName, mealPlanOptionsTableName, belongsToMealPlanEventColumn, mealPlanEventsTableName, idColumn,
+						mealPlansTableName, mealPlanEventsTableName, belongsToMealPlanColumn, mealPlansTableName, idColumn,
+						mealPlanTasksTableName, mealPlanTaskCompletedAtColumn,
+						mealPlansTableName, idColumn, mealPlanIDColumn,
+						mealPlansTableName, archivedAtColumn,
+						mealPlanTasksTableName, idColumn, mealPlanTaskIDColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetMealPlanTask",
+						Type: OneType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s
 FROM %s
 	JOIN %s ON %s.%s=%s.%s
@@ -187,29 +177,29 @@ WHERE %s.%s IS NULL
 	AND %s.%s IS NULL
 	AND %s.%s IS NULL
 	AND %s.%s = sqlc.arg(%s);`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					mealPlanTasksTableName,
-					mealPlanOptionsTableName, mealPlanTasksTableName, belongsToMealPlanOptionColumn, mealPlanOptionsTableName, idColumn,
-					mealPlanEventsTableName, mealPlanOptionsTableName, belongsToMealPlanEventColumn, mealPlanEventsTableName, idColumn,
-					mealPlansTableName, mealPlanEventsTableName, belongsToMealPlanColumn, mealPlansTableName, idColumn,
-					mealsTableName, mealPlanOptionsTableName, mealIDColumn, mealsTableName, idColumn,
-					recipePrepTasksTableName, mealPlanTasksTableName, belongsToRecipePrepTaskColumn, recipePrepTasksTableName, idColumn,
-					recipePrepTaskStepsTableName, recipePrepTaskStepsTableName, belongsToRecipePrepTaskColumn, recipePrepTasksTableName, idColumn,
-					recipeStepsTableName, recipePrepTaskStepsTableName, belongsToRecipeStepColumn, recipeStepsTableName, idColumn,
-					mealPlanOptionsTableName, archivedAtColumn,
-					mealPlanEventsTableName, archivedAtColumn,
-					mealPlansTableName, archivedAtColumn,
-					mealsTableName, archivedAtColumn,
-					recipeStepsTableName, archivedAtColumn,
-					mealPlanTasksTableName, idColumn, mealPlanTaskIDColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "ListAllMealPlanTasksByMealPlan",
-					Type: ManyType,
+						strings.Join(fullSelectColumns, ",\n\t"),
+						mealPlanTasksTableName,
+						mealPlanOptionsTableName, mealPlanTasksTableName, belongsToMealPlanOptionColumn, mealPlanOptionsTableName, idColumn,
+						mealPlanEventsTableName, mealPlanOptionsTableName, belongsToMealPlanEventColumn, mealPlanEventsTableName, idColumn,
+						mealPlansTableName, mealPlanEventsTableName, belongsToMealPlanColumn, mealPlansTableName, idColumn,
+						mealsTableName, mealPlanOptionsTableName, mealIDColumn, mealsTableName, idColumn,
+						recipePrepTasksTableName, mealPlanTasksTableName, belongsToRecipePrepTaskColumn, recipePrepTasksTableName, idColumn,
+						recipePrepTaskStepsTableName, recipePrepTaskStepsTableName, belongsToRecipePrepTaskColumn, recipePrepTasksTableName, idColumn,
+						recipeStepsTableName, recipePrepTaskStepsTableName, belongsToRecipeStepColumn, recipeStepsTableName, idColumn,
+						mealPlanOptionsTableName, archivedAtColumn,
+						mealPlanEventsTableName, archivedAtColumn,
+						mealPlansTableName, archivedAtColumn,
+						mealsTableName, archivedAtColumn,
+						recipeStepsTableName, archivedAtColumn,
+						mealPlanTasksTableName, idColumn, mealPlanTaskIDColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "ListAllMealPlanTasksByMealPlan",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s
 FROM %s
 	JOIN %s ON %s.%s=%s.%s
@@ -225,29 +215,29 @@ WHERE %s.%s IS NULL
 	AND %s.%s IS NULL
 	AND %s.%s IS NULL
 	AND %s.%s = sqlc.arg(%s);`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					mealPlanTasksTableName,
-					mealPlanOptionsTableName, mealPlanTasksTableName, belongsToMealPlanOptionColumn, mealPlanOptionsTableName, idColumn,
-					mealPlanEventsTableName, mealPlanOptionsTableName, belongsToMealPlanEventColumn, mealPlanEventsTableName, idColumn,
-					mealPlansTableName, mealPlanEventsTableName, belongsToMealPlanColumn, mealPlansTableName, idColumn,
-					mealsTableName, mealPlanOptionsTableName, mealIDColumn, mealsTableName, idColumn,
-					recipePrepTasksTableName, mealPlanTasksTableName, belongsToRecipePrepTaskColumn, recipePrepTasksTableName, idColumn,
-					recipePrepTaskStepsTableName, recipePrepTaskStepsTableName, belongsToRecipePrepTaskColumn, recipePrepTasksTableName, idColumn,
-					recipeStepsTableName, recipePrepTaskStepsTableName, belongsToRecipeStepColumn, recipeStepsTableName, idColumn,
-					mealPlanOptionsTableName, archivedAtColumn,
-					mealPlanEventsTableName, archivedAtColumn,
-					mealPlansTableName, archivedAtColumn,
-					mealsTableName, archivedAtColumn,
-					recipeStepsTableName, archivedAtColumn,
-					mealPlansTableName, idColumn, mealPlanIDColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "ListIncompleteMealPlanTasksByMealPlanOption",
-					Type: ManyType,
+						strings.Join(fullSelectColumns, ",\n\t"),
+						mealPlanTasksTableName,
+						mealPlanOptionsTableName, mealPlanTasksTableName, belongsToMealPlanOptionColumn, mealPlanOptionsTableName, idColumn,
+						mealPlanEventsTableName, mealPlanOptionsTableName, belongsToMealPlanEventColumn, mealPlanEventsTableName, idColumn,
+						mealPlansTableName, mealPlanEventsTableName, belongsToMealPlanColumn, mealPlansTableName, idColumn,
+						mealsTableName, mealPlanOptionsTableName, mealIDColumn, mealsTableName, idColumn,
+						recipePrepTasksTableName, mealPlanTasksTableName, belongsToRecipePrepTaskColumn, recipePrepTasksTableName, idColumn,
+						recipePrepTaskStepsTableName, recipePrepTaskStepsTableName, belongsToRecipePrepTaskColumn, recipePrepTasksTableName, idColumn,
+						recipeStepsTableName, recipePrepTaskStepsTableName, belongsToRecipeStepColumn, recipeStepsTableName, idColumn,
+						mealPlanOptionsTableName, archivedAtColumn,
+						mealPlanEventsTableName, archivedAtColumn,
+						mealPlansTableName, archivedAtColumn,
+						mealsTableName, archivedAtColumn,
+						recipeStepsTableName, archivedAtColumn,
+						mealPlansTableName, idColumn, mealPlanIDColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "ListIncompleteMealPlanTasksByMealPlanOption",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s
 FROM %s
 	 FULL OUTER JOIN %s ON %s.%s=%s.%s
@@ -257,66 +247,66 @@ FROM %s
 	 JOIN %s ON %s.%s=%s.%s
 WHERE %s.%s = sqlc.arg(%s)
 AND %s.%s IS NULL;`,
-					strings.Join(completeSelectColumns, ",\n\t"),
-					mealPlanTasksTableName,
-					mealPlanOptionsTableName, mealPlanTasksTableName, belongsToMealPlanOptionColumn, mealPlanOptionsTableName, idColumn,
-					mealPlansTableName, mealPlanOptionsTableName, belongsToMealPlanColumn, mealPlansTableName, idColumn,
-					mealsTableName, mealPlanOptionsTableName, mealIDColumn, mealsTableName, idColumn,
-					recipeStepsTableName, mealPlanTasksTableName, satisfiesRecipeStepColumn, recipeStepsTableName, idColumn,
-					validPreparationsTableName, recipeStepsTableName, preparationIDColumn, validPreparationsTableName, idColumn,
-					mealPlanTasksTableName, belongsToMealPlanOptionColumn, belongsToMealPlanOptionColumn,
-					mealPlanTasksTableName, mealPlanTaskCompletedAtColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "MealPlanTaskNotificationHasBeenSent",
-					Type: OneType,
+						strings.Join(completeSelectColumns, ",\n\t"),
+						mealPlanTasksTableName,
+						mealPlanOptionsTableName, mealPlanTasksTableName, belongsToMealPlanOptionColumn, mealPlanOptionsTableName, idColumn,
+						mealPlansTableName, mealPlanOptionsTableName, belongsToMealPlanColumn, mealPlansTableName, idColumn,
+						mealsTableName, mealPlanOptionsTableName, mealIDColumn, mealsTableName, idColumn,
+						recipeStepsTableName, mealPlanTasksTableName, satisfiesRecipeStepColumn, recipeStepsTableName, idColumn,
+						validPreparationsTableName, recipeStepsTableName, preparationIDColumn, validPreparationsTableName, idColumn,
+						mealPlanTasksTableName, belongsToMealPlanOptionColumn, belongsToMealPlanOptionColumn,
+						mealPlanTasksTableName, mealPlanTaskCompletedAtColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT %s.%s IS NOT NULL
+				{
+					Annotation: QueryAnnotation{
+						Name: "MealPlanTaskNotificationHasBeenSent",
+						Type: OneType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT %s.%s IS NOT NULL
 FROM %s
 WHERE %s.%s = sqlc.arg(%s);`,
-					mealPlanTasksTableName, mealPlanTaskNotificationSentAtColumn,
-					mealPlanTasksTableName,
-					mealPlanTasksTableName, idColumn, mealPlanTaskIDColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "MarkMealPlanTaskNotificationSent",
-					Type: ExecType,
+						mealPlanTasksTableName, mealPlanTaskNotificationSentAtColumn,
+						mealPlanTasksTableName,
+						mealPlanTasksTableName, idColumn, mealPlanTaskIDColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET %s = %s
+				{
+					Annotation: QueryAnnotation{
+						Name: "MarkMealPlanTaskNotificationSent",
+						Type: ExecType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET %s = %s
 WHERE %s = sqlc.arg(%s);`,
-					mealPlanTasksTableName,
-					mealPlanTaskNotificationSentAtColumn, currentTimeExpression,
-					idColumn, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "ClearMealPlanTaskNotificationSentForEvent",
-					Type: ExecType,
+						mealPlanTasksTableName,
+						mealPlanTaskNotificationSentAtColumn, currentTimeExpression,
+						idColumn, idColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET %s = NULL
+				{
+					Annotation: QueryAnnotation{
+						Name: "ClearMealPlanTaskNotificationSentForEvent",
+						Type: ExecType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET %s = NULL
 FROM %s
 WHERE %s.%s = %s.%s
 	AND %s.%s = sqlc.arg(%s)
 	AND %s.%s IS NULL;`,
-					mealPlanTasksTableName,
-					mealPlanTaskNotificationSentAtColumn,
-					mealPlanOptionsTableName,
-					mealPlanTasksTableName, belongsToMealPlanOptionColumn, mealPlanOptionsTableName, idColumn,
-					mealPlanOptionsTableName, belongsToMealPlanEventColumn, mealPlanEventIDColumn,
-					mealPlanTasksTableName, mealPlanTaskCompletedAtColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetMealPlanTaskIDsThatNeedNotification",
-					Type: ManyType,
+						mealPlanTasksTableName,
+						mealPlanTaskNotificationSentAtColumn,
+						mealPlanOptionsTableName,
+						mealPlanTasksTableName, belongsToMealPlanOptionColumn, mealPlanOptionsTableName, idColumn,
+						mealPlanOptionsTableName, belongsToMealPlanEventColumn, mealPlanEventIDColumn,
+						mealPlanTasksTableName, mealPlanTaskCompletedAtColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT %s.%s
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetMealPlanTaskIDsThatNeedNotification",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT %s.%s
 FROM %s
 	JOIN %s ON %s.%s = %s.%s
 	JOIN %s ON %s.%s = %s.%s
@@ -327,40 +317,41 @@ WHERE %s.%s IS NULL
 	AND %s.%s IS NULL
 	AND %s.%s IS NULL
 	AND %s.%s > %s;`,
-					mealPlanTasksTableName, idColumn,
-					mealPlanTasksTableName,
-					mealPlanOptionsTableName, mealPlanTasksTableName, belongsToMealPlanOptionColumn, mealPlanOptionsTableName, idColumn,
-					mealPlanEventsTableName, mealPlanOptionsTableName, belongsToMealPlanEventColumn, mealPlanEventsTableName, idColumn,
-					mealPlansTableName, mealPlanEventsTableName, belongsToMealPlanColumn, mealPlansTableName, idColumn,
-					mealPlanTasksTableName, mealPlanTaskCompletedAtColumn,
-					mealPlanTasksTableName, mealPlanTaskNotificationSentAtColumn,
-					mealPlanOptionsTableName, archivedAtColumn,
-					mealPlanEventsTableName, archivedAtColumn,
-					mealPlansTableName, archivedAtColumn,
-					mealPlanEventsTableName, "starts_at",
-					currentTimeExpression,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetMealPlanTaskAccountID",
-					Type: OneType,
+						mealPlanTasksTableName, idColumn,
+						mealPlanTasksTableName,
+						mealPlanOptionsTableName, mealPlanTasksTableName, belongsToMealPlanOptionColumn, mealPlanOptionsTableName, idColumn,
+						mealPlanEventsTableName, mealPlanOptionsTableName, belongsToMealPlanEventColumn, mealPlanEventsTableName, idColumn,
+						mealPlansTableName, mealPlanEventsTableName, belongsToMealPlanColumn, mealPlansTableName, idColumn,
+						mealPlanTasksTableName, mealPlanTaskCompletedAtColumn,
+						mealPlanTasksTableName, mealPlanTaskNotificationSentAtColumn,
+						mealPlanOptionsTableName, archivedAtColumn,
+						mealPlanEventsTableName, archivedAtColumn,
+						mealPlansTableName, archivedAtColumn,
+						mealPlanEventsTableName, "starts_at",
+						currentTimeExpression,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT %s.%s
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetMealPlanTaskAccountID",
+						Type: OneType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT %s.%s
 FROM %s
 	JOIN %s ON %s.%s = %s.%s
 	JOIN %s ON %s.%s = %s.%s
 	JOIN %s ON %s.%s = %s.%s
 WHERE %s.%s = sqlc.arg(%s);`,
-					mealPlansTableName, belongsToAccountColumn,
-					mealPlanTasksTableName,
-					mealPlanOptionsTableName, mealPlanTasksTableName, belongsToMealPlanOptionColumn, mealPlanOptionsTableName, idColumn,
-					mealPlanEventsTableName, mealPlanOptionsTableName, belongsToMealPlanEventColumn, mealPlanEventsTableName, idColumn,
-					mealPlansTableName, mealPlanEventsTableName, belongsToMealPlanColumn, mealPlansTableName, idColumn,
-					mealPlanTasksTableName, idColumn, mealPlanTaskIDColumn,
-				)),
+						mealPlansTableName, belongsToAccountColumn,
+						mealPlanTasksTableName,
+						mealPlanOptionsTableName, mealPlanTasksTableName, belongsToMealPlanOptionColumn, mealPlanOptionsTableName, idColumn,
+						mealPlanEventsTableName, mealPlanOptionsTableName, belongsToMealPlanEventColumn, mealPlanEventsTableName, idColumn,
+						mealPlansTableName, mealPlanEventsTableName, belongsToMealPlanColumn, mealPlansTableName, idColumn,
+						mealPlanTasksTableName, idColumn, mealPlanTaskIDColumn,
+					)),
+				},
 			},
-		}
+		)
 	default:
 		return nil
 	}

--- a/backend/cmd/tools/codegen/queries/mealplanning_meal_plans.go
+++ b/backend/cmd/tools/codegen/queries/mealplanning_meal_plans.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"fmt"
+	"slices"
 	"strings"
+
+	"github.com/primandproper/platform-go/v11/database/querygen"
 
 	"github.com/cristalhq/builq"
 )
@@ -42,91 +45,64 @@ func buildMealPlansQueries(database string) []*Query {
 	switch database {
 	case postgres:
 
-		insertColumns := filterForInsert(mealPlansColumns, mealPlanGroceryListInitializedColumn, mealPlanTasksCreatedColumn, electionMethodColumn)
-
-		return []*Query{
-			{
-				Annotation: QueryAnnotation{
-					Name: "ArchiveMealPlan",
-					Type: ExecRowsType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET %s = %s WHERE %s IS NULL AND %s = sqlc.arg(%s) AND %s = sqlc.arg(%s);`,
-					mealPlansTableName,
-					archivedAtColumn,
-					currentTimeExpression,
-					archivedAtColumn,
-					belongsToAccountColumn,
-					belongsToAccountColumn,
-					idColumn,
-					idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CreateMealPlan",
-					Type: ExecType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`INSERT INTO %s (
-	%s
-) VALUES (
-	%s
-);`,
-					mealPlansTableName,
-					strings.Join(insertColumns, ",\n\t"),
-					strings.Join(applyToEach(insertColumns, func(i int, s string) string {
-						return fmt.Sprintf("sqlc.arg(%s)", s)
-					}), ",\n\t"),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CheckMealPlanExistence",
-					Type: OneType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT EXISTS (
+		return slices.Concat(
+			querygen.StandardCRUD(mealPlansTableName, mealPlansColumns,
+				querygen.WithEntity("MealPlan", "MealPlans"),
+				querygen.WithOwnership(belongsToAccountColumn),
+				querygen.WithDatabaseOwned(mealPlanGroceryListInitializedColumn, mealPlanTasksCreatedColumn, electionMethodColumn),
+				querygen.WithImmutable(createdByUserColumn),
+				querygen.WithOmitted(querygen.ExistsQuery, querygen.ListQuery),
+			),
+			[]*Query{
+				{
+					Annotation: QueryAnnotation{
+						Name: "CheckMealPlanExistence",
+						Type: OneType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT EXISTS (
 	SELECT %s.%s
 	FROM %s
 	WHERE %s.%s IS NULL
 		AND %s.%s = sqlc.arg(%s)
 		AND %s.%s = sqlc.arg(%s)
 );`,
-					mealPlansTableName, idColumn,
-					mealPlansTableName,
-					mealPlansTableName, archivedAtColumn,
-					mealPlansTableName, idColumn, mealPlanIDColumn,
-					mealPlansTableName, belongsToAccountColumn, belongsToAccountColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "FinalizeMealPlan",
-					Type: ExecType,
+						mealPlansTableName, idColumn,
+						mealPlansTableName,
+						mealPlansTableName, archivedAtColumn,
+						mealPlansTableName, idColumn, mealPlanIDColumn,
+						mealPlansTableName, belongsToAccountColumn, belongsToAccountColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(
-					`UPDATE %s SET %s = sqlc.arg(%s) WHERE %s IS NULL AND %s = sqlc.arg(%s);`,
-					mealPlansTableName,
-					mealPlanStatusColumn,
-					mealPlanStatusColumn,
-					archivedAtColumn,
-					idColumn,
-					idColumn,
-				)),
-			},
-			{
-				// The finalization saga's working set: every plan the pipeline still owes
-				// something to and has no saga for yet. The two arms are the two ways a plan
-				// gets here — one that has just run out of voting time, and one that was
-				// finalized by a user request or by a build that predates the saga and never
-				// had its tasks or its grocery list built.
-				//
-				// The second arm is also the migration. A plan left half-processed by the
-				// three jobs this replaced is picked up by exactly the same predicate, and
-				// the saga's steps skip whatever it already has.
-				Annotation: QueryAnnotation{
-					Name: "GetMealPlansAwaitingFinalizationSaga",
-					Type: ManyType,
+				{
+					Annotation: QueryAnnotation{
+						Name: "FinalizeMealPlan",
+						Type: ExecType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(
+						`UPDATE %s SET %s = sqlc.arg(%s) WHERE %s IS NULL AND %s = sqlc.arg(%s);`,
+						mealPlansTableName,
+						mealPlanStatusColumn,
+						mealPlanStatusColumn,
+						archivedAtColumn,
+						idColumn,
+						idColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					// The finalization saga's working set: every plan the pipeline still owes
+					// something to and has no saga for yet. The two arms are the two ways a plan
+					// gets here — one that has just run out of voting time, and one that was
+					// finalized by a user request or by a build that predates the saga and never
+					// had its tasks or its grocery list built.
+					//
+					// The second arm is also the migration. A plan left half-processed by the
+					// three jobs this replaced is picked up by exactly the same predicate, and
+					// the saga's steps skip whatever it already has.
+					Annotation: QueryAnnotation{
+						Name: "GetMealPlansAwaitingFinalizationSaga",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s.%s,
 	%s.%s
 FROM %s
@@ -138,49 +114,49 @@ WHERE %s.%s IS NULL
 	)
 ORDER BY %s.%s
 LIMIT sqlc.arg(query_limit);`,
-					mealPlansTableName, idColumn,
-					mealPlansTableName, belongsToAccountColumn,
-					mealPlansTableName,
-					mealPlansTableName, archivedAtColumn,
-					mealPlansTableName, mealPlanFinalizationSagaIDColumn,
-					mealPlansTableName, mealPlanStatusColumn, mealPlansTableName, mealPlanVotingDeadlineColumn, currentTimeExpression,
-					mealPlansTableName, mealPlanStatusColumn, mealPlansTableName, mealPlanTasksCreatedColumn, mealPlansTableName, mealPlanGroceryListInitializedColumn,
-					mealPlansTableName, mealPlanVotingDeadlineColumn,
-				)),
-			},
-			{
-				// Claims a plan for one saga. The IS NULL predicate is what makes starting
-				// idempotent: the instance row is written in this same transaction, so a
-				// second starter that loses the race matches no rows here and rolls its
-				// instance back rather than running the pipeline twice.
-				Annotation: QueryAnnotation{
-					Name: "AttachMealPlanFinalizationSaga",
-					Type: ExecRowsType,
+						mealPlansTableName, idColumn,
+						mealPlansTableName, belongsToAccountColumn,
+						mealPlansTableName,
+						mealPlansTableName, archivedAtColumn,
+						mealPlansTableName, mealPlanFinalizationSagaIDColumn,
+						mealPlansTableName, mealPlanStatusColumn, mealPlansTableName, mealPlanVotingDeadlineColumn, currentTimeExpression,
+						mealPlansTableName, mealPlanStatusColumn, mealPlansTableName, mealPlanTasksCreatedColumn, mealPlansTableName, mealPlanGroceryListInitializedColumn,
+						mealPlansTableName, mealPlanVotingDeadlineColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
+				{
+					// Claims a plan for one saga. The IS NULL predicate is what makes starting
+					// idempotent: the instance row is written in this same transaction, so a
+					// second starter that loses the race matches no rows here and rolls its
+					// instance back rather than running the pipeline twice.
+					Annotation: QueryAnnotation{
+						Name: "AttachMealPlanFinalizationSaga",
+						Type: ExecRowsType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
 	%s = sqlc.arg(%s),
 	%s = %s
 WHERE %s IS NULL
 	AND %s IS NULL
 	AND %s = sqlc.arg(%s);`,
-					mealPlansTableName,
-					mealPlanFinalizationSagaIDColumn, mealPlanFinalizationSagaIDColumn,
-					lastUpdatedAtColumn, currentTimeExpression,
-					archivedAtColumn,
-					mealPlanFinalizationSagaIDColumn,
-					idColumn, idColumn,
-				)),
-			},
-			{
-				// The task creator's query, narrowed to one plan. It used to select every
-				// finalized plan with tasks_created IS FALSE, because the job rediscovered
-				// its own work; the saga already knows which plan it is running for, and the
-				// flag it used to filter on is now the step's own idempotency guard.
-				Annotation: QueryAnnotation{
-					Name: "GetFinalizedMealPlanOptionsForMealPlan",
-					Type: ManyType,
+						mealPlansTableName,
+						mealPlanFinalizationSagaIDColumn, mealPlanFinalizationSagaIDColumn,
+						lastUpdatedAtColumn, currentTimeExpression,
+						archivedAtColumn,
+						mealPlanFinalizationSagaIDColumn,
+						idColumn, idColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					// The task creator's query, narrowed to one plan. It used to select every
+					// finalized plan with tasks_created IS FALSE, because the job rediscovered
+					// its own work; the saga already knows which plan it is running for, and the
+					// flag it used to filter on is now the step's own idempotency guard.
+					Annotation: QueryAnnotation{
+						Name: "GetFinalizedMealPlanOptionsForMealPlan",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s.%s as meal_plan_id,
 	%s.%s as meal_plan_option_id,
 	%s.%s as meal_id,
@@ -209,96 +185,76 @@ ORDER BY
 	%s.%s,
 	%s.%s,
 	%s.%s;`,
-					mealPlansTableName, idColumn,
-					mealPlanOptionsTableName, idColumn,
-					mealsTableName, idColumn,
-					mealPlanEventsTableName, idColumn,
-					mealComponentsTableName, recipeIDColumn, recipeIDColumn,
-					mealPlanOptionsTableName,
-					mealPlanEventsTableName, mealPlanOptionsTableName, belongsToMealPlanEventColumn, mealPlanEventsTableName, idColumn,
-					mealPlansTableName, mealPlanEventsTableName, belongsToMealPlanColumn, mealPlansTableName, idColumn,
-					mealComponentsTableName, mealPlanOptionsTableName, mealIDColumn, mealComponentsTableName, belongsToMealColumn,
-					mealsTableName, mealPlanOptionsTableName, mealIDColumn, mealsTableName, idColumn,
-					mealPlansTableName, archivedAtColumn,
-					mealPlansTableName, mealPlanStatusColumn,
-					mealPlanOptionsTableName, mealPlanOptionsChosenColumn,
-					mealPlansTableName, idColumn, mealPlanIDColumn,
-					mealPlansTableName, idColumn,
-					mealPlanOptionsTableName, idColumn,
-					mealsTableName, idColumn,
-					mealPlanEventsTableName, idColumn,
-					mealComponentsTableName, recipeIDColumn,
-					mealPlansTableName, idColumn,
-					mealPlanOptionsTableName, idColumn,
-					mealsTableName, idColumn,
-					mealPlanEventsTableName, idColumn,
-					mealComponentsTableName, recipeIDColumn,
-				)),
-			},
-			{
-				// Compensation for the grocery list step, paired with the DELETE of the items
-				// the saga recorded. The flag and the rows it describes are cleared in one
-				// transaction, exactly as they were written.
-				Annotation: QueryAnnotation{
-					Name: "UnmarkMealPlanGroceryListInitialized",
-					Type: ExecType,
+						mealPlansTableName, idColumn,
+						mealPlanOptionsTableName, idColumn,
+						mealsTableName, idColumn,
+						mealPlanEventsTableName, idColumn,
+						mealComponentsTableName, recipeIDColumn, recipeIDColumn,
+						mealPlanOptionsTableName,
+						mealPlanEventsTableName, mealPlanOptionsTableName, belongsToMealPlanEventColumn, mealPlanEventsTableName, idColumn,
+						mealPlansTableName, mealPlanEventsTableName, belongsToMealPlanColumn, mealPlansTableName, idColumn,
+						mealComponentsTableName, mealPlanOptionsTableName, mealIDColumn, mealComponentsTableName, belongsToMealColumn,
+						mealsTableName, mealPlanOptionsTableName, mealIDColumn, mealsTableName, idColumn,
+						mealPlansTableName, archivedAtColumn,
+						mealPlansTableName, mealPlanStatusColumn,
+						mealPlanOptionsTableName, mealPlanOptionsChosenColumn,
+						mealPlansTableName, idColumn, mealPlanIDColumn,
+						mealPlansTableName, idColumn,
+						mealPlanOptionsTableName, idColumn,
+						mealsTableName, idColumn,
+						mealPlanEventsTableName, idColumn,
+						mealComponentsTableName, recipeIDColumn,
+						mealPlansTableName, idColumn,
+						mealPlanOptionsTableName, idColumn,
+						mealsTableName, idColumn,
+						mealPlanEventsTableName, idColumn,
+						mealComponentsTableName, recipeIDColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
+				{
+					// Compensation for the grocery list step, paired with the DELETE of the items
+					// the saga recorded. The flag and the rows it describes are cleared in one
+					// transaction, exactly as they were written.
+					Annotation: QueryAnnotation{
+						Name: "UnmarkMealPlanGroceryListInitialized",
+						Type: ExecType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
 	%s = FALSE,
 	%s = %s
 WHERE %s IS NULL
 	AND %s = sqlc.arg(%s);`,
-					mealPlansTableName,
-					mealPlanGroceryListInitializedColumn,
-					lastUpdatedAtColumn, currentTimeExpression,
-					archivedAtColumn,
-					idColumn, idColumn,
-				)),
-			},
-			{
-				// Compensation for the task creation step. See above.
-				Annotation: QueryAnnotation{
-					Name: "UnmarkMealPlanPrepTasksCreated",
-					Type: ExecType,
+						mealPlansTableName,
+						mealPlanGroceryListInitializedColumn,
+						lastUpdatedAtColumn, currentTimeExpression,
+						archivedAtColumn,
+						idColumn, idColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
+				{
+					// Compensation for the task creation step. See above.
+					Annotation: QueryAnnotation{
+						Name: "UnmarkMealPlanPrepTasksCreated",
+						Type: ExecType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
 	%s = FALSE,
 	%s = %s
 WHERE %s IS NULL
 	AND %s = sqlc.arg(%s);`,
-					mealPlansTableName,
-					mealPlanTasksCreatedColumn,
-					lastUpdatedAtColumn, currentTimeExpression,
-					archivedAtColumn,
-					idColumn, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetMealPlan",
-					Type: OneType,
+						mealPlansTableName,
+						mealPlanTasksCreatedColumn,
+						lastUpdatedAtColumn, currentTimeExpression,
+						archivedAtColumn,
+						idColumn, idColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
-	%s
-FROM %s
-WHERE %s.%s IS NULL
-  AND %s.%s = sqlc.arg(%s)
-  AND %s.%s = sqlc.arg(%s);`,
-					strings.Join(applyToEach(mealPlansColumns, func(i int, s string) string {
-						return fmt.Sprintf("%s.%s", mealPlansTableName, s)
-					}), ",\n\t"),
-					mealPlansTableName,
-					mealPlansTableName, archivedAtColumn,
-					mealPlansTableName, idColumn, idColumn,
-					mealPlansTableName, belongsToAccountColumn, belongsToAccountColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetMealPlansForAccount",
-					Type: ManyType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetMealPlansForAccount",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s
@@ -306,23 +262,23 @@ FROM %s
 WHERE %s.%s IS NULL
 	%s
 %s;`,
-					strings.Join(applyToEach(mealPlansColumns, func(i int, s string) string {
-						return fmt.Sprintf("%s.%s", mealPlansTableName, s)
-					}), ",\n\t"),
-					buildFilterCountSelect(mealPlansTableName, true, true, []string{}, fmt.Sprintf("%s.%s = sqlc.arg(%s)", mealPlansTableName, belongsToAccountColumn, belongsToAccountColumn)),
-					buildTotalCountSelect(mealPlansTableName, true, []string{}, fmt.Sprintf("%s.%s = sqlc.arg(%s)", mealPlansTableName, belongsToAccountColumn, belongsToAccountColumn)),
-					mealPlansTableName,
-					mealPlansTableName, archivedAtColumn,
-					buildFilterConditions(mealPlansTableName, true, true, fmt.Sprintf("%s.%s = sqlc.arg(%s)", mealPlansTableName, belongsToAccountColumn, belongsToAccountColumn)),
-					buildCursorLimitClause(mealPlansTableName),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetMealPlanPastVotingDeadline",
-					Type: OneType,
+						strings.Join(applyToEach(mealPlansColumns, func(i int, s string) string {
+							return fmt.Sprintf("%s.%s", mealPlansTableName, s)
+						}), ",\n\t"),
+						buildFilterCountSelect(mealPlansTableName, true, true, []string{}, fmt.Sprintf("%s.%s = sqlc.arg(%s)", mealPlansTableName, belongsToAccountColumn, belongsToAccountColumn)),
+						buildTotalCountSelect(mealPlansTableName, true, []string{}, fmt.Sprintf("%s.%s = sqlc.arg(%s)", mealPlansTableName, belongsToAccountColumn, belongsToAccountColumn)),
+						mealPlansTableName,
+						mealPlansTableName, archivedAtColumn,
+						buildFilterConditions(mealPlansTableName, true, true, fmt.Sprintf("%s.%s = sqlc.arg(%s)", mealPlansTableName, belongsToAccountColumn, belongsToAccountColumn)),
+						buildCursorLimitClause(mealPlansTableName),
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetMealPlanPastVotingDeadline",
+						Type: OneType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s
 FROM %s
 WHERE %s.%s IS NULL
@@ -330,23 +286,23 @@ WHERE %s.%s IS NULL
 	AND %s.%s = sqlc.arg(account_id)
 	AND %s.%s = 'awaiting_votes'
 	AND %s > %s.%s;`,
-					strings.Join(applyToEach(mealPlansColumns, func(i int, s string) string {
-						return fmt.Sprintf("%s.%s", mealPlansTableName, s)
-					}), ",\n\t"),
-					mealPlansTableName,
-					mealPlansTableName, archivedAtColumn,
-					mealPlansTableName, idColumn,
-					mealPlansTableName, belongsToAccountColumn,
-					mealPlansTableName, mealPlanStatusColumn,
-					currentTimeExpression, mealPlansTableName, mealPlanVotingDeadlineColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "FindMealPlansForDates",
-					Type: ManyType,
+						strings.Join(applyToEach(mealPlansColumns, func(i int, s string) string {
+							return fmt.Sprintf("%s.%s", mealPlansTableName, s)
+						}), ",\n\t"),
+						mealPlansTableName,
+						mealPlansTableName, archivedAtColumn,
+						mealPlansTableName, idColumn,
+						mealPlansTableName, belongsToAccountColumn,
+						mealPlansTableName, mealPlanStatusColumn,
+						currentTimeExpression, mealPlansTableName, mealPlanVotingDeadlineColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT DISTINCT
+				{
+					Annotation: QueryAnnotation{
+						Name: "FindMealPlansForDates",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT DISTINCT
 	%s
 FROM %s
 	JOIN %s ON %s.%s = %s.%s
@@ -356,75 +312,55 @@ WHERE %s.%s IS NULL
 	AND %s.%s <= sqlc.arg(end_time)
 	AND %s.%s >= sqlc.arg(start_time)
 ORDER BY %s.%s;`,
-					strings.Join(applyToEach(mealPlansColumns, func(i int, s string) string {
-						return fmt.Sprintf("%s.%s", mealPlansTableName, s)
-					}), ",\n\t"),
-					mealPlansTableName,
-					mealPlanEventsTableName, mealPlansTableName, idColumn, mealPlanEventsTableName, belongsToMealPlanColumn,
-					mealPlansTableName, archivedAtColumn,
-					mealPlanEventsTableName, archivedAtColumn,
-					mealPlansTableName, belongsToAccountColumn, belongsToAccountColumn,
-					mealPlanEventsTableName, "starts_at",
-					mealPlanEventsTableName, "ends_at",
-					mealPlansTableName, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "MarkMealPlanAsGroceryListInitialized",
-					Type: ExecType,
+						strings.Join(applyToEach(mealPlansColumns, func(i int, s string) string {
+							return fmt.Sprintf("%s.%s", mealPlansTableName, s)
+						}), ",\n\t"),
+						mealPlansTableName,
+						mealPlanEventsTableName, mealPlansTableName, idColumn, mealPlanEventsTableName, belongsToMealPlanColumn,
+						mealPlansTableName, archivedAtColumn,
+						mealPlanEventsTableName, archivedAtColumn,
+						mealPlansTableName, belongsToAccountColumn, belongsToAccountColumn,
+						mealPlanEventsTableName, "starts_at",
+						mealPlanEventsTableName, "ends_at",
+						mealPlansTableName, idColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
+				{
+					Annotation: QueryAnnotation{
+						Name: "MarkMealPlanAsGroceryListInitialized",
+						Type: ExecType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
 	%s = TRUE,
 	%s = %s
 WHERE %s IS NULL
 	AND %s = sqlc.arg(%s);`,
-					mealPlansTableName,
-					mealPlanGroceryListInitializedColumn,
-					lastUpdatedAtColumn, currentTimeExpression,
-					archivedAtColumn,
-					idColumn, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "MarkMealPlanAsPrepTasksCreated",
-					Type: ExecType,
+						mealPlansTableName,
+						mealPlanGroceryListInitializedColumn,
+						lastUpdatedAtColumn, currentTimeExpression,
+						archivedAtColumn,
+						idColumn, idColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
+				{
+					Annotation: QueryAnnotation{
+						Name: "MarkMealPlanAsPrepTasksCreated",
+						Type: ExecType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
 	%s = TRUE,
 	%s = %s
 WHERE %s IS NULL
 	AND %s = sqlc.arg(%s);`,
-					mealPlansTableName,
-					mealPlanTasksCreatedColumn,
-					lastUpdatedAtColumn, currentTimeExpression,
-					archivedAtColumn,
-					idColumn, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "UpdateMealPlan",
-					Type: ExecRowsType,
+						mealPlansTableName,
+						mealPlanTasksCreatedColumn,
+						lastUpdatedAtColumn, currentTimeExpression,
+						archivedAtColumn,
+						idColumn, idColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
-	%s,
-	%s = %s
-WHERE %s IS NULL
-	AND %s = sqlc.arg(%s)
-	AND %s = sqlc.arg(%s);`,
-					mealPlansTableName,
-					strings.Join(applyToEach(filterForUpdate(mealPlansColumns, mealPlanGroceryListInitializedColumn, mealPlanTasksCreatedColumn, electionMethodColumn, belongsToAccountColumn, createdByUserColumn), func(i int, s string) string {
-						return fmt.Sprintf("%s = sqlc.arg(%s)", s, s)
-					}), ",\n\t"),
-					lastUpdatedAtColumn, currentTimeExpression,
-					archivedAtColumn,
-					belongsToAccountColumn, belongsToAccountColumn,
-					idColumn, idColumn,
-				)),
 			},
-		}
+		)
 	default:
 		return nil
 	}

--- a/backend/cmd/tools/codegen/queries/mealplanning_meals.go
+++ b/backend/cmd/tools/codegen/queries/mealplanning_meals.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"fmt"
+	"slices"
 	"strings"
+
+	"github.com/primandproper/platform-go/v11/database/querygen"
 
 	"github.com/cristalhq/builq"
 )
@@ -35,8 +38,6 @@ func buildMealsQueries(database string) []*Query {
 	switch database {
 	case postgres:
 
-		insertColumns := filterForInsert(mealsColumns)
-
 		fullSelectColumns := append(
 			applyToEach(mealsColumns, func(i int, s string) string {
 				return fmt.Sprintf("%s.%s", mealsTableName, s)
@@ -46,63 +47,34 @@ func buildMealsQueries(database string) []*Query {
 			})...,
 		)
 
-		return []*Query{
-			{
-				Annotation: QueryAnnotation{
-					Name: "ArchiveMeal",
-					Type: ExecRowsType,
+		return slices.Concat(
+			querygen.StandardCRUD(mealsTableName, mealsColumns,
+				querygen.WithEntity("Meal", "Meals"),
+				querygen.WithOmitted(querygen.ArchiveQuery, querygen.GetQuery, querygen.ListQuery, querygen.MarkAsIndexedQuery, querygen.UpdateQuery),
+			),
+			[]*Query{
+				{
+					Annotation: QueryAnnotation{
+						Name: "ArchiveMeal",
+						Type: ExecRowsType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET %s = %s WHERE %s IS NULL AND %s = sqlc.arg(%s) AND %s = sqlc.arg(%s);`,
+						mealsTableName,
+						archivedAtColumn,
+						currentTimeExpression,
+						archivedAtColumn,
+						createdByUserColumn,
+						createdByUserColumn,
+						idColumn,
+						idColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET %s = %s WHERE %s IS NULL AND %s = sqlc.arg(%s) AND %s = sqlc.arg(%s);`,
-					mealsTableName,
-					archivedAtColumn,
-					currentTimeExpression,
-					archivedAtColumn,
-					createdByUserColumn,
-					createdByUserColumn,
-					idColumn,
-					idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CreateMeal",
-					Type: ExecType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`INSERT INTO %s (
-	%s
-) VALUES (
-	%s
-);`,
-					mealsTableName,
-					strings.Join(insertColumns, ",\n\t"),
-					strings.Join(applyToEach(insertColumns, func(i int, s string) string {
-						return fmt.Sprintf("sqlc.arg(%s)", s)
-					}), ",\n\t"),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CheckMealExistence",
-					Type: OneType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT EXISTS (
-	SELECT %s.%s
-	FROM %s
-	WHERE %s.%s IS NULL
-		AND %s.%s = sqlc.arg(%s)
-);`,
-					mealsTableName, idColumn,
-					mealsTableName,
-					mealsTableName, archivedAtColumn,
-					mealsTableName, idColumn, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetMealsByCreatorAndName",
-					Type: ManyType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetMealsByCreatorAndName",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s
 FROM %s
 	JOIN %s ON %s.%s=%s.%s
@@ -112,52 +84,45 @@ WHERE %s.%s IS NULL
 	AND %s.%s = sqlc.arg(%s)
 	AND %s.%s = sqlc.arg(%s)
 ORDER BY %s.%s ASC, %s.%s ASC;`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					mealsTableName,
-					mealComponentsTableName, mealComponentsTableName, belongsToMealColumn, mealsTableName, idColumn,
-					mealComponentsTableName, archivedAtColumn,
-					recipesTableName, recipesTableName, idColumn, mealComponentsTableName, recipeIDColumn,
-					recipesTableName, archivedAtColumn,
-					mealsTableName, archivedAtColumn,
-					mealsTableName, createdByUserColumn, createdByUserColumn,
-					mealsTableName, nameColumn, nameColumn,
-					mealsTableName, idColumn,
-					mealComponentsTableName, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "ScanMealIDsForReindex",
-					Type: ManyType,
+						strings.Join(fullSelectColumns, ",\n\t"),
+						mealsTableName,
+						mealComponentsTableName, mealComponentsTableName, belongsToMealColumn, mealsTableName, idColumn,
+						mealComponentsTableName, archivedAtColumn,
+						recipesTableName, recipesTableName, idColumn, mealComponentsTableName, recipeIDColumn,
+						recipesTableName, archivedAtColumn,
+						mealsTableName, archivedAtColumn,
+						mealsTableName, createdByUserColumn, createdByUserColumn,
+						mealsTableName, nameColumn, nameColumn,
+						mealsTableName, idColumn,
+						mealComponentsTableName, idColumn,
+					)),
 				},
-				Content: buildReindexScanQuery(mealsTableName),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetMealsNeedingIndexing",
-					Type: ManyType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT %s.%s
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetMealsNeedingIndexing",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT %s.%s
 	FROM %s
 	WHERE %s.%s IS NULL
 	AND (
 		%s.%s IS NULL
 		OR %s.%s < %s - '24 hours'::INTERVAL
 	);`,
-					mealsTableName, idColumn,
-					mealsTableName,
-					mealsTableName, archivedAtColumn,
-					mealsTableName, lastIndexedAtColumn,
-					mealsTableName, lastIndexedAtColumn,
-					currentTimeExpression,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetMeal",
-					Type: ManyType,
+						mealsTableName, idColumn,
+						mealsTableName,
+						mealsTableName, archivedAtColumn,
+						mealsTableName, lastIndexedAtColumn,
+						mealsTableName, lastIndexedAtColumn,
+						currentTimeExpression,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetMeal",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s
 FROM %s
 	JOIN %s ON %s.%s=%s.%s
@@ -165,22 +130,22 @@ FROM %s
 		AND EXISTS (SELECT 1 FROM %s WHERE %s.%s = %s.%s AND %s.%s IS NULL)
 WHERE %s.%s IS NULL
   AND %s.%s = sqlc.arg(%s);`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					mealsTableName,
-					mealComponentsTableName, mealComponentsTableName, belongsToMealColumn, mealsTableName, idColumn,
-					mealComponentsTableName, archivedAtColumn,
-					recipesTableName, recipesTableName, idColumn, mealComponentsTableName, recipeIDColumn,
-					recipesTableName, archivedAtColumn,
-					mealsTableName, archivedAtColumn,
-					mealsTableName, idColumn, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetMeals",
-					Type: ManyType,
+						strings.Join(fullSelectColumns, ",\n\t"),
+						mealsTableName,
+						mealComponentsTableName, mealComponentsTableName, belongsToMealColumn, mealsTableName, idColumn,
+						mealComponentsTableName, archivedAtColumn,
+						recipesTableName, recipesTableName, idColumn, mealComponentsTableName, recipeIDColumn,
+						recipesTableName, archivedAtColumn,
+						mealsTableName, archivedAtColumn,
+						mealsTableName, idColumn, idColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetMeals",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s
@@ -191,29 +156,29 @@ WHERE
 	%s.%s IS NULL
 	%s
 %s;`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					buildFilterCountSelect(mealsTableName, true, true, []string{}),
-					buildTotalCountSelect(mealsTableName, true, []string{}),
-					mealsTableName,
-					mealComponentsTableName, mealComponentsTableName, belongsToMealColumn, mealsTableName, idColumn,
-					mealComponentsTableName, archivedAtColumn,
-					recipesTableName, recipesTableName, idColumn, mealComponentsTableName, recipeIDColumn,
-					recipesTableName, archivedAtColumn,
-					mealsTableName, archivedAtColumn,
-					buildFilterConditions(
+						strings.Join(fullSelectColumns, ",\n\t"),
+						buildFilterCountSelect(mealsTableName, true, true, []string{}),
+						buildTotalCountSelect(mealsTableName, true, []string{}),
 						mealsTableName,
-						true,
-						true,
-					),
-					buildCursorLimitClause(mealsTableName),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetMealsWithIDs",
-					Type: ManyType,
+						mealComponentsTableName, mealComponentsTableName, belongsToMealColumn, mealsTableName, idColumn,
+						mealComponentsTableName, archivedAtColumn,
+						recipesTableName, recipesTableName, idColumn, mealComponentsTableName, recipeIDColumn,
+						recipesTableName, archivedAtColumn,
+						mealsTableName, archivedAtColumn,
+						buildFilterConditions(
+							mealsTableName,
+							true,
+							true,
+						),
+						buildCursorLimitClause(mealsTableName),
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetMealsWithIDs",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s
 FROM %s
 	JOIN %s ON %s.%s=%s.%s
@@ -222,23 +187,23 @@ FROM %s
 WHERE %s.%s IS NULL
   AND %s.%s = ANY(sqlc.arg(ids)::text[])
 ORDER BY %s.%s ASC;`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					mealsTableName,
-					mealComponentsTableName, mealComponentsTableName, belongsToMealColumn, mealsTableName, idColumn,
-					mealComponentsTableName, archivedAtColumn,
-					recipesTableName, recipesTableName, idColumn, mealComponentsTableName, recipeIDColumn,
-					recipesTableName, archivedAtColumn,
-					mealsTableName, archivedAtColumn,
-					mealsTableName, idColumn,
-					mealsTableName, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetMealsCreatedByUser",
-					Type: ManyType,
+						strings.Join(fullSelectColumns, ",\n\t"),
+						mealsTableName,
+						mealComponentsTableName, mealComponentsTableName, belongsToMealColumn, mealsTableName, idColumn,
+						mealComponentsTableName, archivedAtColumn,
+						recipesTableName, recipesTableName, idColumn, mealComponentsTableName, recipeIDColumn,
+						recipesTableName, archivedAtColumn,
+						mealsTableName, archivedAtColumn,
+						mealsTableName, idColumn,
+						mealsTableName, idColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetMealsCreatedByUser",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s
@@ -250,26 +215,26 @@ WHERE
 	AND %s.%s = sqlc.arg(%s)
 	%s
 %s;`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					buildFilterCountSelect(mealsTableName, true, true, []string{}, fmt.Sprintf("%s.%s = sqlc.arg(%s)", mealsTableName, createdByUserColumn, createdByUserColumn)),
-					buildTotalCountSelect(mealsTableName, true, []string{}, fmt.Sprintf("%s.%s = sqlc.arg(%s)", mealsTableName, createdByUserColumn, createdByUserColumn)),
-					mealsTableName,
-					mealComponentsTableName, mealComponentsTableName, belongsToMealColumn, mealsTableName, idColumn,
-					mealComponentsTableName, archivedAtColumn,
-					recipesTableName, recipesTableName, idColumn, mealComponentsTableName, recipeIDColumn,
-					recipesTableName, archivedAtColumn,
-					mealsTableName, archivedAtColumn,
-					mealsTableName, createdByUserColumn, createdByUserColumn,
-					buildFilterConditions(mealsTableName, true, true, fmt.Sprintf("%s.%s = sqlc.arg(%s)", mealsTableName, createdByUserColumn, createdByUserColumn)),
-					buildCursorLimitClause(mealsTableName),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "SearchForMeals",
-					Type: ManyType,
+						strings.Join(fullSelectColumns, ",\n\t"),
+						buildFilterCountSelect(mealsTableName, true, true, []string{}, fmt.Sprintf("%s.%s = sqlc.arg(%s)", mealsTableName, createdByUserColumn, createdByUserColumn)),
+						buildTotalCountSelect(mealsTableName, true, []string{}, fmt.Sprintf("%s.%s = sqlc.arg(%s)", mealsTableName, createdByUserColumn, createdByUserColumn)),
+						mealsTableName,
+						mealComponentsTableName, mealComponentsTableName, belongsToMealColumn, mealsTableName, idColumn,
+						mealComponentsTableName, archivedAtColumn,
+						recipesTableName, recipesTableName, idColumn, mealComponentsTableName, recipeIDColumn,
+						recipesTableName, archivedAtColumn,
+						mealsTableName, archivedAtColumn,
+						mealsTableName, createdByUserColumn, createdByUserColumn,
+						buildFilterConditions(mealsTableName, true, true, fmt.Sprintf("%s.%s = sqlc.arg(%s)", mealsTableName, createdByUserColumn, createdByUserColumn)),
+						buildCursorLimitClause(mealsTableName),
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "SearchForMeals",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s
@@ -282,42 +247,43 @@ WHERE
 	AND %s.%s %s
 	%s
 %s;`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					buildFilterCountSelect(mealsTableName, true, true, []string{}),
-					buildTotalCountSelect(mealsTableName, true, []string{}),
-					mealsTableName,
-					mealComponentsTableName, mealComponentsTableName, belongsToMealColumn, mealsTableName, idColumn,
-					mealComponentsTableName, archivedAtColumn,
-					recipesTableName, recipesTableName, idColumn, mealComponentsTableName, recipeIDColumn,
-					recipesTableName, archivedAtColumn,
-					mealsTableName, archivedAtColumn,
-					mealsTableName, nameColumn, buildILIKEForArgument("query"),
-					buildFilterConditions(
+						strings.Join(fullSelectColumns, ",\n\t"),
+						buildFilterCountSelect(mealsTableName, true, true, []string{}),
+						buildTotalCountSelect(mealsTableName, true, []string{}),
 						mealsTableName,
-						true,
-						true,
-					),
-					buildCursorLimitClause(mealsTableName),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "MarkMealsAsIndexed",
-					Type: ExecRowsType,
+						mealComponentsTableName, mealComponentsTableName, belongsToMealColumn, mealsTableName, idColumn,
+						mealComponentsTableName, archivedAtColumn,
+						recipesTableName, recipesTableName, idColumn, mealComponentsTableName, recipeIDColumn,
+						recipesTableName, archivedAtColumn,
+						mealsTableName, archivedAtColumn,
+						mealsTableName, nameColumn, buildILIKEForArgument("query"),
+						buildFilterConditions(
+							mealsTableName,
+							true,
+							true,
+						),
+						buildCursorLimitClause(mealsTableName),
+					)),
 				},
-				// Bulk, and named for what querygen emits, so migrating this table to
-				// StandardCRUD deletes this declaration without renaming anything.
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
+				{
+					Annotation: QueryAnnotation{
+						Name: "MarkMealsAsIndexed",
+						Type: ExecRowsType,
+					},
+					// Bulk, and named for what querygen emits, so migrating this table to
+					// StandardCRUD deletes this declaration without renaming anything.
+					Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
 	%s = %s
 WHERE %s = ANY(sqlc.arg(%s)::text[]);`,
-					mealsTableName,
-					lastIndexedAtColumn,
-					currentTimeExpression,
-					idColumn,
-					idsArg,
-				)),
+						mealsTableName,
+						lastIndexedAtColumn,
+						currentTimeExpression,
+						idColumn,
+						idsArg,
+					)),
+				},
 			},
-		}
+		)
 	default:
 		return nil
 	}

--- a/backend/cmd/tools/codegen/queries/mealplanning_recipe_list_items.go
+++ b/backend/cmd/tools/codegen/queries/mealplanning_recipe_list_items.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"fmt"
+	"slices"
 	"strings"
+
+	"github.com/primandproper/platform-go/v11/database/querygen"
 
 	"github.com/cristalhq/builq"
 )
@@ -31,45 +34,19 @@ func buildRecipeListItemsQueries(database string) []*Query {
 	switch database {
 	case postgres:
 
-		insertColumns := filterForInsert(recipeListItemsColumns)
-
-		return []*Query{
-			{
-				Annotation: QueryAnnotation{
-					Name: "ArchiveRecipeListItem",
-					Type: ExecRowsType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET %s = %s WHERE %s IS NULL AND %s = sqlc.arg(%s) AND %s = sqlc.arg(%s);`,
-					recipeListItemsTableName,
-					archivedAtColumn, currentTimeExpression,
-					archivedAtColumn,
-					"belongs_to_recipe_list", "belongs_to_recipe_list",
-					idColumn, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CreateRecipeListItem",
-					Type: ExecType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`INSERT INTO %s (
-	%s
-) VALUES (
-	%s
-);`,
-					recipeListItemsTableName,
-					strings.Join(insertColumns, ",\n\t"),
-					strings.Join(applyToEach(insertColumns, func(i int, s string) string {
-						return fmt.Sprintf("sqlc.arg(%s)", s)
-					}), ",\n\t"),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetRecipeListItems",
-					Type: ManyType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+		return slices.Concat(
+			querygen.StandardCRUD(recipeListItemsTableName, recipeListItemsColumns,
+				querygen.WithEntity("RecipeListItem", "RecipeListItems"),
+				querygen.WithOwnership("belongs_to_recipe_list"),
+				querygen.WithOmitted(querygen.ExistsQuery, querygen.GetQuery, querygen.ListQuery),
+			),
+			[]*Query{
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetRecipeListItems",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s
@@ -78,40 +55,20 @@ WHERE %s.%s IS NULL
 	%s
 	AND %s.belongs_to_recipe_list = sqlc.arg(%s)
 %s;`,
-					strings.Join(applyToEach(recipeListItemsColumns, func(i int, s string) string {
-						return fmt.Sprintf("%s.%s", recipeListItemsTableName, s)
-					}), ",\n\t"),
-					buildFilterCountSelect(recipeListItemsTableName, true, true, []string{}, fmt.Sprintf("%s.belongs_to_recipe_list = sqlc.arg(%s)", recipeListItemsTableName, recipeListIDColumn)),
-					buildTotalCountSelect(recipeListItemsTableName, true, []string{}),
-					recipeListItemsTableName,
-					recipeListItemsTableName, archivedAtColumn,
-					buildFilterConditions(recipeListItemsTableName, true, false, fmt.Sprintf("%s.belongs_to_recipe_list = sqlc.arg(%s)", recipeListItemsTableName, recipeListIDColumn)),
-					recipeListItemsTableName, recipeListIDColumn,
-					buildCursorLimitClause(recipeListItemsTableName),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "UpdateRecipeListItem",
-					Type: ExecRowsType,
+						strings.Join(applyToEach(recipeListItemsColumns, func(i int, s string) string {
+							return fmt.Sprintf("%s.%s", recipeListItemsTableName, s)
+						}), ",\n\t"),
+						buildFilterCountSelect(recipeListItemsTableName, true, true, []string{}, fmt.Sprintf("%s.belongs_to_recipe_list = sqlc.arg(%s)", recipeListItemsTableName, recipeListIDColumn)),
+						buildTotalCountSelect(recipeListItemsTableName, true, []string{}),
+						recipeListItemsTableName,
+						recipeListItemsTableName, archivedAtColumn,
+						buildFilterConditions(recipeListItemsTableName, true, false, fmt.Sprintf("%s.belongs_to_recipe_list = sqlc.arg(%s)", recipeListItemsTableName, recipeListIDColumn)),
+						recipeListItemsTableName, recipeListIDColumn,
+						buildCursorLimitClause(recipeListItemsTableName),
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
-	%s,
-	%s = %s
-WHERE %s IS NULL
-	AND %s = sqlc.arg(%s)
-	AND %s = sqlc.arg(%s);`,
-					recipeListItemsTableName,
-					strings.Join(applyToEach(filterForUpdate(recipeListItemsColumns, "belongs_to_recipe_list"), func(i int, s string) string {
-						return fmt.Sprintf("%s = sqlc.arg(%s)", s, s)
-					}), ",\n\t"),
-					lastUpdatedAtColumn, currentTimeExpression,
-					archivedAtColumn,
-					"belongs_to_recipe_list", "belongs_to_recipe_list",
-					idColumn, idColumn,
-				)),
 			},
-		}
+		)
 	default:
 		return nil
 	}

--- a/backend/cmd/tools/codegen/queries/mealplanning_recipe_lists.go
+++ b/backend/cmd/tools/codegen/queries/mealplanning_recipe_lists.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"fmt"
+	"slices"
 	"strings"
+
+	"github.com/primandproper/platform-go/v11/database/querygen"
 
 	"github.com/cristalhq/builq"
 )
@@ -29,7 +32,6 @@ func buildRecipeListsQueries(database string) []*Query {
 	switch database {
 	case postgres:
 
-		insertColumns := filterForInsert(recipeListsColumns)
 		fullSelectColumns := mergeColumns(
 			applyToEach(recipeListsColumns, func(i int, s string) string {
 				return fmt.Sprintf("%s.%s", recipeListsTableName, s)
@@ -40,43 +42,19 @@ func buildRecipeListsQueries(database string) []*Query {
 			2,
 		)
 
-		return []*Query{
-			{
-				Annotation: QueryAnnotation{
-					Name: "ArchiveRecipeList",
-					Type: ExecRowsType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET %s = %s WHERE %s IS NULL AND %s = sqlc.arg(%s) AND %s = sqlc.arg(%s);`,
-					recipeListsTableName,
-					archivedAtColumn, currentTimeExpression,
-					archivedAtColumn,
-					belongsToUserColumn, belongsToUserColumn,
-					idColumn, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CreateRecipeList",
-					Type: ExecType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`INSERT INTO %s (
-	%s
-) VALUES (
-	%s
-);`,
-					recipeListsTableName,
-					strings.Join(insertColumns, ",\n\t"),
-					strings.Join(applyToEach(insertColumns, func(i int, s string) string {
-						return fmt.Sprintf("sqlc.arg(%s)", s)
-					}), ",\n\t"),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetRecipeLists",
-					Type: ManyType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+		return slices.Concat(
+			querygen.StandardCRUD(recipeListsTableName, recipeListsColumns,
+				querygen.WithEntity("RecipeList", "RecipeLists"),
+				querygen.WithOwnership(belongsToUserColumn),
+				querygen.WithOmitted(querygen.ExistsQuery, querygen.GetQuery, querygen.ListQuery),
+			),
+			[]*Query{
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetRecipeLists",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s
@@ -85,38 +63,18 @@ FROM %s
 	WHERE %s.%s IS NULL
 	%s
 %s;`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					buildFilterCountSelect(recipeListsTableName, true, true, []string{}),
-					buildTotalCountSelect(recipeListsTableName, true, []string{}),
-					recipeListsTableName,
-					recipeListItemsTableName, recipeListItemsTableName, "belongs_to_recipe_list", recipeListsTableName, idColumn, recipeListItemsTableName, archivedAtColumn,
-					recipeListsTableName, archivedAtColumn,
-					buildFilterConditions(recipeListsTableName, true, false),
-					buildCursorLimitClause(recipeListsTableName),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "UpdateRecipeList",
-					Type: ExecRowsType,
+						strings.Join(fullSelectColumns, ",\n\t"),
+						buildFilterCountSelect(recipeListsTableName, true, true, []string{}),
+						buildTotalCountSelect(recipeListsTableName, true, []string{}),
+						recipeListsTableName,
+						recipeListItemsTableName, recipeListItemsTableName, "belongs_to_recipe_list", recipeListsTableName, idColumn, recipeListItemsTableName, archivedAtColumn,
+						recipeListsTableName, archivedAtColumn,
+						buildFilterConditions(recipeListsTableName, true, false),
+						buildCursorLimitClause(recipeListsTableName),
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
-	%s,
-	%s = %s
-WHERE %s IS NULL
-	AND %s = sqlc.arg(%s)
-	AND %s = sqlc.arg(%s);`,
-					recipeListsTableName,
-					strings.Join(applyToEach(filterForUpdate(recipeListsColumns, belongsToUserColumn), func(i int, s string) string {
-						return fmt.Sprintf("%s = sqlc.arg(%s)", s, s)
-					}), ",\n\t"),
-					lastUpdatedAtColumn, currentTimeExpression,
-					archivedAtColumn,
-					belongsToUserColumn, belongsToUserColumn,
-					idColumn, idColumn,
-				)),
 			},
-		}
+		)
 	default:
 		return nil
 	}

--- a/backend/cmd/tools/codegen/queries/mealplanning_recipe_media.go
+++ b/backend/cmd/tools/codegen/queries/mealplanning_recipe_media.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"fmt"
+	"slices"
 	"strings"
+
+	"github.com/primandproper/platform-go/v11/database/querygen"
 
 	"github.com/cristalhq/builq"
 )
@@ -32,63 +35,18 @@ func buildRecipeMediaQueries(database string) []*Query {
 	switch database {
 	case postgres:
 
-		insertColumns := filterForInsert(recipeMediaColumns)
-
-		return []*Query{
-			{
-				Annotation: QueryAnnotation{
-					Name: "ArchiveRecipeMedia",
-					Type: ExecRowsType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET %s = %s WHERE %s IS NULL AND %s = sqlc.arg(%s);`,
-					recipeMediaTableName,
-					archivedAtColumn,
-					currentTimeExpression,
-					archivedAtColumn,
-					idColumn,
-					idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CreateRecipeMedia",
-					Type: ExecType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`INSERT INTO %s (
-	%s
-) VALUES (
-	%s
-);`,
-					recipeMediaTableName,
-					strings.Join(insertColumns, ",\n\t"),
-					strings.Join(applyToEach(insertColumns, func(i int, s string) string {
-						return fmt.Sprintf("sqlc.arg(%s)", s)
-					}), ",\n\t"),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CheckRecipeMediaExistence",
-					Type: OneType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT EXISTS (
-	SELECT %s.%s
-	FROM %s
-	WHERE %s.%s IS NULL
-		AND %s.%s = sqlc.arg(%s)
-);`,
-					recipeMediaTableName, idColumn,
-					recipeMediaTableName,
-					recipeMediaTableName, archivedAtColumn,
-					recipeMediaTableName, idColumn, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetRecipeMediaForRecipe",
-					Type: ManyType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+		return slices.Concat(
+			querygen.StandardCRUD(recipeMediaTableName, recipeMediaColumns,
+				querygen.WithEntity("RecipeMedia", "RecipeMedias"),
+				querygen.WithOmitted(querygen.ListQuery),
+			),
+			[]*Query{
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetRecipeMediaForRecipe",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s
 FROM %s
 WHERE %s.%s = sqlc.arg(%s)
@@ -96,23 +54,23 @@ WHERE %s.%s = sqlc.arg(%s)
 	AND %s.%s IS NULL
 GROUP BY %s.%s
 ORDER BY %s.%s;`,
-					strings.Join(applyToEach(recipeMediaColumns, func(i int, s string) string {
-						return fmt.Sprintf("%s.%s", recipeMediaTableName, s)
-					}), ",\n\t"),
-					recipeMediaTableName,
-					recipeMediaTableName, belongsToRecipeColumn, recipeIDColumn,
-					recipeMediaTableName, belongsToRecipeStepColumn,
-					recipeMediaTableName, archivedAtColumn,
-					recipeMediaTableName, idColumn,
-					recipeMediaTableName, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetRecipeMediaForRecipeStep",
-					Type: ManyType,
+						strings.Join(applyToEach(recipeMediaColumns, func(i int, s string) string {
+							return fmt.Sprintf("%s.%s", recipeMediaTableName, s)
+						}), ",\n\t"),
+						recipeMediaTableName,
+						recipeMediaTableName, belongsToRecipeColumn, recipeIDColumn,
+						recipeMediaTableName, belongsToRecipeStepColumn,
+						recipeMediaTableName, archivedAtColumn,
+						recipeMediaTableName, idColumn,
+						recipeMediaTableName, idColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetRecipeMediaForRecipeStep",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s
 FROM %s
 WHERE %s.%s = sqlc.arg(%s)
@@ -120,57 +78,19 @@ WHERE %s.%s = sqlc.arg(%s)
 	AND %s.%s IS NULL
 GROUP BY %s.%s
 ORDER BY %s.%s;`,
-					strings.Join(applyToEach(recipeMediaColumns, func(i int, s string) string {
-						return fmt.Sprintf("%s.%s", recipeMediaTableName, s)
-					}), ",\n\t"),
-					recipeMediaTableName,
-					recipeMediaTableName, belongsToRecipeColumn, recipeIDColumn,
-					recipeMediaTableName, belongsToRecipeStepColumn, recipeStepIDColumn,
-					recipeMediaTableName, archivedAtColumn,
-					recipeMediaTableName, idColumn,
-					recipeMediaTableName, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetRecipeMedia",
-					Type: OneType,
+						strings.Join(applyToEach(recipeMediaColumns, func(i int, s string) string {
+							return fmt.Sprintf("%s.%s", recipeMediaTableName, s)
+						}), ",\n\t"),
+						recipeMediaTableName,
+						recipeMediaTableName, belongsToRecipeColumn, recipeIDColumn,
+						recipeMediaTableName, belongsToRecipeStepColumn, recipeStepIDColumn,
+						recipeMediaTableName, archivedAtColumn,
+						recipeMediaTableName, idColumn,
+						recipeMediaTableName, idColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
-	%s
-FROM %s
-WHERE %s.%s IS NULL
-	AND %s.%s = sqlc.arg(%s);`,
-					strings.Join(applyToEach(recipeMediaColumns, func(i int, s string) string {
-						return fmt.Sprintf("%s.%s", recipeMediaTableName, s)
-					}), ",\n\t"),
-					recipeMediaTableName,
-					recipeMediaTableName, archivedAtColumn,
-					recipeMediaTableName, idColumn, idColumn,
-				)),
 			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "UpdateRecipeMedia",
-					Type: ExecRowsType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
-	%s,
-	%s = %s
-WHERE %s IS NULL
-	AND %s = sqlc.arg(%s);`,
-					recipeMediaTableName,
-					strings.Join(applyToEach(filterForUpdate(recipeMediaColumns), func(i int, s string) string {
-						return fmt.Sprintf("%s = sqlc.arg(%s)", s, s)
-					}), ",\n\t"),
-					lastUpdatedAtColumn,
-					currentTimeExpression,
-					archivedAtColumn,
-					idColumn,
-					idColumn,
-				)),
-			},
-		}
+		)
 	default:
 		return nil
 	}

--- a/backend/cmd/tools/codegen/queries/mealplanning_recipe_prep_task_steps.go
+++ b/backend/cmd/tools/codegen/queries/mealplanning_recipe_prep_task_steps.go
@@ -1,10 +1,7 @@
 package main
 
 import (
-	"fmt"
-	"strings"
-
-	"github.com/cristalhq/builq"
+	"github.com/primandproper/platform-go/v11/database/querygen"
 )
 
 const (
@@ -28,27 +25,10 @@ func buildRecipePrepTaskStepsQueries(database string) []*Query {
 	switch database {
 	case postgres:
 
-		insertColumns := filterForInsert(recipePrepTaskStepsColumns)
-
-		return []*Query{
-			{
-				Annotation: QueryAnnotation{
-					Name: "CreateRecipePrepTaskStep",
-					Type: ExecType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`INSERT INTO %s (
-	%s
-) VALUES (
-	%s
-);`,
-					recipePrepTaskStepsTableName,
-					strings.Join(insertColumns, ",\n\t"),
-					strings.Join(applyToEach(insertColumns, func(i int, s string) string {
-						return fmt.Sprintf("sqlc.arg(%s)", s)
-					}), ",\n\t"),
-				)),
-			},
-		}
+		return querygen.StandardCRUD(recipePrepTaskStepsTableName, recipePrepTaskStepsColumns,
+			querygen.WithEntity("RecipePrepTaskStep", "RecipePrepTaskSteps"),
+			querygen.WithOmitted(querygen.ExistsQuery, querygen.GetQuery, querygen.ListQuery, querygen.UpdateQuery),
+		)
 	default:
 		return nil
 	}

--- a/backend/cmd/tools/codegen/queries/mealplanning_recipe_prep_tasks.go
+++ b/backend/cmd/tools/codegen/queries/mealplanning_recipe_prep_tasks.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"fmt"
+	"slices"
 	"strings"
+
+	"github.com/primandproper/platform-go/v11/database/querygen"
 
 	"github.com/cristalhq/builq"
 )
@@ -38,8 +41,6 @@ func buildRecipePrepTasksQueries(database string) []*Query {
 	switch database {
 	case postgres:
 
-		insertColumns := filterForInsert(recipePrepTasksColumns)
-
 		fullSelectColumns := append(
 			applyToEach(recipePrepTasksColumns, func(i int, s string) string {
 				return fmt.Sprintf("%s.%s", recipePrepTasksTableName, s)
@@ -49,44 +50,18 @@ func buildRecipePrepTasksQueries(database string) []*Query {
 			})...,
 		)
 
-		return []*Query{
-			{
-				Annotation: QueryAnnotation{
-					Name: "ArchiveRecipePrepTask",
-					Type: ExecRowsType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET %s = %s WHERE %s IS NULL AND %s = sqlc.arg(%s);`,
-					recipePrepTasksTableName,
-					archivedAtColumn,
-					currentTimeExpression,
-					archivedAtColumn,
-					idColumn,
-					idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CreateRecipePrepTask",
-					Type: ExecType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`INSERT INTO %s (
-	%s
-) VALUES (
-	%s
-);`,
-					recipePrepTasksTableName,
-					strings.Join(insertColumns, ",\n\t"),
-					strings.Join(applyToEach(insertColumns, func(i int, s string) string {
-						return fmt.Sprintf("sqlc.arg(%s)", s)
-					}), ",\n\t"),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CheckRecipePrepTaskExistence",
-					Type: OneType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT EXISTS (
+		return slices.Concat(
+			querygen.StandardCRUD(recipePrepTasksTableName, recipePrepTasksColumns,
+				querygen.WithEntity("RecipePrepTask", "RecipePrepTasks"),
+				querygen.WithOmitted(querygen.ExistsQuery, querygen.GetQuery, querygen.ListQuery),
+			),
+			[]*Query{
+				{
+					Annotation: QueryAnnotation{
+						Name: "CheckRecipePrepTaskExistence",
+						Type: OneType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT EXISTS (
 	SELECT %s.%s
 	FROM %s
 		JOIN %s ON %s.%s=%s.%s
@@ -96,40 +71,40 @@ func buildRecipePrepTasksQueries(database string) []*Query {
 		AND %s.%s IS NULL
 		AND %s.%s = sqlc.arg(recipe_id)
 );`,
-					recipePrepTasksTableName, idColumn,
-					recipePrepTasksTableName,
-					recipesTableName, recipePrepTasksTableName, belongsToRecipeColumn, recipesTableName, idColumn,
-					recipePrepTasksTableName, archivedAtColumn,
-					recipePrepTasksTableName, belongsToRecipeColumn,
-					recipePrepTasksTableName, idColumn,
-					recipesTableName, archivedAtColumn,
-					recipesTableName, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetRecipePrepTask",
-					Type: ManyType,
+						recipePrepTasksTableName, idColumn,
+						recipePrepTasksTableName,
+						recipesTableName, recipePrepTasksTableName, belongsToRecipeColumn, recipesTableName, idColumn,
+						recipePrepTasksTableName, archivedAtColumn,
+						recipePrepTasksTableName, belongsToRecipeColumn,
+						recipePrepTasksTableName, idColumn,
+						recipesTableName, archivedAtColumn,
+						recipesTableName, idColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetRecipePrepTask",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s
 FROM %s
 	JOIN %s ON %s.%s=%s.%s
 WHERE %s.%s IS NULL
 	AND %s.%s = sqlc.arg(recipe_prep_task_id);`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					recipePrepTasksTableName,
-					recipePrepTaskStepsTableName, recipePrepTasksTableName, idColumn, recipePrepTaskStepsTableName, belongsToRecipePrepTaskColumn,
-					recipePrepTasksTableName, archivedAtColumn,
-					recipePrepTasksTableName, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "ListAllRecipePrepTasksByRecipe",
-					Type: ManyType,
+						strings.Join(fullSelectColumns, ",\n\t"),
+						recipePrepTasksTableName,
+						recipePrepTaskStepsTableName, recipePrepTasksTableName, idColumn, recipePrepTaskStepsTableName, belongsToRecipePrepTaskColumn,
+						recipePrepTasksTableName, archivedAtColumn,
+						recipePrepTasksTableName, idColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "ListAllRecipePrepTasksByRecipe",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s
 FROM %s
 	JOIN %s ON %s.%s=%s.%s
@@ -139,37 +114,19 @@ WHERE %s.%s IS NULL
 	AND %s.%s IS NULL
 	AND %s.%s IS NULL
 	AND %s.%s = sqlc.arg(recipe_id);`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					recipePrepTasksTableName,
-					recipePrepTaskStepsTableName, recipePrepTaskStepsTableName, belongsToRecipePrepTaskColumn, recipePrepTasksTableName, idColumn,
-					recipeStepsTableName, recipePrepTaskStepsTableName, belongsToRecipeStepColumn, recipeStepsTableName, idColumn,
-					recipesTableName, recipePrepTasksTableName, belongsToRecipeColumn, recipesTableName, idColumn,
-					recipePrepTasksTableName, archivedAtColumn,
-					recipeStepsTableName, archivedAtColumn,
-					recipesTableName, archivedAtColumn,
-					recipesTableName, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "UpdateRecipePrepTask",
-					Type: ExecRowsType,
+						strings.Join(fullSelectColumns, ",\n\t"),
+						recipePrepTasksTableName,
+						recipePrepTaskStepsTableName, recipePrepTaskStepsTableName, belongsToRecipePrepTaskColumn, recipePrepTasksTableName, idColumn,
+						recipeStepsTableName, recipePrepTaskStepsTableName, belongsToRecipeStepColumn, recipeStepsTableName, idColumn,
+						recipesTableName, recipePrepTasksTableName, belongsToRecipeColumn, recipesTableName, idColumn,
+						recipePrepTasksTableName, archivedAtColumn,
+						recipeStepsTableName, archivedAtColumn,
+						recipesTableName, archivedAtColumn,
+						recipesTableName, idColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
-	%s,
-	%s = %s
-WHERE %s IS NULL
-	AND %s = sqlc.arg(%s);`,
-					recipePrepTasksTableName,
-					strings.Join(applyToEach(filterForUpdate(recipePrepTasksColumns), func(i int, s string) string {
-						return fmt.Sprintf("%s = sqlc.arg(%s)", s, s)
-					}), ",\n\t"),
-					lastUpdatedAtColumn, currentTimeExpression,
-					archivedAtColumn,
-					idColumn, idColumn,
-				)),
 			},
-		}
+		)
 	default:
 		return nil
 	}

--- a/backend/cmd/tools/codegen/queries/mealplanning_recipe_ratings.go
+++ b/backend/cmd/tools/codegen/queries/mealplanning_recipe_ratings.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"fmt"
+	"slices"
 	"strings"
+
+	"github.com/primandproper/platform-go/v11/database/querygen"
 
 	"github.com/cristalhq/builq"
 )
@@ -34,63 +37,19 @@ func buildRecipeRatingsQueries(database string) []*Query {
 	switch database {
 	case postgres:
 
-		insertColumns := filterForInsert(recipeRatingsColumns)
-
-		return []*Query{
-			{
-				Annotation: QueryAnnotation{
-					Name: "ArchiveRecipeRating",
-					Type: ExecRowsType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET %s = %s WHERE %s IS NULL AND %s = sqlc.arg(%s);`,
-					recipeRatingsTableName,
-					archivedAtColumn,
-					currentTimeExpression,
-					archivedAtColumn,
-					idColumn,
-					idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CreateRecipeRating",
-					Type: ExecType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`INSERT INTO %s (
-	%s
-) VALUES (
-	%s
-);`,
-					recipeRatingsTableName,
-					strings.Join(insertColumns, ",\n\t"),
-					strings.Join(applyToEach(insertColumns, func(i int, s string) string {
-						return fmt.Sprintf("sqlc.arg(%s)", s)
-					}), ",\n\t"),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CheckRecipeRatingExistence",
-					Type: OneType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT EXISTS (
-	SELECT %s.%s
-	FROM %s
-	WHERE %s.%s IS NULL
-		AND %s.%s = sqlc.arg(%s)
-);`,
-					recipeRatingsTableName, idColumn,
-					recipeRatingsTableName,
-					recipeRatingsTableName, archivedAtColumn,
-					recipeRatingsTableName, idColumn, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetRecipeRatingsForRecipe",
-					Type: ManyType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+		return slices.Concat(
+			querygen.StandardCRUD(recipeRatingsTableName, recipeRatingsColumns,
+				querygen.WithEntity("RecipeRating", "RecipeRatings"),
+				querygen.WithImmutable(createdByUserColumn),
+				querygen.WithOmitted(querygen.ListQuery),
+			),
+			[]*Query{
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetRecipeRatingsForRecipe",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s
@@ -101,25 +60,25 @@ WHERE
 	%s
 GROUP BY %s.%s
 %s;`,
-					strings.Join(applyToEach(recipeRatingsColumns, func(i int, s string) string {
-						return fmt.Sprintf("%s.%s", recipeRatingsTableName, s)
-					}), ",\n\t"),
-					buildFilterCountSelect(recipeRatingsTableName, true, true, []string{}, fmt.Sprintf("%s.%s = sqlc.arg(%s)", recipeRatingsTableName, belongsToRecipeColumn, belongsToRecipeColumn)),
-					buildTotalCountSelect(recipeRatingsTableName, true, []string{}, fmt.Sprintf("%s.%s = sqlc.arg(%s)", recipeRatingsTableName, belongsToRecipeColumn, belongsToRecipeColumn)),
-					recipeRatingsTableName,
-					recipeRatingsTableName, archivedAtColumn,
-					recipeRatingsTableName, belongsToRecipeColumn, belongsToRecipeColumn,
-					buildFilterConditions(recipeRatingsTableName, true, true, fmt.Sprintf("%s.%s = sqlc.arg(%s)", recipeRatingsTableName, belongsToRecipeColumn, belongsToRecipeColumn)),
-					recipeRatingsTableName, idColumn,
-					buildCursorLimitClause(recipeRatingsTableName),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetRecipeRatingsForUser",
-					Type: ManyType,
+						strings.Join(applyToEach(recipeRatingsColumns, func(i int, s string) string {
+							return fmt.Sprintf("%s.%s", recipeRatingsTableName, s)
+						}), ",\n\t"),
+						buildFilterCountSelect(recipeRatingsTableName, true, true, []string{}, fmt.Sprintf("%s.%s = sqlc.arg(%s)", recipeRatingsTableName, belongsToRecipeColumn, belongsToRecipeColumn)),
+						buildTotalCountSelect(recipeRatingsTableName, true, []string{}, fmt.Sprintf("%s.%s = sqlc.arg(%s)", recipeRatingsTableName, belongsToRecipeColumn, belongsToRecipeColumn)),
+						recipeRatingsTableName,
+						recipeRatingsTableName, archivedAtColumn,
+						recipeRatingsTableName, belongsToRecipeColumn, belongsToRecipeColumn,
+						buildFilterConditions(recipeRatingsTableName, true, true, fmt.Sprintf("%s.%s = sqlc.arg(%s)", recipeRatingsTableName, belongsToRecipeColumn, belongsToRecipeColumn)),
+						recipeRatingsTableName, idColumn,
+						buildCursorLimitClause(recipeRatingsTableName),
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetRecipeRatingsForUser",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s
@@ -130,57 +89,21 @@ WHERE
 	%s
 GROUP BY %s.%s
 %s;`,
-					strings.Join(applyToEach(recipeRatingsColumns, func(i int, s string) string {
-						return fmt.Sprintf("%s.%s", recipeRatingsTableName, s)
-					}), ",\n\t"),
-					buildFilterCountSelect(recipeRatingsTableName, true, true, []string{}, fmt.Sprintf("%s.%s = sqlc.arg(%s)", recipeRatingsTableName, createdByUserColumn, createdByUserColumn)),
-					buildTotalCountSelect(recipeRatingsTableName, true, []string{}, fmt.Sprintf("%s.%s = sqlc.arg(%s)", recipeRatingsTableName, createdByUserColumn, createdByUserColumn)),
-					recipeRatingsTableName,
-					recipeRatingsTableName, archivedAtColumn,
-					recipeRatingsTableName, createdByUserColumn, createdByUserColumn,
-					buildFilterConditions(recipeRatingsTableName, true, true, fmt.Sprintf("%s.%s = sqlc.arg(%s)", recipeRatingsTableName, createdByUserColumn, createdByUserColumn)),
-					recipeRatingsTableName, idColumn,
-					buildCursorLimitClause(recipeRatingsTableName),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetRecipeRating",
-					Type: OneType,
+						strings.Join(applyToEach(recipeRatingsColumns, func(i int, s string) string {
+							return fmt.Sprintf("%s.%s", recipeRatingsTableName, s)
+						}), ",\n\t"),
+						buildFilterCountSelect(recipeRatingsTableName, true, true, []string{}, fmt.Sprintf("%s.%s = sqlc.arg(%s)", recipeRatingsTableName, createdByUserColumn, createdByUserColumn)),
+						buildTotalCountSelect(recipeRatingsTableName, true, []string{}, fmt.Sprintf("%s.%s = sqlc.arg(%s)", recipeRatingsTableName, createdByUserColumn, createdByUserColumn)),
+						recipeRatingsTableName,
+						recipeRatingsTableName, archivedAtColumn,
+						recipeRatingsTableName, createdByUserColumn, createdByUserColumn,
+						buildFilterConditions(recipeRatingsTableName, true, true, fmt.Sprintf("%s.%s = sqlc.arg(%s)", recipeRatingsTableName, createdByUserColumn, createdByUserColumn)),
+						recipeRatingsTableName, idColumn,
+						buildCursorLimitClause(recipeRatingsTableName),
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
-	%s
-FROM %s
-WHERE %s.%s IS NULL
-	AND %s.%s = sqlc.arg(%s);`,
-					strings.Join(applyToEach(recipeRatingsColumns, func(i int, s string) string {
-						return fmt.Sprintf("%s.%s", recipeRatingsTableName, s)
-					}), ",\n\t"),
-					recipeRatingsTableName,
-					recipeRatingsTableName, archivedAtColumn,
-					recipeRatingsTableName, idColumn, idColumn,
-				)),
 			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "UpdateRecipeRating",
-					Type: ExecRowsType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
-	%s,
-	%s = %s
-WHERE %s IS NULL
-	AND %s = sqlc.arg(%s);`,
-					recipeRatingsTableName,
-					strings.Join(applyToEach(filterForUpdate(recipeRatingsColumns, createdByUserColumn), func(i int, s string) string {
-						return fmt.Sprintf("%s = sqlc.arg(%s)", s, s)
-					}), ",\n\t"),
-					lastUpdatedAtColumn, currentTimeExpression,
-					archivedAtColumn,
-					idColumn, idColumn,
-				)),
-			},
-		}
+		)
 	default:
 		return nil
 	}

--- a/backend/cmd/tools/codegen/queries/mealplanning_recipe_step_completion_condition_ingredients.go
+++ b/backend/cmd/tools/codegen/queries/mealplanning_recipe_step_completion_condition_ingredients.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"fmt"
+	"slices"
 	"strings"
+
+	"github.com/primandproper/platform-go/v11/database/querygen"
 
 	"github.com/cristalhq/builq"
 )
@@ -30,8 +33,6 @@ func buildRecipeStepCompletionConditionIngredientsQueries(database string) []*Qu
 	switch database {
 	case postgres:
 
-		insertColumns := filterForInsert(recipeStepCompletionConditionIngredientsColumns)
-
 		fullSelectColumns := append(
 			applyToEach(recipeStepCompletionConditionIngredientsColumns, func(i int, s string) string {
 				return fmt.Sprintf("%s.%s as %s_%s", recipeStepCompletionConditionIngredientsTableName, s, strings.TrimSuffix(recipeStepCompletionConditionIngredientsTableName, "s"), s)
@@ -41,30 +42,18 @@ func buildRecipeStepCompletionConditionIngredientsQueries(database string) []*Qu
 			})...,
 		)
 
-		return []*Query{
-			{
-				Annotation: QueryAnnotation{
-					Name: "CreateRecipeStepCompletionConditionIngredient",
-					Type: ExecType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`INSERT INTO %s (
-	%s
-) VALUES (
-	%s
-);`,
-					recipeStepCompletionConditionIngredientsTableName,
-					strings.Join(insertColumns, ",\n\t"),
-					strings.Join(applyToEach(insertColumns, func(i int, s string) string {
-						return fmt.Sprintf("sqlc.arg(%s)", s)
-					}), ",\n\t"),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetAllRecipeStepCompletionConditionIngredientsForRecipeCompletionIDs",
-					Type: ManyType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+		return slices.Concat(
+			querygen.StandardCRUD(recipeStepCompletionConditionIngredientsTableName, recipeStepCompletionConditionIngredientsColumns,
+				querygen.WithEntity("RecipeStepCompletionConditionIngredient", "RecipeStepCompletionConditionIngredients"),
+				querygen.WithOmitted(querygen.ArchiveQuery, querygen.ExistsQuery, querygen.GetQuery, querygen.ListQuery, querygen.UpdateQuery),
+			),
+			[]*Query{
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetAllRecipeStepCompletionConditionIngredientsForRecipeCompletionIDs",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s
 FROM %s
 	JOIN %s ON %s.%s = %s.%s
@@ -73,17 +62,18 @@ WHERE %s.%s IS NULL
 	AND %s.%s IS NULL
 	AND %s.%s = ANY(sqlc.arg(ids)::text[])
 	AND %s.%s IS NULL;`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					recipeStepCompletionConditionIngredientsTableName,
-					recipeStepCompletionConditionsTableName, recipeStepCompletionConditionIngredientsTableName, belongsToRecipeStepCompletionConditionColumn, recipeStepCompletionConditionsTableName, idColumn,
-					validIngredientStatesTableName, recipeStepCompletionConditionsTableName, ingredientStateColumn, validIngredientStatesTableName, idColumn,
-					recipeStepCompletionConditionsTableName, archivedAtColumn,
-					recipeStepCompletionConditionIngredientsTableName, archivedAtColumn,
-					recipeStepCompletionConditionIngredientsTableName, belongsToRecipeStepCompletionConditionColumn,
-					validIngredientStatesTableName, archivedAtColumn,
-				)),
+						strings.Join(fullSelectColumns, ",\n\t"),
+						recipeStepCompletionConditionIngredientsTableName,
+						recipeStepCompletionConditionsTableName, recipeStepCompletionConditionIngredientsTableName, belongsToRecipeStepCompletionConditionColumn, recipeStepCompletionConditionsTableName, idColumn,
+						validIngredientStatesTableName, recipeStepCompletionConditionsTableName, ingredientStateColumn, validIngredientStatesTableName, idColumn,
+						recipeStepCompletionConditionsTableName, archivedAtColumn,
+						recipeStepCompletionConditionIngredientsTableName, archivedAtColumn,
+						recipeStepCompletionConditionIngredientsTableName, belongsToRecipeStepCompletionConditionColumn,
+						validIngredientStatesTableName, archivedAtColumn,
+					)),
+				},
 			},
-		}
+		)
 	default:
 		return nil
 	}

--- a/backend/cmd/tools/codegen/queries/mealplanning_recipe_step_completion_conditions.go
+++ b/backend/cmd/tools/codegen/queries/mealplanning_recipe_step_completion_conditions.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"fmt"
+	"slices"
 	"strings"
+
+	"github.com/primandproper/platform-go/v11/database/querygen"
 
 	"github.com/cristalhq/builq"
 )
@@ -33,8 +36,6 @@ func buildRecipeStepCompletionConditionQueries(database string) []*Query {
 	switch database {
 	case postgres:
 
-		insertColumns := filterForInsert(recipeStepCompletionConditionsColumns)
-
 		fullSelectColumns := mergeColumns(
 			applyToEach(recipeStepCompletionConditionIngredientsColumns, func(i int, s string) string {
 				return fmt.Sprintf("%s.%s as recipe_step_completion_condition_ingredient_%s", recipeStepCompletionConditionIngredientsTableName, s, s)
@@ -51,46 +52,34 @@ func buildRecipeStepCompletionConditionQueries(database string) []*Query {
 			3,
 		)
 
-		return []*Query{
-			{
-				Annotation: QueryAnnotation{
-					Name: "ArchiveRecipeStepCompletionCondition",
-					Type: ExecRowsType,
+		return slices.Concat(
+			querygen.StandardCRUD(recipeStepCompletionConditionsTableName, recipeStepCompletionConditionsColumns,
+				querygen.WithEntity("RecipeStepCompletionCondition", "RecipeStepCompletionConditions"),
+				querygen.WithOmitted(querygen.ArchiveQuery, querygen.ExistsQuery, querygen.GetQuery, querygen.ListQuery),
+			),
+			[]*Query{
+				{
+					Annotation: QueryAnnotation{
+						Name: "ArchiveRecipeStepCompletionCondition",
+						Type: ExecRowsType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET %s = %s WHERE %s IS NULL AND %s = sqlc.arg(%s) AND %s = sqlc.arg(%s);`,
+						recipeStepCompletionConditionsTableName,
+						archivedAtColumn,
+						currentTimeExpression,
+						archivedAtColumn,
+						belongsToRecipeStepColumn,
+						belongsToRecipeStepColumn,
+						idColumn,
+						idColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET %s = %s WHERE %s IS NULL AND %s = sqlc.arg(%s) AND %s = sqlc.arg(%s);`,
-					recipeStepCompletionConditionsTableName,
-					archivedAtColumn,
-					currentTimeExpression,
-					archivedAtColumn,
-					belongsToRecipeStepColumn,
-					belongsToRecipeStepColumn,
-					idColumn,
-					idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CreateRecipeStepCompletionCondition",
-					Type: ExecType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`INSERT INTO %s (
-	%s
-) VALUES (
-	%s
-);`,
-					recipeStepCompletionConditionsTableName,
-					strings.Join(insertColumns, ",\n\t"),
-					strings.Join(applyToEach(insertColumns, func(i int, s string) string {
-						return fmt.Sprintf("sqlc.arg(%s)", s)
-					}), ",\n\t"),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CheckRecipeStepCompletionConditionExistence",
-					Type: OneType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT EXISTS (
+				{
+					Annotation: QueryAnnotation{
+						Name: "CheckRecipeStepCompletionConditionExistence",
+						Type: OneType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT EXISTS (
 	SELECT %s.%s
 	FROM %s
 		JOIN %s ON %s.%s=%s.%s
@@ -104,26 +93,26 @@ func buildRecipeStepCompletionConditionQueries(database string) []*Query {
 		AND %s.%s IS NULL
 		AND %s.%s = sqlc.arg(%s)
 );`,
-					recipeStepCompletionConditionsTableName, idColumn,
-					recipeStepCompletionConditionsTableName,
-					recipeStepsTableName, recipeStepCompletionConditionsTableName, belongsToRecipeStepColumn, recipeStepsTableName, idColumn,
-					recipesTableName, recipeStepsTableName, belongsToRecipeColumn, recipesTableName, idColumn,
-					recipeStepCompletionConditionsTableName, archivedAtColumn,
-					recipeStepCompletionConditionsTableName, belongsToRecipeStepColumn, recipeStepIDColumn,
-					recipeStepCompletionConditionsTableName, idColumn, recipeStepCompletionConditionIDColumn,
-					recipeStepsTableName, archivedAtColumn,
-					recipeStepsTableName, belongsToRecipeColumn, recipeIDColumn,
-					recipeStepsTableName, idColumn, recipeStepIDColumn,
-					recipesTableName, archivedAtColumn,
-					recipesTableName, idColumn, recipeIDColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetAllRecipeStepCompletionConditionsForRecipe",
-					Type: ManyType,
+						recipeStepCompletionConditionsTableName, idColumn,
+						recipeStepCompletionConditionsTableName,
+						recipeStepsTableName, recipeStepCompletionConditionsTableName, belongsToRecipeStepColumn, recipeStepsTableName, idColumn,
+						recipesTableName, recipeStepsTableName, belongsToRecipeColumn, recipesTableName, idColumn,
+						recipeStepCompletionConditionsTableName, archivedAtColumn,
+						recipeStepCompletionConditionsTableName, belongsToRecipeStepColumn, recipeStepIDColumn,
+						recipeStepCompletionConditionsTableName, idColumn, recipeStepCompletionConditionIDColumn,
+						recipeStepsTableName, archivedAtColumn,
+						recipeStepsTableName, belongsToRecipeColumn, recipeIDColumn,
+						recipeStepsTableName, idColumn, recipeStepIDColumn,
+						recipesTableName, archivedAtColumn,
+						recipesTableName, idColumn, recipeIDColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetAllRecipeStepCompletionConditionsForRecipe",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s
 FROM %s
 	JOIN %s ON %s.%s = %s.%s
@@ -140,29 +129,29 @@ GROUP BY
 	%s.%s,
 	%s.%s,
 	%s.%s;`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					recipeStepCompletionConditionIngredientsTableName,
-					recipeStepCompletionConditionsTableName, recipeStepCompletionConditionIngredientsTableName, belongsToRecipeStepCompletionConditionColumn, recipeStepCompletionConditionsTableName, idColumn,
-					recipeStepsTableName, recipeStepCompletionConditionsTableName, belongsToRecipeStepColumn, recipeStepsTableName, idColumn,
-					recipesTableName, recipeStepsTableName, belongsToRecipeColumn, recipesTableName, idColumn,
-					validIngredientStatesTableName, recipeStepCompletionConditionsTableName, ingredientStateColumn, validIngredientStatesTableName, idColumn,
-					recipeStepCompletionConditionsTableName, archivedAtColumn,
-					recipeStepCompletionConditionIngredientsTableName, archivedAtColumn,
-					recipeStepsTableName, archivedAtColumn,
-					recipesTableName, archivedAtColumn,
-					validIngredientStatesTableName, archivedAtColumn,
-					recipesTableName, idColumn, idColumn,
-					recipeStepCompletionConditionsTableName, idColumn,
-					recipeStepCompletionConditionIngredientsTableName, idColumn,
-					validIngredientStatesTableName, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetRecipeStepCompletionConditions",
-					Type: ManyType,
+						strings.Join(fullSelectColumns, ",\n\t"),
+						recipeStepCompletionConditionIngredientsTableName,
+						recipeStepCompletionConditionsTableName, recipeStepCompletionConditionIngredientsTableName, belongsToRecipeStepCompletionConditionColumn, recipeStepCompletionConditionsTableName, idColumn,
+						recipeStepsTableName, recipeStepCompletionConditionsTableName, belongsToRecipeStepColumn, recipeStepsTableName, idColumn,
+						recipesTableName, recipeStepsTableName, belongsToRecipeColumn, recipesTableName, idColumn,
+						validIngredientStatesTableName, recipeStepCompletionConditionsTableName, ingredientStateColumn, validIngredientStatesTableName, idColumn,
+						recipeStepCompletionConditionsTableName, archivedAtColumn,
+						recipeStepCompletionConditionIngredientsTableName, archivedAtColumn,
+						recipeStepsTableName, archivedAtColumn,
+						recipesTableName, archivedAtColumn,
+						validIngredientStatesTableName, archivedAtColumn,
+						recipesTableName, idColumn, idColumn,
+						recipeStepCompletionConditionsTableName, idColumn,
+						recipeStepCompletionConditionIngredientsTableName, idColumn,
+						validIngredientStatesTableName, idColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetRecipeStepCompletionConditions",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s
@@ -173,24 +162,24 @@ FROM %s
 WHERE %s.%s IS NULL
 	%s
 %s;`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					buildFilterCountSelect(recipeStepCompletionConditionIngredientsTableName, true, true, []string{}, "recipe_step_completion_conditions.belongs_to_recipe_step = sqlc.arg(recipe_step_id)"),
-					buildTotalCountSelect(recipeStepCompletionConditionIngredientsTableName, true, []string{}),
-					recipeStepCompletionConditionIngredientsTableName,
-					recipeStepCompletionConditionsTableName, recipeStepCompletionConditionIngredientsTableName, belongsToRecipeStepCompletionConditionColumn, recipeStepCompletionConditionsTableName, idColumn,
-					recipeStepsTableName, recipeStepCompletionConditionsTableName, belongsToRecipeStepColumn, recipeStepsTableName, idColumn,
-					validIngredientStatesTableName, recipeStepCompletionConditionsTableName, ingredientStateColumn, validIngredientStatesTableName, idColumn,
-					recipeStepCompletionConditionsTableName, archivedAtColumn,
-					buildFilterConditions(recipeStepCompletionConditionsTableName, true, false, "recipe_step_completion_conditions.belongs_to_recipe_step = sqlc.arg(recipe_step_id)"),
-					buildCursorLimitClause(recipeStepCompletionConditionsTableName),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetRecipeStepCompletionConditionWithIngredients",
-					Type: ManyType,
+						strings.Join(fullSelectColumns, ",\n\t"),
+						buildFilterCountSelect(recipeStepCompletionConditionIngredientsTableName, true, true, []string{}, "recipe_step_completion_conditions.belongs_to_recipe_step = sqlc.arg(recipe_step_id)"),
+						buildTotalCountSelect(recipeStepCompletionConditionIngredientsTableName, true, []string{}),
+						recipeStepCompletionConditionIngredientsTableName,
+						recipeStepCompletionConditionsTableName, recipeStepCompletionConditionIngredientsTableName, belongsToRecipeStepCompletionConditionColumn, recipeStepCompletionConditionsTableName, idColumn,
+						recipeStepsTableName, recipeStepCompletionConditionsTableName, belongsToRecipeStepColumn, recipeStepsTableName, idColumn,
+						validIngredientStatesTableName, recipeStepCompletionConditionsTableName, ingredientStateColumn, validIngredientStatesTableName, idColumn,
+						recipeStepCompletionConditionsTableName, archivedAtColumn,
+						buildFilterConditions(recipeStepCompletionConditionsTableName, true, false, "recipe_step_completion_conditions.belongs_to_recipe_step = sqlc.arg(recipe_step_id)"),
+						buildCursorLimitClause(recipeStepCompletionConditionsTableName),
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetRecipeStepCompletionConditionWithIngredients",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s
 FROM %s
 	JOIN %s ON %s.%s = %s.%s
@@ -206,43 +195,25 @@ WHERE %s.%s IS NULL
 	AND %s.%s = sqlc.arg(%s)
 	AND %s.%s IS NULL
 	AND %s.%s = sqlc.arg(%s);`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					recipeStepCompletionConditionIngredientsTableName,
-					recipeStepCompletionConditionsTableName, recipeStepCompletionConditionIngredientsTableName, belongsToRecipeStepCompletionConditionColumn, recipeStepCompletionConditionsTableName, idColumn,
-					recipeStepsTableName, recipeStepCompletionConditionsTableName, belongsToRecipeStepColumn, recipeStepsTableName, idColumn,
-					recipesTableName, recipeStepsTableName, belongsToRecipeColumn, recipesTableName, idColumn,
-					validIngredientStatesTableName, recipeStepCompletionConditionsTableName, ingredientStateColumn, validIngredientStatesTableName, idColumn,
-					recipeStepCompletionConditionsTableName, archivedAtColumn,
-					recipeStepCompletionConditionIngredientsTableName, archivedAtColumn,
-					recipeStepCompletionConditionsTableName, belongsToRecipeStepColumn, recipeStepIDColumn,
-					recipeStepCompletionConditionsTableName, idColumn,
-					recipeStepsTableName, archivedAtColumn,
-					recipeStepsTableName, belongsToRecipeColumn, recipeIDColumn,
-					recipeStepsTableName, idColumn, recipeStepIDColumn,
-					recipesTableName, archivedAtColumn,
-					recipesTableName, idColumn, recipeIDColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "UpdateRecipeStepCompletionCondition",
-					Type: ExecRowsType,
+						strings.Join(fullSelectColumns, ",\n\t"),
+						recipeStepCompletionConditionIngredientsTableName,
+						recipeStepCompletionConditionsTableName, recipeStepCompletionConditionIngredientsTableName, belongsToRecipeStepCompletionConditionColumn, recipeStepCompletionConditionsTableName, idColumn,
+						recipeStepsTableName, recipeStepCompletionConditionsTableName, belongsToRecipeStepColumn, recipeStepsTableName, idColumn,
+						recipesTableName, recipeStepsTableName, belongsToRecipeColumn, recipesTableName, idColumn,
+						validIngredientStatesTableName, recipeStepCompletionConditionsTableName, ingredientStateColumn, validIngredientStatesTableName, idColumn,
+						recipeStepCompletionConditionsTableName, archivedAtColumn,
+						recipeStepCompletionConditionIngredientsTableName, archivedAtColumn,
+						recipeStepCompletionConditionsTableName, belongsToRecipeStepColumn, recipeStepIDColumn,
+						recipeStepCompletionConditionsTableName, idColumn,
+						recipeStepsTableName, archivedAtColumn,
+						recipeStepsTableName, belongsToRecipeColumn, recipeIDColumn,
+						recipeStepsTableName, idColumn, recipeStepIDColumn,
+						recipesTableName, archivedAtColumn,
+						recipesTableName, idColumn, recipeIDColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
-	%s,
-	%s = %s
-WHERE %s IS NULL
-	AND %s = sqlc.arg(%s);`,
-					recipeStepCompletionConditionsTableName,
-					strings.Join(applyToEach(filterForUpdate(recipeStepCompletionConditionsColumns), func(i int, s string) string {
-						return fmt.Sprintf("%s = sqlc.arg(%s)", s, s)
-					}), ",\n\t"),
-					lastUpdatedAtColumn, currentTimeExpression,
-					archivedAtColumn,
-					idColumn, idColumn,
-				)),
 			},
-		}
+		)
 	default:
 		return nil
 	}

--- a/backend/cmd/tools/codegen/queries/mealplanning_recipe_step_ingredients.go
+++ b/backend/cmd/tools/codegen/queries/mealplanning_recipe_step_ingredients.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"fmt"
+	"slices"
 	"strings"
+
+	"github.com/primandproper/platform-go/v11/database/querygen"
 
 	"github.com/cristalhq/builq"
 )
@@ -47,8 +50,6 @@ func buildRecipeStepIngredientsQueries(database string) []*Query {
 	switch database {
 	case postgres:
 
-		insertColumns := filterForInsert(recipeStepIngredientsColumns)
-
 		fullSelectColumn := mergeColumns(
 			applyToEach(filterFromSlice(recipeStepIngredientsColumns, ingredientIDColumn, measurementUnitColumn), func(i int, s string) string {
 				return fmt.Sprintf("%s.%s", recipeStepIngredientsTableName, s)
@@ -64,46 +65,19 @@ func buildRecipeStepIngredientsQueries(database string) []*Query {
 			3,
 		)
 
-		return []*Query{
-			{
-				Annotation: QueryAnnotation{
-					Name: "ArchiveRecipeStepIngredient",
-					Type: ExecRowsType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET %s = %s WHERE %s IS NULL AND %s = sqlc.arg(%s) AND %s = sqlc.arg(%s);`,
-					recipeStepIngredientsTableName,
-					archivedAtColumn,
-					currentTimeExpression,
-					archivedAtColumn,
-					belongsToRecipeStepColumn,
-					belongsToRecipeStepColumn,
-					idColumn,
-					idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CreateRecipeStepIngredient",
-					Type: ExecType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`INSERT INTO %s (
-	%s
-) VALUES (
-	%s
-);`,
-					recipeStepIngredientsTableName,
-					strings.Join(insertColumns, ",\n\t"),
-					strings.Join(applyToEach(insertColumns, func(i int, s string) string {
-						return fmt.Sprintf("sqlc.arg(%s)", s)
-					}), ",\n\t"),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CheckRecipeStepIngredientExistence",
-					Type: OneType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT EXISTS (
+		return slices.Concat(
+			querygen.StandardCRUD(recipeStepIngredientsTableName, recipeStepIngredientsColumns,
+				querygen.WithEntity("RecipeStepIngredient", "RecipeStepIngredients"),
+				querygen.WithOwnership(belongsToRecipeStepColumn),
+				querygen.WithOmitted(querygen.ExistsQuery, querygen.GetQuery, querygen.ListQuery),
+			),
+			[]*Query{
+				{
+					Annotation: QueryAnnotation{
+						Name: "CheckRecipeStepIngredientExistence",
+						Type: OneType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT EXISTS (
 	SELECT %s.%s
 	FROM %s
 		JOIN %s ON %s.%s=%s.%s
@@ -117,26 +91,26 @@ func buildRecipeStepIngredientsQueries(database string) []*Query {
 		AND %s.%s IS NULL
 		AND %s.%s = sqlc.arg(%s)
 );`,
-					recipeStepIngredientsTableName, idColumn,
-					recipeStepIngredientsTableName,
-					recipeStepsTableName, recipeStepIngredientsTableName, belongsToRecipeStepColumn, recipeStepsTableName, idColumn,
-					recipesTableName, recipeStepsTableName, belongsToRecipeColumn, recipesTableName, idColumn,
-					recipeStepIngredientsTableName, archivedAtColumn,
-					recipeStepIngredientsTableName, belongsToRecipeStepColumn, recipeStepIDColumn,
-					recipeStepIngredientsTableName, idColumn, recipeStepIngredientIDColumn,
-					recipeStepsTableName, archivedAtColumn,
-					recipeStepsTableName, belongsToRecipeColumn, recipeIDColumn,
-					recipeStepsTableName, idColumn, recipeStepIDColumn,
-					recipesTableName, archivedAtColumn,
-					recipesTableName, idColumn, recipeIDColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetAllRecipeStepIngredientsForRecipe",
-					Type: ManyType,
+						recipeStepIngredientsTableName, idColumn,
+						recipeStepIngredientsTableName,
+						recipeStepsTableName, recipeStepIngredientsTableName, belongsToRecipeStepColumn, recipeStepsTableName, idColumn,
+						recipesTableName, recipeStepsTableName, belongsToRecipeColumn, recipesTableName, idColumn,
+						recipeStepIngredientsTableName, archivedAtColumn,
+						recipeStepIngredientsTableName, belongsToRecipeStepColumn, recipeStepIDColumn,
+						recipeStepIngredientsTableName, idColumn, recipeStepIngredientIDColumn,
+						recipeStepsTableName, archivedAtColumn,
+						recipeStepsTableName, belongsToRecipeColumn, recipeIDColumn,
+						recipeStepsTableName, idColumn, recipeStepIDColumn,
+						recipesTableName, archivedAtColumn,
+						recipesTableName, idColumn, recipeIDColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetAllRecipeStepIngredientsForRecipe",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s
 FROM %s
 	JOIN %s ON %s.%s = %s.%s
@@ -147,23 +121,23 @@ WHERE
 	%s.%s IS NULL
 	AND %s.%s = sqlc.arg(%s)
 	AND %s.%s = sqlc.arg(%s);`,
-					strings.Join(fullSelectColumn, ",\n\t"),
-					recipeStepIngredientsTableName,
-					recipeStepsTableName, recipeStepIngredientsTableName, belongsToRecipeStepColumn, recipeStepsTableName, idColumn,
-					recipesTableName, recipeStepsTableName, belongsToRecipeColumn, recipesTableName, idColumn,
-					validIngredientsTableName, recipeStepIngredientsTableName, ingredientIDColumn, validIngredientsTableName, idColumn,
-					validMeasurementUnitsTableName, recipeStepIngredientsTableName, measurementUnitColumn, validMeasurementUnitsTableName, idColumn,
-					recipeStepIngredientsTableName, archivedAtColumn,
-					recipesTableName, idColumn, recipeIDColumn,
-					recipeStepsTableName, belongsToRecipeColumn, recipeIDColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetRecipeStepIngredients",
-					Type: ManyType,
+						strings.Join(fullSelectColumn, ",\n\t"),
+						recipeStepIngredientsTableName,
+						recipeStepsTableName, recipeStepIngredientsTableName, belongsToRecipeStepColumn, recipeStepsTableName, idColumn,
+						recipesTableName, recipeStepsTableName, belongsToRecipeColumn, recipesTableName, idColumn,
+						validIngredientsTableName, recipeStepIngredientsTableName, ingredientIDColumn, validIngredientsTableName, idColumn,
+						validMeasurementUnitsTableName, recipeStepIngredientsTableName, measurementUnitColumn, validMeasurementUnitsTableName, idColumn,
+						recipeStepIngredientsTableName, archivedAtColumn,
+						recipesTableName, idColumn, recipeIDColumn,
+						recipeStepsTableName, belongsToRecipeColumn, recipeIDColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetRecipeStepIngredients",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s
@@ -180,65 +154,65 @@ WHERE
 	AND %s.%s = sqlc.arg(%s)
 	%s
 %s;`,
-					strings.Join(fullSelectColumn, ",\n\t"),
+						strings.Join(fullSelectColumn, ",\n\t"),
 
-					//
+						//
 
-					buildFilterCountSelect(
+						buildFilterCountSelect(
+							recipeStepIngredientsTableName,
+							true,
+							true,
+							[]string{
+								fmt.Sprintf("%s ON %s.%s = %s.%s", recipeStepsTableName, recipeStepIngredientsTableName, belongsToRecipeStepColumn, recipeStepsTableName, idColumn),
+								fmt.Sprintf("%s ON %s.%s = %s.%s", recipesTableName, recipeStepsTableName, belongsToRecipeColumn, recipesTableName, idColumn),
+							},
+							fmt.Sprintf("%s.%s = sqlc.arg(%s)", recipesTableName, idColumn, recipeIDColumn),
+							fmt.Sprintf("%s.%s = sqlc.arg(%s)", recipeStepsTableName, idColumn, recipeStepIDColumn),
+							fmt.Sprintf("%s.%s = sqlc.arg(%s)", recipeStepsTableName, belongsToRecipeColumn, recipeIDColumn),
+							fmt.Sprintf("%s.%s = sqlc.arg(%s)", recipeStepIngredientsTableName, belongsToRecipeStepColumn, recipeStepIDColumn),
+						),
+
+						//
+
+						buildTotalCountSelect(
+
+							recipeStepIngredientsTableName,
+							true,
+							[]string{
+								fmt.Sprintf("%s ON %s.%s = %s.%s", recipeStepsTableName, recipeStepIngredientsTableName, belongsToRecipeStepColumn, recipeStepsTableName, idColumn),
+								fmt.Sprintf("%s ON %s.%s = %s.%s", recipesTableName, recipeStepsTableName, belongsToRecipeColumn, recipesTableName, idColumn),
+							},
+							fmt.Sprintf("%s.%s = sqlc.arg(%s)", recipesTableName, idColumn, recipeIDColumn),
+							fmt.Sprintf("%s.%s = sqlc.arg(%s)", recipeStepsTableName, idColumn, recipeStepIDColumn),
+							fmt.Sprintf("%s.%s = sqlc.arg(%s)", recipeStepsTableName, belongsToRecipeColumn, recipeIDColumn),
+							fmt.Sprintf("%s.%s = sqlc.arg(%s)", recipeStepIngredientsTableName, belongsToRecipeStepColumn, recipeStepIDColumn),
+						),
+
+						//
+
 						recipeStepIngredientsTableName,
-						true,
-						true,
-						[]string{
-							fmt.Sprintf("%s ON %s.%s = %s.%s", recipeStepsTableName, recipeStepIngredientsTableName, belongsToRecipeStepColumn, recipeStepsTableName, idColumn),
-							fmt.Sprintf("%s ON %s.%s = %s.%s", recipesTableName, recipeStepsTableName, belongsToRecipeColumn, recipesTableName, idColumn),
-						},
-						fmt.Sprintf("%s.%s = sqlc.arg(%s)", recipesTableName, idColumn, recipeIDColumn),
-						fmt.Sprintf("%s.%s = sqlc.arg(%s)", recipeStepsTableName, idColumn, recipeStepIDColumn),
-						fmt.Sprintf("%s.%s = sqlc.arg(%s)", recipeStepsTableName, belongsToRecipeColumn, recipeIDColumn),
-						fmt.Sprintf("%s.%s = sqlc.arg(%s)", recipeStepIngredientsTableName, belongsToRecipeStepColumn, recipeStepIDColumn),
-					),
+						recipeStepsTableName, recipeStepIngredientsTableName, belongsToRecipeStepColumn, recipeStepsTableName, idColumn,
+						recipesTableName, recipeStepsTableName, belongsToRecipeColumn, recipesTableName, idColumn,
+						validIngredientsTableName, recipeStepIngredientsTableName, ingredientIDColumn, validIngredientsTableName, idColumn,
+						validMeasurementUnitsTableName, recipeStepIngredientsTableName, measurementUnitColumn, validMeasurementUnitsTableName, idColumn,
 
-					//
+						//
 
-					buildTotalCountSelect(
-
-						recipeStepIngredientsTableName,
-						true,
-						[]string{
-							fmt.Sprintf("%s ON %s.%s = %s.%s", recipeStepsTableName, recipeStepIngredientsTableName, belongsToRecipeStepColumn, recipeStepsTableName, idColumn),
-							fmt.Sprintf("%s ON %s.%s = %s.%s", recipesTableName, recipeStepsTableName, belongsToRecipeColumn, recipesTableName, idColumn),
-						},
-						fmt.Sprintf("%s.%s = sqlc.arg(%s)", recipesTableName, idColumn, recipeIDColumn),
-						fmt.Sprintf("%s.%s = sqlc.arg(%s)", recipeStepsTableName, idColumn, recipeStepIDColumn),
-						fmt.Sprintf("%s.%s = sqlc.arg(%s)", recipeStepsTableName, belongsToRecipeColumn, recipeIDColumn),
-						fmt.Sprintf("%s.%s = sqlc.arg(%s)", recipeStepIngredientsTableName, belongsToRecipeStepColumn, recipeStepIDColumn),
-					),
-
-					//
-
-					recipeStepIngredientsTableName,
-					recipeStepsTableName, recipeStepIngredientsTableName, belongsToRecipeStepColumn, recipeStepsTableName, idColumn,
-					recipesTableName, recipeStepsTableName, belongsToRecipeColumn, recipesTableName, idColumn,
-					validIngredientsTableName, recipeStepIngredientsTableName, ingredientIDColumn, validIngredientsTableName, idColumn,
-					validMeasurementUnitsTableName, recipeStepIngredientsTableName, measurementUnitColumn, validMeasurementUnitsTableName, idColumn,
-
-					//
-
-					recipeStepIngredientsTableName, archivedAtColumn,
-					recipesTableName, idColumn, recipeIDColumn,
-					recipeStepsTableName, idColumn, recipeStepIDColumn,
-					recipeStepsTableName, belongsToRecipeColumn, recipeIDColumn,
-					recipeStepIngredientsTableName, belongsToRecipeStepColumn, recipeStepIDColumn,
-					buildFilterConditions(recipeStepIngredientsTableName, true, false),
-					buildCursorLimitClause(recipeStepIngredientsTableName),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetRecipeStepIngredient",
-					Type: OneType,
+						recipeStepIngredientsTableName, archivedAtColumn,
+						recipesTableName, idColumn, recipeIDColumn,
+						recipeStepsTableName, idColumn, recipeStepIDColumn,
+						recipeStepsTableName, belongsToRecipeColumn, recipeIDColumn,
+						recipeStepIngredientsTableName, belongsToRecipeStepColumn, recipeStepIDColumn,
+						buildFilterConditions(recipeStepIngredientsTableName, true, false),
+						buildCursorLimitClause(recipeStepIngredientsTableName),
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetRecipeStepIngredient",
+						Type: OneType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s
 FROM %s
 	JOIN %s ON %s.%s = %s.%s
@@ -253,44 +227,24 @@ WHERE %s.%s IS NULL
 	AND %s.%s = sqlc.arg(%s)
 	AND %s.%s IS NULL
 	AND %s.%s = sqlc.arg(%s);`,
-					strings.Join(fullSelectColumn, ",\n\t"),
-					recipeStepIngredientsTableName,
-					recipeStepsTableName, recipeStepIngredientsTableName, belongsToRecipeStepColumn, recipeStepsTableName, idColumn,
-					recipesTableName, recipeStepsTableName, belongsToRecipeColumn, recipesTableName, idColumn,
-					validIngredientsTableName, recipeStepIngredientsTableName, ingredientIDColumn, validIngredientsTableName, idColumn,
-					validMeasurementUnitsTableName, recipeStepIngredientsTableName, measurementUnitColumn, validMeasurementUnitsTableName, idColumn,
-					recipeStepIngredientsTableName, archivedAtColumn,
-					recipeStepIngredientsTableName, belongsToRecipeStepColumn, recipeStepIDColumn,
-					recipeStepIngredientsTableName, idColumn, recipeStepIngredientIDColumn,
-					recipeStepsTableName, archivedAtColumn,
-					recipeStepsTableName, belongsToRecipeColumn, recipeIDColumn,
-					recipeStepsTableName, idColumn, recipeStepIDColumn,
-					recipesTableName, archivedAtColumn,
-					recipesTableName, idColumn, recipeIDColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "UpdateRecipeStepIngredient",
-					Type: ExecRowsType,
+						strings.Join(fullSelectColumn, ",\n\t"),
+						recipeStepIngredientsTableName,
+						recipeStepsTableName, recipeStepIngredientsTableName, belongsToRecipeStepColumn, recipeStepsTableName, idColumn,
+						recipesTableName, recipeStepsTableName, belongsToRecipeColumn, recipesTableName, idColumn,
+						validIngredientsTableName, recipeStepIngredientsTableName, ingredientIDColumn, validIngredientsTableName, idColumn,
+						validMeasurementUnitsTableName, recipeStepIngredientsTableName, measurementUnitColumn, validMeasurementUnitsTableName, idColumn,
+						recipeStepIngredientsTableName, archivedAtColumn,
+						recipeStepIngredientsTableName, belongsToRecipeStepColumn, recipeStepIDColumn,
+						recipeStepIngredientsTableName, idColumn, recipeStepIngredientIDColumn,
+						recipeStepsTableName, archivedAtColumn,
+						recipeStepsTableName, belongsToRecipeColumn, recipeIDColumn,
+						recipeStepsTableName, idColumn, recipeStepIDColumn,
+						recipesTableName, archivedAtColumn,
+						recipesTableName, idColumn, recipeIDColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
-	%s,
-	%s = %s
-WHERE %s IS NULL
-	AND %s = sqlc.arg(%s)
-	AND %s = sqlc.arg(%s);`,
-					recipeStepIngredientsTableName,
-					strings.Join(applyToEach(filterForUpdate(recipeStepIngredientsColumns, belongsToRecipeStepColumn), func(i int, s string) string {
-						return fmt.Sprintf("%s = sqlc.arg(%s)", s, s)
-					}), ",\n\t"),
-					lastUpdatedAtColumn, currentTimeExpression,
-					archivedAtColumn,
-					belongsToRecipeStepColumn, belongsToRecipeStepColumn,
-					idColumn, idColumn,
-				)),
 			},
-		}
+		)
 	default:
 		return nil
 	}

--- a/backend/cmd/tools/codegen/queries/mealplanning_recipe_step_instruments.go
+++ b/backend/cmd/tools/codegen/queries/mealplanning_recipe_step_instruments.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"fmt"
+	"slices"
 	"strings"
+
+	"github.com/primandproper/platform-go/v11/database/querygen"
 
 	"github.com/cristalhq/builq"
 )
@@ -41,8 +44,6 @@ func buildRecipeStepInstrumentsQueries(database string) []*Query {
 	switch database {
 	case postgres:
 
-		insertColumns := filterForInsert(recipeStepInstrumentsColumns)
-
 		fullSelectColumn := mergeColumns(
 			applyToEach(filterFromSlice(recipeStepInstrumentsColumns, instrumentIDColumn, measurementUnitColumn), func(i int, s string) string {
 				return fmt.Sprintf("%s.%s", recipeStepInstrumentsTableName, s)
@@ -53,46 +54,19 @@ func buildRecipeStepInstrumentsQueries(database string) []*Query {
 			1,
 		)
 
-		return []*Query{
-			{
-				Annotation: QueryAnnotation{
-					Name: "ArchiveRecipeStepInstrument",
-					Type: ExecRowsType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET %s = %s WHERE %s IS NULL AND %s = sqlc.arg(%s) AND %s = sqlc.arg(%s);`,
-					recipeStepInstrumentsTableName,
-					archivedAtColumn,
-					currentTimeExpression,
-					archivedAtColumn,
-					belongsToRecipeStepColumn,
-					belongsToRecipeStepColumn,
-					idColumn,
-					idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CreateRecipeStepInstrument",
-					Type: ExecType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`INSERT INTO %s (
-	%s
-) VALUES (
-	%s
-);`,
-					recipeStepInstrumentsTableName,
-					strings.Join(insertColumns, ",\n\t"),
-					strings.Join(applyToEach(insertColumns, func(i int, s string) string {
-						return fmt.Sprintf("sqlc.arg(%s)", s)
-					}), ",\n\t"),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CheckRecipeStepInstrumentExistence",
-					Type: OneType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT EXISTS (
+		return slices.Concat(
+			querygen.StandardCRUD(recipeStepInstrumentsTableName, recipeStepInstrumentsColumns,
+				querygen.WithEntity("RecipeStepInstrument", "RecipeStepInstruments"),
+				querygen.WithOwnership(belongsToRecipeStepColumn),
+				querygen.WithOmitted(querygen.ExistsQuery, querygen.GetQuery, querygen.ListQuery),
+			),
+			[]*Query{
+				{
+					Annotation: QueryAnnotation{
+						Name: "CheckRecipeStepInstrumentExistence",
+						Type: OneType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT EXISTS (
 	SELECT %s.%s
 	FROM %s
 		JOIN %s ON %s.%s=%s.%s
@@ -106,26 +80,26 @@ func buildRecipeStepInstrumentsQueries(database string) []*Query {
 		AND %s.%s IS NULL
 		AND %s.%s = sqlc.arg(%s)
 );`,
-					recipeStepInstrumentsTableName, idColumn,
-					recipeStepInstrumentsTableName,
-					recipeStepsTableName, recipeStepInstrumentsTableName, belongsToRecipeStepColumn, recipeStepsTableName, idColumn,
-					recipesTableName, recipeStepsTableName, belongsToRecipeColumn, recipesTableName, idColumn,
-					recipeStepInstrumentsTableName, archivedAtColumn,
-					recipeStepInstrumentsTableName, belongsToRecipeStepColumn, recipeStepIDColumn,
-					recipeStepInstrumentsTableName, idColumn, recipeStepInstrumentIDColumn,
-					recipeStepsTableName, archivedAtColumn,
-					recipeStepsTableName, belongsToRecipeColumn, recipeIDColumn,
-					recipeStepsTableName, idColumn, recipeStepIDColumn,
-					recipesTableName, archivedAtColumn,
-					recipesTableName, idColumn, recipeIDColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetRecipeStepInstrumentsForRecipe",
-					Type: ManyType,
+						recipeStepInstrumentsTableName, idColumn,
+						recipeStepInstrumentsTableName,
+						recipeStepsTableName, recipeStepInstrumentsTableName, belongsToRecipeStepColumn, recipeStepsTableName, idColumn,
+						recipesTableName, recipeStepsTableName, belongsToRecipeColumn, recipesTableName, idColumn,
+						recipeStepInstrumentsTableName, archivedAtColumn,
+						recipeStepInstrumentsTableName, belongsToRecipeStepColumn, recipeStepIDColumn,
+						recipeStepInstrumentsTableName, idColumn, recipeStepInstrumentIDColumn,
+						recipeStepsTableName, archivedAtColumn,
+						recipeStepsTableName, belongsToRecipeColumn, recipeIDColumn,
+						recipeStepsTableName, idColumn, recipeStepIDColumn,
+						recipesTableName, archivedAtColumn,
+						recipesTableName, idColumn, recipeIDColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetRecipeStepInstrumentsForRecipe",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s
 FROM %s
 	LEFT JOIN %s ON %s.%s=%s.%s
@@ -136,24 +110,24 @@ WHERE %s.%s IS NULL
 	AND %s.%s = sqlc.arg(%s)
 	AND %s.%s IS NULL
 	AND %s.%s = sqlc.arg(%s);`,
-					strings.Join(fullSelectColumn, ",\n\t"),
-					recipeStepInstrumentsTableName,
-					validInstrumentsTableName, recipeStepInstrumentsTableName, instrumentIDColumn, validInstrumentsTableName, idColumn,
-					recipeStepsTableName, recipeStepInstrumentsTableName, belongsToRecipeStepColumn, recipeStepsTableName, idColumn,
-					recipesTableName, recipeStepsTableName, belongsToRecipeColumn, recipesTableName, idColumn,
-					recipeStepInstrumentsTableName, archivedAtColumn,
-					recipeStepsTableName, archivedAtColumn,
-					recipeStepsTableName, belongsToRecipeColumn, recipeIDColumn,
-					recipesTableName, archivedAtColumn,
-					recipesTableName, idColumn, recipeIDColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetRecipeStepInstrument",
-					Type: OneType,
+						strings.Join(fullSelectColumn, ",\n\t"),
+						recipeStepInstrumentsTableName,
+						validInstrumentsTableName, recipeStepInstrumentsTableName, instrumentIDColumn, validInstrumentsTableName, idColumn,
+						recipeStepsTableName, recipeStepInstrumentsTableName, belongsToRecipeStepColumn, recipeStepsTableName, idColumn,
+						recipesTableName, recipeStepsTableName, belongsToRecipeColumn, recipesTableName, idColumn,
+						recipeStepInstrumentsTableName, archivedAtColumn,
+						recipeStepsTableName, archivedAtColumn,
+						recipeStepsTableName, belongsToRecipeColumn, recipeIDColumn,
+						recipesTableName, archivedAtColumn,
+						recipesTableName, idColumn, recipeIDColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetRecipeStepInstrument",
+						Type: OneType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s
 FROM %s
 	LEFT JOIN %s ON %s.%s=%s.%s
@@ -167,27 +141,27 @@ WHERE %s.%s IS NULL
 	AND %s.%s = sqlc.arg(%s)
 	AND %s.%s IS NULL
 	AND %s.%s = sqlc.arg(%s);`,
-					strings.Join(fullSelectColumn, ",\n\t"),
-					recipeStepInstrumentsTableName,
-					validInstrumentsTableName, recipeStepInstrumentsTableName, instrumentIDColumn, validInstrumentsTableName, idColumn,
-					recipeStepsTableName, recipeStepInstrumentsTableName, belongsToRecipeStepColumn, recipeStepsTableName, idColumn,
-					recipesTableName, recipeStepsTableName, belongsToRecipeColumn, recipesTableName, idColumn,
-					recipeStepInstrumentsTableName, archivedAtColumn,
-					recipeStepInstrumentsTableName, belongsToRecipeStepColumn, recipeStepIDColumn,
-					recipeStepInstrumentsTableName, idColumn, recipeStepInstrumentIDColumn,
-					recipeStepsTableName, archivedAtColumn,
-					recipeStepsTableName, belongsToRecipeColumn, recipeIDColumn,
-					recipeStepsTableName, idColumn, recipeStepIDColumn,
-					recipesTableName, archivedAtColumn,
-					recipesTableName, idColumn, recipeIDColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetRecipeStepInstruments",
-					Type: ManyType,
+						strings.Join(fullSelectColumn, ",\n\t"),
+						recipeStepInstrumentsTableName,
+						validInstrumentsTableName, recipeStepInstrumentsTableName, instrumentIDColumn, validInstrumentsTableName, idColumn,
+						recipeStepsTableName, recipeStepInstrumentsTableName, belongsToRecipeStepColumn, recipeStepsTableName, idColumn,
+						recipesTableName, recipeStepsTableName, belongsToRecipeColumn, recipesTableName, idColumn,
+						recipeStepInstrumentsTableName, archivedAtColumn,
+						recipeStepInstrumentsTableName, belongsToRecipeStepColumn, recipeStepIDColumn,
+						recipeStepInstrumentsTableName, idColumn, recipeStepInstrumentIDColumn,
+						recipeStepsTableName, archivedAtColumn,
+						recipeStepsTableName, belongsToRecipeColumn, recipeIDColumn,
+						recipeStepsTableName, idColumn, recipeStepIDColumn,
+						recipesTableName, archivedAtColumn,
+						recipesTableName, idColumn, recipeIDColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetRecipeStepInstruments",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s
@@ -205,46 +179,26 @@ WHERE
 	AND %s.%s = sqlc.arg(%s)
 	%s
 %s;`,
-					strings.Join(fullSelectColumn, ",\n\t"),
-					buildFilterCountSelect(recipeStepInstrumentsTableName, true, true, nil),
-					buildTotalCountSelect(recipeStepInstrumentsTableName, true, []string{}),
-					recipeStepInstrumentsTableName,
-					validInstrumentsTableName, recipeStepInstrumentsTableName, instrumentIDColumn, validInstrumentsTableName, idColumn,
-					recipeStepsTableName, recipeStepInstrumentsTableName, belongsToRecipeStepColumn, recipeStepsTableName, idColumn,
-					recipesTableName, recipeStepsTableName, belongsToRecipeColumn, recipesTableName, idColumn,
-					recipeStepInstrumentsTableName, archivedAtColumn,
-					recipeStepInstrumentsTableName, belongsToRecipeStepColumn, recipeStepIDColumn,
-					recipeStepsTableName, archivedAtColumn,
-					recipeStepsTableName, belongsToRecipeColumn, recipeIDColumn,
-					recipeStepsTableName, idColumn, recipeStepIDColumn,
-					recipesTableName, archivedAtColumn,
-					recipesTableName, idColumn, recipeIDColumn,
-					buildFilterConditions(recipeStepInstrumentsTableName, true, false),
-					buildCursorLimitClause(recipeStepInstrumentsTableName),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "UpdateRecipeStepInstrument",
-					Type: ExecRowsType,
+						strings.Join(fullSelectColumn, ",\n\t"),
+						buildFilterCountSelect(recipeStepInstrumentsTableName, true, true, nil),
+						buildTotalCountSelect(recipeStepInstrumentsTableName, true, []string{}),
+						recipeStepInstrumentsTableName,
+						validInstrumentsTableName, recipeStepInstrumentsTableName, instrumentIDColumn, validInstrumentsTableName, idColumn,
+						recipeStepsTableName, recipeStepInstrumentsTableName, belongsToRecipeStepColumn, recipeStepsTableName, idColumn,
+						recipesTableName, recipeStepsTableName, belongsToRecipeColumn, recipesTableName, idColumn,
+						recipeStepInstrumentsTableName, archivedAtColumn,
+						recipeStepInstrumentsTableName, belongsToRecipeStepColumn, recipeStepIDColumn,
+						recipeStepsTableName, archivedAtColumn,
+						recipeStepsTableName, belongsToRecipeColumn, recipeIDColumn,
+						recipeStepsTableName, idColumn, recipeStepIDColumn,
+						recipesTableName, archivedAtColumn,
+						recipesTableName, idColumn, recipeIDColumn,
+						buildFilterConditions(recipeStepInstrumentsTableName, true, false),
+						buildCursorLimitClause(recipeStepInstrumentsTableName),
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
-	%s,
-	%s = %s
-WHERE %s IS NULL
-	AND %s = sqlc.arg(%s)
-	AND %s = sqlc.arg(%s);`,
-					recipeStepInstrumentsTableName,
-					strings.Join(applyToEach(filterForUpdate(recipeStepInstrumentsColumns, belongsToRecipeStepColumn), func(i int, s string) string {
-						return fmt.Sprintf("%s = sqlc.arg(%s)", s, s)
-					}), ",\n\t"),
-					lastUpdatedAtColumn, currentTimeExpression,
-					archivedAtColumn,
-					belongsToRecipeStepColumn, belongsToRecipeStepColumn,
-					idColumn, idColumn,
-				)),
 			},
-		}
+		)
 	default:
 		return nil
 	}

--- a/backend/cmd/tools/codegen/queries/mealplanning_recipe_step_products.go
+++ b/backend/cmd/tools/codegen/queries/mealplanning_recipe_step_products.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"fmt"
+	"slices"
 	"strings"
+
+	"github.com/primandproper/platform-go/v11/database/querygen"
 
 	"github.com/cristalhq/builq"
 )
@@ -46,8 +49,6 @@ func buildRecipeStepProductsQueries(database string) []*Query {
 	switch database {
 	case postgres:
 
-		insertColumns := filterForInsert(recipeStepProductsColumns)
-
 		fullSelectColumns := mergeColumns(
 			applyToEach(filterFromSlice(recipeStepProductsColumns, measurementUnitColumn), func(i int, s string) string {
 				return fmt.Sprintf("%s.%s", recipeStepProductsTableName, s)
@@ -58,46 +59,19 @@ func buildRecipeStepProductsQueries(database string) []*Query {
 			3,
 		)
 
-		return []*Query{
-			{
-				Annotation: QueryAnnotation{
-					Name: "ArchiveRecipeStepProduct",
-					Type: ExecRowsType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET %s = %s WHERE %s IS NULL AND %s = sqlc.arg(%s) AND %s = sqlc.arg(%s);`,
-					recipeStepProductsTableName,
-					archivedAtColumn,
-					currentTimeExpression,
-					archivedAtColumn,
-					belongsToRecipeStepColumn,
-					belongsToRecipeStepColumn,
-					idColumn,
-					idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CreateRecipeStepProduct",
-					Type: ExecType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`INSERT INTO %s (
-	%s
-) VALUES (
-	%s
-);`,
-					recipeStepProductsTableName,
-					strings.Join(insertColumns, ",\n\t"),
-					strings.Join(applyToEach(insertColumns, func(i int, s string) string {
-						return fmt.Sprintf("sqlc.arg(%s)", s)
-					}), ",\n\t"),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CheckRecipeStepProductExistence",
-					Type: OneType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT EXISTS (
+		return slices.Concat(
+			querygen.StandardCRUD(recipeStepProductsTableName, recipeStepProductsColumns,
+				querygen.WithEntity("RecipeStepProduct", "RecipeStepProducts"),
+				querygen.WithOwnership(belongsToRecipeStepColumn),
+				querygen.WithOmitted(querygen.ExistsQuery, querygen.GetQuery, querygen.ListQuery),
+			),
+			[]*Query{
+				{
+					Annotation: QueryAnnotation{
+						Name: "CheckRecipeStepProductExistence",
+						Type: OneType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT EXISTS (
 	SELECT %s.%s
 	FROM %s
 		JOIN %s ON %s.%s=%s.%s
@@ -111,26 +85,26 @@ func buildRecipeStepProductsQueries(database string) []*Query {
 		AND %s.%s IS NULL
 		AND %s.%s = sqlc.arg(%s)
 );`,
-					recipeStepProductsTableName, idColumn,
-					recipeStepProductsTableName,
-					recipeStepsTableName, recipeStepProductsTableName, belongsToRecipeStepColumn, recipeStepsTableName, idColumn,
-					recipesTableName, recipeStepsTableName, belongsToRecipeColumn, recipesTableName, idColumn,
-					recipeStepProductsTableName, archivedAtColumn,
-					recipeStepProductsTableName, belongsToRecipeStepColumn, recipeStepIDColumn,
-					recipeStepProductsTableName, idColumn, recipeStepProductIDColumn,
-					recipeStepsTableName, archivedAtColumn,
-					recipeStepsTableName, belongsToRecipeColumn, recipeIDColumn,
-					recipeStepsTableName, idColumn, recipeStepIDColumn,
-					recipesTableName, archivedAtColumn,
-					recipesTableName, idColumn, recipeIDColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetRecipeStepProductsForRecipe",
-					Type: ManyType,
+						recipeStepProductsTableName, idColumn,
+						recipeStepProductsTableName,
+						recipeStepsTableName, recipeStepProductsTableName, belongsToRecipeStepColumn, recipeStepsTableName, idColumn,
+						recipesTableName, recipeStepsTableName, belongsToRecipeColumn, recipesTableName, idColumn,
+						recipeStepProductsTableName, archivedAtColumn,
+						recipeStepProductsTableName, belongsToRecipeStepColumn, recipeStepIDColumn,
+						recipeStepProductsTableName, idColumn, recipeStepProductIDColumn,
+						recipeStepsTableName, archivedAtColumn,
+						recipeStepsTableName, belongsToRecipeColumn, recipeIDColumn,
+						recipeStepsTableName, idColumn, recipeStepIDColumn,
+						recipesTableName, archivedAtColumn,
+						recipesTableName, idColumn, recipeIDColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetRecipeStepProductsForRecipe",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s
 FROM %s
 	JOIN %s ON %s.%s=%s.%s
@@ -141,31 +115,31 @@ WHERE %s.%s IS NULL
 	AND %s.%s = sqlc.arg(%s)
 	AND %s.%s IS NULL
 	AND %s.%s = sqlc.arg(%s);`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					recipeStepProductsTableName,
-					recipeStepsTableName, recipeStepProductsTableName, belongsToRecipeStepColumn, recipeStepsTableName, idColumn,
-					recipesTableName, recipeStepsTableName, belongsToRecipeColumn, recipesTableName, idColumn,
-					validMeasurementUnitsTableName, recipeStepProductsTableName, measurementUnitColumn, validMeasurementUnitsTableName, idColumn,
-					recipeStepProductsTableName, archivedAtColumn,
-					recipeStepsTableName, archivedAtColumn,
-					recipeStepsTableName, belongsToRecipeColumn, recipeIDColumn,
-					recipesTableName, archivedAtColumn,
-					recipesTableName, idColumn, recipeIDColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetRecipeStepProducts",
-					Type: ManyType,
+						strings.Join(fullSelectColumns, ",\n\t"),
+						recipeStepProductsTableName,
+						recipeStepsTableName, recipeStepProductsTableName, belongsToRecipeStepColumn, recipeStepsTableName, idColumn,
+						recipesTableName, recipeStepsTableName, belongsToRecipeColumn, recipesTableName, idColumn,
+						validMeasurementUnitsTableName, recipeStepProductsTableName, measurementUnitColumn, validMeasurementUnitsTableName, idColumn,
+						recipeStepProductsTableName, archivedAtColumn,
+						recipeStepsTableName, archivedAtColumn,
+						recipeStepsTableName, belongsToRecipeColumn, recipeIDColumn,
+						recipesTableName, archivedAtColumn,
+						recipesTableName, idColumn, recipeIDColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetRecipeStepProducts",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	(
 		SELECT COUNT(%s.%s)
 		FROM %s
 		WHERE %s.%s IS NULL
-			AND %s.%s = sqlc.arg(%s)
+				AND %s.%s = sqlc.arg(%s)
 	) AS total_count
 FROM %s
 	JOIN %s ON %s.%s=%s.%s
@@ -180,33 +154,33 @@ WHERE %s.%s IS NULL
 	AND %s.%s = sqlc.arg(%s)
 	%s
 %s;`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					buildFilterCountSelect(recipeStepProductsTableName, true, true, nil),
-					recipeStepProductsTableName, idColumn,
-					recipeStepProductsTableName,
-					recipeStepProductsTableName, archivedAtColumn,
-					recipeStepProductsTableName, belongsToRecipeStepColumn, recipeStepIDColumn,
-					recipeStepProductsTableName,
-					recipeStepsTableName, recipeStepProductsTableName, belongsToRecipeStepColumn, recipeStepsTableName, idColumn,
-					recipesTableName, recipeStepsTableName, belongsToRecipeColumn, recipesTableName, idColumn,
-					validMeasurementUnitsTableName, recipeStepProductsTableName, measurementUnitColumn, validMeasurementUnitsTableName, idColumn,
-					recipeStepProductsTableName, archivedAtColumn,
-					recipeStepProductsTableName, belongsToRecipeStepColumn, recipeStepIDColumn,
-					recipeStepsTableName, archivedAtColumn,
-					recipeStepsTableName, idColumn, recipeStepIDColumn,
-					recipeStepsTableName, belongsToRecipeColumn, recipeIDColumn,
-					recipesTableName, archivedAtColumn,
-					recipesTableName, idColumn, recipeIDColumn,
-					buildFilterConditions(recipeStepProductsTableName, true, true),
-					buildCursorLimitClause(recipeStepProductsTableName),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetRecipeStepProduct",
-					Type: OneType,
+						strings.Join(fullSelectColumns, ",\n\t"),
+						buildFilterCountSelect(recipeStepProductsTableName, true, true, nil),
+						recipeStepProductsTableName, idColumn,
+						recipeStepProductsTableName,
+						recipeStepProductsTableName, archivedAtColumn,
+						recipeStepProductsTableName, belongsToRecipeStepColumn, recipeStepIDColumn,
+						recipeStepProductsTableName,
+						recipeStepsTableName, recipeStepProductsTableName, belongsToRecipeStepColumn, recipeStepsTableName, idColumn,
+						recipesTableName, recipeStepsTableName, belongsToRecipeColumn, recipesTableName, idColumn,
+						validMeasurementUnitsTableName, recipeStepProductsTableName, measurementUnitColumn, validMeasurementUnitsTableName, idColumn,
+						recipeStepProductsTableName, archivedAtColumn,
+						recipeStepProductsTableName, belongsToRecipeStepColumn, recipeStepIDColumn,
+						recipeStepsTableName, archivedAtColumn,
+						recipeStepsTableName, idColumn, recipeStepIDColumn,
+						recipeStepsTableName, belongsToRecipeColumn, recipeIDColumn,
+						recipesTableName, archivedAtColumn,
+						recipesTableName, idColumn, recipeIDColumn,
+						buildFilterConditions(recipeStepProductsTableName, true, true),
+						buildCursorLimitClause(recipeStepProductsTableName),
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetRecipeStepProduct",
+						Type: OneType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s
 FROM %s
 	JOIN %s ON %s.%s=%s.%s
@@ -220,43 +194,23 @@ WHERE %s.%s IS NULL
 	AND %s.%s = sqlc.arg(%s)
 	AND %s.%s IS NULL
 	AND %s.%s = sqlc.arg(%s);`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					recipeStepProductsTableName,
-					recipeStepsTableName, recipeStepProductsTableName, belongsToRecipeStepColumn, recipeStepsTableName, idColumn,
-					recipesTableName, recipeStepsTableName, belongsToRecipeColumn, recipesTableName, idColumn,
-					validMeasurementUnitsTableName, recipeStepProductsTableName, measurementUnitColumn, validMeasurementUnitsTableName, idColumn,
-					recipeStepProductsTableName, archivedAtColumn,
-					recipeStepProductsTableName, belongsToRecipeStepColumn, recipeStepIDColumn,
-					recipeStepProductsTableName, idColumn, recipeStepProductIDColumn,
-					recipeStepsTableName, archivedAtColumn,
-					recipeStepsTableName, belongsToRecipeColumn, recipeIDColumn,
-					recipeStepsTableName, idColumn, recipeStepIDColumn,
-					recipesTableName, archivedAtColumn,
-					recipesTableName, idColumn, recipeIDColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "UpdateRecipeStepProduct",
-					Type: ExecRowsType,
+						strings.Join(fullSelectColumns, ",\n\t"),
+						recipeStepProductsTableName,
+						recipeStepsTableName, recipeStepProductsTableName, belongsToRecipeStepColumn, recipeStepsTableName, idColumn,
+						recipesTableName, recipeStepsTableName, belongsToRecipeColumn, recipesTableName, idColumn,
+						validMeasurementUnitsTableName, recipeStepProductsTableName, measurementUnitColumn, validMeasurementUnitsTableName, idColumn,
+						recipeStepProductsTableName, archivedAtColumn,
+						recipeStepProductsTableName, belongsToRecipeStepColumn, recipeStepIDColumn,
+						recipeStepProductsTableName, idColumn, recipeStepProductIDColumn,
+						recipeStepsTableName, archivedAtColumn,
+						recipeStepsTableName, belongsToRecipeColumn, recipeIDColumn,
+						recipeStepsTableName, idColumn, recipeStepIDColumn,
+						recipesTableName, archivedAtColumn,
+						recipesTableName, idColumn, recipeIDColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
-	%s,
-	%s = %s
-WHERE %s IS NULL
-	AND %s = sqlc.arg(%s)
-	AND %s = sqlc.arg(%s);`,
-					recipeStepProductsTableName,
-					strings.Join(applyToEach(filterForUpdate(recipeStepProductsColumns, belongsToRecipeStepColumn), func(i int, s string) string {
-						return fmt.Sprintf("%s = sqlc.arg(%s)", s, s)
-					}), ",\n\t"),
-					lastUpdatedAtColumn, currentTimeExpression,
-					archivedAtColumn,
-					belongsToRecipeStepColumn, belongsToRecipeStepColumn,
-					idColumn, idColumn,
-				)),
 			},
-		}
+		)
 	default:
 		return nil
 	}

--- a/backend/cmd/tools/codegen/queries/mealplanning_recipe_step_vessels.go
+++ b/backend/cmd/tools/codegen/queries/mealplanning_recipe_step_vessels.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"fmt"
+	"slices"
 	"strings"
+
+	"github.com/primandproper/platform-go/v11/database/querygen"
 
 	"github.com/cristalhq/builq"
 )
@@ -40,8 +43,6 @@ func buildRecipeStepVesselsQueries(database string) []*Query {
 	switch database {
 	case postgres:
 
-		insertColumns := filterForInsert(recipeStepVesselsColumns)
-
 		fullSelectColumns := mergeColumns(
 			applyToEach(filterFromSlice(recipeStepVesselsColumns, validVesselIDColumn), func(i int, s string) string {
 				return fmt.Sprintf("%s.%s", recipeStepVesselsTableName, s)
@@ -58,46 +59,19 @@ func buildRecipeStepVesselsQueries(database string) []*Query {
 			1,
 		)
 
-		return []*Query{
-			{
-				Annotation: QueryAnnotation{
-					Name: "ArchiveRecipeStepVessel",
-					Type: ExecRowsType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET %s = %s WHERE %s IS NULL AND %s = sqlc.arg(%s) AND %s = sqlc.arg(%s);`,
-					recipeStepVesselsTableName,
-					archivedAtColumn,
-					currentTimeExpression,
-					archivedAtColumn,
-					belongsToRecipeStepColumn,
-					belongsToRecipeStepColumn,
-					idColumn,
-					idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CreateRecipeStepVessel",
-					Type: ExecType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`INSERT INTO %s (
-	%s
-) VALUES (
-	%s
-);`,
-					recipeStepVesselsTableName,
-					strings.Join(insertColumns, ",\n\t"),
-					strings.Join(applyToEach(insertColumns, func(i int, s string) string {
-						return fmt.Sprintf("sqlc.arg(%s)", s)
-					}), ",\n\t"),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CheckRecipeStepVesselExistence",
-					Type: OneType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT EXISTS (
+		return slices.Concat(
+			querygen.StandardCRUD(recipeStepVesselsTableName, recipeStepVesselsColumns,
+				querygen.WithEntity("RecipeStepVessel", "RecipeStepVessels"),
+				querygen.WithOwnership(belongsToRecipeStepColumn),
+				querygen.WithOmitted(querygen.ExistsQuery, querygen.GetQuery, querygen.ListQuery, querygen.UpdateQuery),
+			),
+			[]*Query{
+				{
+					Annotation: QueryAnnotation{
+						Name: "CheckRecipeStepVesselExistence",
+						Type: OneType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT EXISTS (
 	SELECT %s.%s
 	FROM %s
 		JOIN %s ON %s.%s=%s.%s
@@ -111,26 +85,26 @@ func buildRecipeStepVesselsQueries(database string) []*Query {
 		AND %s.%s IS NULL
 		AND %s.%s = sqlc.arg(%s)
 );`,
-					recipeStepVesselsTableName, idColumn,
-					recipeStepVesselsTableName,
-					recipeStepsTableName, recipeStepVesselsTableName, belongsToRecipeStepColumn, recipeStepsTableName, idColumn,
-					recipesTableName, recipeStepsTableName, belongsToRecipeColumn, recipesTableName, idColumn,
-					recipeStepVesselsTableName, archivedAtColumn,
-					recipeStepVesselsTableName, belongsToRecipeStepColumn, recipeStepIDColumn,
-					recipeStepVesselsTableName, idColumn, recipeStepVesselIDColumn,
-					recipeStepsTableName, archivedAtColumn,
-					recipeStepsTableName, belongsToRecipeColumn, recipeIDColumn,
-					recipeStepsTableName, idColumn, recipeStepIDColumn,
-					recipesTableName, archivedAtColumn,
-					recipesTableName, idColumn, recipeIDColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetRecipeStepVesselsForRecipe",
-					Type: ManyType,
+						recipeStepVesselsTableName, idColumn,
+						recipeStepVesselsTableName,
+						recipeStepsTableName, recipeStepVesselsTableName, belongsToRecipeStepColumn, recipeStepsTableName, idColumn,
+						recipesTableName, recipeStepsTableName, belongsToRecipeColumn, recipesTableName, idColumn,
+						recipeStepVesselsTableName, archivedAtColumn,
+						recipeStepVesselsTableName, belongsToRecipeStepColumn, recipeStepIDColumn,
+						recipeStepVesselsTableName, idColumn, recipeStepVesselIDColumn,
+						recipeStepsTableName, archivedAtColumn,
+						recipeStepsTableName, belongsToRecipeColumn, recipeIDColumn,
+						recipeStepsTableName, idColumn, recipeStepIDColumn,
+						recipesTableName, archivedAtColumn,
+						recipesTableName, idColumn, recipeIDColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetRecipeStepVesselsForRecipe",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s
 FROM %s
 	LEFT JOIN %s ON %s.%s=%s.%s
@@ -142,25 +116,25 @@ WHERE %s.%s IS NULL
 	AND %s.%s = sqlc.arg(%s)
 	AND %s.%s IS NULL
 	AND %s.%s = sqlc.arg(%s);`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					recipeStepVesselsTableName,
-					validVesselsTableName, recipeStepVesselsTableName, validVesselIDColumn, validVesselsTableName, idColumn,
-					validMeasurementUnitsTableName, validVesselsTableName, capacityUnitColumn, validMeasurementUnitsTableName, idColumn,
-					recipeStepsTableName, recipeStepVesselsTableName, belongsToRecipeStepColumn, recipeStepsTableName, idColumn,
-					recipesTableName, recipeStepsTableName, belongsToRecipeColumn, recipesTableName, idColumn,
-					recipeStepVesselsTableName, archivedAtColumn,
-					recipeStepsTableName, archivedAtColumn,
-					recipeStepsTableName, belongsToRecipeColumn, recipeIDColumn,
-					recipesTableName, archivedAtColumn,
-					recipesTableName, idColumn, recipeIDColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetRecipeStepVessel",
-					Type: OneType,
+						strings.Join(fullSelectColumns, ",\n\t"),
+						recipeStepVesselsTableName,
+						validVesselsTableName, recipeStepVesselsTableName, validVesselIDColumn, validVesselsTableName, idColumn,
+						validMeasurementUnitsTableName, validVesselsTableName, capacityUnitColumn, validMeasurementUnitsTableName, idColumn,
+						recipeStepsTableName, recipeStepVesselsTableName, belongsToRecipeStepColumn, recipeStepsTableName, idColumn,
+						recipesTableName, recipeStepsTableName, belongsToRecipeColumn, recipesTableName, idColumn,
+						recipeStepVesselsTableName, archivedAtColumn,
+						recipeStepsTableName, archivedAtColumn,
+						recipeStepsTableName, belongsToRecipeColumn, recipeIDColumn,
+						recipesTableName, archivedAtColumn,
+						recipesTableName, idColumn, recipeIDColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetRecipeStepVessel",
+						Type: OneType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s
 FROM %s
 	LEFT JOIN %s ON %s.%s=%s.%s
@@ -175,28 +149,28 @@ WHERE %s.%s IS NULL
 	AND %s.%s = sqlc.arg(%s)
 	AND %s.%s IS NULL
 	AND %s.%s = sqlc.arg(%s);`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					recipeStepVesselsTableName,
-					validVesselsTableName, recipeStepVesselsTableName, validVesselIDColumn, validVesselsTableName, idColumn,
-					validMeasurementUnitsTableName, validVesselsTableName, capacityUnitColumn, validMeasurementUnitsTableName, idColumn,
-					recipeStepsTableName, recipeStepVesselsTableName, belongsToRecipeStepColumn, recipeStepsTableName, idColumn,
-					recipesTableName, recipeStepsTableName, belongsToRecipeColumn, recipesTableName, idColumn,
-					recipeStepVesselsTableName, archivedAtColumn,
-					recipeStepVesselsTableName, belongsToRecipeStepColumn, recipeStepIDColumn,
-					recipeStepVesselsTableName, idColumn, recipeStepVesselIDColumn,
-					recipeStepsTableName, archivedAtColumn,
-					recipeStepsTableName, belongsToRecipeColumn, recipeIDColumn,
-					recipeStepsTableName, idColumn, recipeStepIDColumn,
-					recipesTableName, archivedAtColumn,
-					recipesTableName, idColumn, recipeIDColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetRecipeStepVessels",
-					Type: ManyType,
+						strings.Join(fullSelectColumns, ",\n\t"),
+						recipeStepVesselsTableName,
+						validVesselsTableName, recipeStepVesselsTableName, validVesselIDColumn, validVesselsTableName, idColumn,
+						validMeasurementUnitsTableName, validVesselsTableName, capacityUnitColumn, validMeasurementUnitsTableName, idColumn,
+						recipeStepsTableName, recipeStepVesselsTableName, belongsToRecipeStepColumn, recipeStepsTableName, idColumn,
+						recipesTableName, recipeStepsTableName, belongsToRecipeColumn, recipesTableName, idColumn,
+						recipeStepVesselsTableName, archivedAtColumn,
+						recipeStepVesselsTableName, belongsToRecipeStepColumn, recipeStepIDColumn,
+						recipeStepVesselsTableName, idColumn, recipeStepVesselIDColumn,
+						recipeStepsTableName, archivedAtColumn,
+						recipeStepsTableName, belongsToRecipeColumn, recipeIDColumn,
+						recipeStepsTableName, idColumn, recipeStepIDColumn,
+						recipesTableName, archivedAtColumn,
+						recipesTableName, idColumn, recipeIDColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetRecipeStepVessels",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s
@@ -214,47 +188,48 @@ WHERE %s.%s IS NULL
 	AND %s.%s = sqlc.arg(%s)
 	%s
 %s;`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					buildFilterCountSelect(recipeStepVesselsTableName, true, true, []string{}),
-					buildTotalCountSelect(recipeStepVesselsTableName, true, []string{}),
-					recipeStepVesselsTableName,
-					validVesselsTableName, recipeStepVesselsTableName, validVesselIDColumn, validVesselsTableName, idColumn,
-					validMeasurementUnitsTableName, validVesselsTableName, capacityUnitColumn, validMeasurementUnitsTableName, idColumn,
-					recipeStepsTableName, recipeStepVesselsTableName, belongsToRecipeStepColumn, recipeStepsTableName, idColumn,
-					recipesTableName, recipeStepsTableName, belongsToRecipeColumn, recipesTableName, idColumn,
-					recipeStepVesselsTableName, archivedAtColumn,
-					recipeStepVesselsTableName, belongsToRecipeStepColumn, recipeStepIDColumn,
-					recipeStepsTableName, belongsToRecipeColumn, recipeIDColumn,
-					recipeStepsTableName, archivedAtColumn,
-					recipeStepsTableName, idColumn, recipeStepIDColumn,
-					recipesTableName, archivedAtColumn,
-					recipesTableName, idColumn, recipeIDColumn,
-					buildFilterConditions(recipeStepVesselsTableName, true, false),
-					buildCursorLimitClause(recipeStepVesselsTableName),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "UpdateRecipeStepVessel",
-					Type: ExecRowsType,
+						strings.Join(fullSelectColumns, ",\n\t"),
+						buildFilterCountSelect(recipeStepVesselsTableName, true, true, []string{}),
+						buildTotalCountSelect(recipeStepVesselsTableName, true, []string{}),
+						recipeStepVesselsTableName,
+						validVesselsTableName, recipeStepVesselsTableName, validVesselIDColumn, validVesselsTableName, idColumn,
+						validMeasurementUnitsTableName, validVesselsTableName, capacityUnitColumn, validMeasurementUnitsTableName, idColumn,
+						recipeStepsTableName, recipeStepVesselsTableName, belongsToRecipeStepColumn, recipeStepsTableName, idColumn,
+						recipesTableName, recipeStepsTableName, belongsToRecipeColumn, recipesTableName, idColumn,
+						recipeStepVesselsTableName, archivedAtColumn,
+						recipeStepVesselsTableName, belongsToRecipeStepColumn, recipeStepIDColumn,
+						recipeStepsTableName, belongsToRecipeColumn, recipeIDColumn,
+						recipeStepsTableName, archivedAtColumn,
+						recipeStepsTableName, idColumn, recipeStepIDColumn,
+						recipesTableName, archivedAtColumn,
+						recipesTableName, idColumn, recipeIDColumn,
+						buildFilterConditions(recipeStepVesselsTableName, true, false),
+						buildCursorLimitClause(recipeStepVesselsTableName),
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
+				{
+					Annotation: QueryAnnotation{
+						Name: "UpdateRecipeStepVessel",
+						Type: ExecRowsType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
 	%s,
 	%s = %s
 WHERE %s IS NULL
 	AND %s = sqlc.arg(%s)
 	AND %s = sqlc.arg(%s);`,
-					recipeStepVesselsTableName,
-					strings.Join(applyToEach(filterForUpdate(recipeStepVesselsColumns), func(i int, s string) string {
-						return fmt.Sprintf("%s = sqlc.arg(%s)", s, s)
-					}), ",\n\t"),
-					lastUpdatedAtColumn, currentTimeExpression,
-					archivedAtColumn,
-					belongsToRecipeStepColumn, belongsToRecipeStepColumn,
-					idColumn, idColumn,
-				)),
+						recipeStepVesselsTableName,
+						strings.Join(applyToEach(filterForUpdate(recipeStepVesselsColumns), func(i int, s string) string {
+							return fmt.Sprintf("%s = sqlc.arg(%s)", s, s)
+						}), ",\n\t"),
+						lastUpdatedAtColumn, currentTimeExpression,
+						archivedAtColumn,
+						belongsToRecipeStepColumn, belongsToRecipeStepColumn,
+						idColumn, idColumn,
+					)),
+				},
 			},
-		}
+		)
 	default:
 		return nil
 	}

--- a/backend/cmd/tools/codegen/queries/mealplanning_recipe_steps.go
+++ b/backend/cmd/tools/codegen/queries/mealplanning_recipe_steps.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"fmt"
+	"slices"
 	"strings"
+
+	"github.com/primandproper/platform-go/v11/database/querygen"
 
 	"github.com/cristalhq/builq"
 )
@@ -42,8 +45,6 @@ func buildRecipeStepsQueries(database string) []*Query {
 	switch database {
 	case postgres:
 
-		insertColumns := filterForInsert(recipeStepsColumns)
-
 		fullSelectColumns := mergeColumns(
 			applyToEach(filterFromSlice(recipeStepsColumns, preparationIDColumn), func(i int, s string) string {
 				return fmt.Sprintf("%s.%s", recipeStepsTableName, s)
@@ -54,46 +55,19 @@ func buildRecipeStepsQueries(database string) []*Query {
 			2,
 		)
 
-		return []*Query{
-			{
-				Annotation: QueryAnnotation{
-					Name: "ArchiveRecipeStep",
-					Type: ExecRowsType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET %s = %s WHERE %s IS NULL AND %s = sqlc.arg(%s) AND %s = sqlc.arg(%s);`,
-					recipeStepsTableName,
-					archivedAtColumn,
-					currentTimeExpression,
-					archivedAtColumn,
-					belongsToRecipeColumn,
-					belongsToRecipeColumn,
-					idColumn,
-					idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CreateRecipeStep",
-					Type: ExecType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`INSERT INTO %s (
-	%s
-) VALUES (
-	%s
-);`,
-					recipeStepsTableName,
-					strings.Join(insertColumns, ",\n\t"),
-					strings.Join(applyToEach(insertColumns, func(i int, s string) string {
-						return fmt.Sprintf("sqlc.arg(%s)", s)
-					}), ",\n\t"),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CheckRecipeStepExistence",
-					Type: OneType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT EXISTS (
+		return slices.Concat(
+			querygen.StandardCRUD(recipeStepsTableName, recipeStepsColumns,
+				querygen.WithEntity("RecipeStep", "RecipeSteps"),
+				querygen.WithOwnership(belongsToRecipeColumn),
+				querygen.WithOmitted(querygen.ExistsQuery, querygen.GetQuery, querygen.ListQuery),
+			),
+			[]*Query{
+				{
+					Annotation: QueryAnnotation{
+						Name: "CheckRecipeStepExistence",
+						Type: OneType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT EXISTS (
 	SELECT %s.%s
 	FROM %s
 		JOIN %s ON %s.%s=%s.%s
@@ -103,22 +77,22 @@ func buildRecipeStepsQueries(database string) []*Query {
 		AND %s.%s IS NULL
 		AND %s.%s = sqlc.arg(%s)
 );`,
-					recipeStepsTableName, idColumn,
-					recipeStepsTableName,
-					recipesTableName, recipeStepsTableName, belongsToRecipeColumn, recipesTableName, idColumn,
-					recipeStepsTableName, archivedAtColumn,
-					recipeStepsTableName, belongsToRecipeColumn, recipeIDColumn,
-					recipeStepsTableName, idColumn, recipeStepIDColumn,
-					recipesTableName, archivedAtColumn,
-					recipesTableName, idColumn, recipeIDColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetRecipeStep",
-					Type: OneType,
+						recipeStepsTableName, idColumn,
+						recipeStepsTableName,
+						recipesTableName, recipeStepsTableName, belongsToRecipeColumn, recipesTableName, idColumn,
+						recipeStepsTableName, archivedAtColumn,
+						recipeStepsTableName, belongsToRecipeColumn, recipeIDColumn,
+						recipeStepsTableName, idColumn, recipeStepIDColumn,
+						recipesTableName, archivedAtColumn,
+						recipesTableName, idColumn, recipeIDColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetRecipeStep",
+						Type: OneType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s
 FROM %s
 	JOIN %s ON %s.%s=%s.%s
@@ -128,23 +102,23 @@ WHERE %s.%s IS NULL
 	AND %s.%s = sqlc.arg(%s)
 	AND %s.%s IS NULL
 	AND %s.%s = sqlc.arg(%s);`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					recipeStepsTableName,
-					recipesTableName, recipeStepsTableName, belongsToRecipeColumn, recipesTableName, idColumn,
-					validPreparationsTableName, recipeStepsTableName, preparationIDColumn, validPreparationsTableName, idColumn,
-					recipeStepsTableName, archivedAtColumn,
-					recipeStepsTableName, belongsToRecipeColumn, recipeIDColumn,
-					recipeStepsTableName, idColumn, recipeStepIDColumn,
-					recipesTableName, archivedAtColumn,
-					recipesTableName, idColumn, recipeIDColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetRecipeSteps",
-					Type: ManyType,
+						strings.Join(fullSelectColumns, ",\n\t"),
+						recipeStepsTableName,
+						recipesTableName, recipeStepsTableName, belongsToRecipeColumn, recipesTableName, idColumn,
+						validPreparationsTableName, recipeStepsTableName, preparationIDColumn, validPreparationsTableName, idColumn,
+						recipeStepsTableName, archivedAtColumn,
+						recipeStepsTableName, belongsToRecipeColumn, recipeIDColumn,
+						recipeStepsTableName, idColumn, recipeStepIDColumn,
+						recipesTableName, archivedAtColumn,
+						recipesTableName, idColumn, recipeIDColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetRecipeSteps",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s
@@ -156,61 +130,41 @@ WHERE %s.%s IS NULL
 	AND %s.%s IS NULL
 	%s
 %s;`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					buildFilterCountSelect(recipeStepsTableName, true, true, []string{}),
-					buildTotalCountSelect(recipeStepsTableName, true, []string{}),
-					recipeStepsTableName,
-					recipesTableName, recipeStepsTableName, belongsToRecipeColumn, recipesTableName, idColumn,
-					validPreparationsTableName, recipeStepsTableName, preparationIDColumn, validPreparationsTableName, idColumn,
-					recipeStepsTableName, archivedAtColumn,
-					recipeStepsTableName, belongsToRecipeColumn, recipeIDColumn,
-					recipesTableName, archivedAtColumn,
-					buildFilterConditions(recipeStepsTableName, true, false),
-					buildCursorLimitClause(recipeStepsTableName),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetRecipeStepByRecipeID",
-					Type: OneType,
+						strings.Join(fullSelectColumns, ",\n\t"),
+						buildFilterCountSelect(recipeStepsTableName, true, true, []string{}),
+						buildTotalCountSelect(recipeStepsTableName, true, []string{}),
+						recipeStepsTableName,
+						recipesTableName, recipeStepsTableName, belongsToRecipeColumn, recipesTableName, idColumn,
+						validPreparationsTableName, recipeStepsTableName, preparationIDColumn, validPreparationsTableName, idColumn,
+						recipeStepsTableName, archivedAtColumn,
+						recipeStepsTableName, belongsToRecipeColumn, recipeIDColumn,
+						recipesTableName, archivedAtColumn,
+						buildFilterConditions(recipeStepsTableName, true, false),
+						buildCursorLimitClause(recipeStepsTableName),
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetRecipeStepByRecipeID",
+						Type: OneType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s
 FROM %s
 	JOIN %s ON %s.%s=%s.%s
 	JOIN %s ON %s.%s=%s.%s
 WHERE %s.%s IS NULL
 	AND %s.%s = sqlc.arg(%s);`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					recipeStepsTableName,
-					recipesTableName, recipeStepsTableName, belongsToRecipeColumn, recipesTableName, idColumn,
-					validPreparationsTableName, recipeStepsTableName, preparationIDColumn, validPreparationsTableName, idColumn,
-					recipeStepsTableName, archivedAtColumn,
-					recipeStepsTableName, idColumn, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "UpdateRecipeStep",
-					Type: ExecRowsType,
+						strings.Join(fullSelectColumns, ",\n\t"),
+						recipeStepsTableName,
+						recipesTableName, recipeStepsTableName, belongsToRecipeColumn, recipesTableName, idColumn,
+						validPreparationsTableName, recipeStepsTableName, preparationIDColumn, validPreparationsTableName, idColumn,
+						recipeStepsTableName, archivedAtColumn,
+						recipeStepsTableName, idColumn, idColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
-	%s,
-	%s = %s
-WHERE %s IS NULL
-	AND %s = sqlc.arg(%s)
-	AND %s = sqlc.arg(%s);`,
-					recipeStepsTableName,
-					strings.Join(applyToEach(filterForUpdate(recipeStepsColumns, belongsToRecipeColumn), func(i int, s string) string {
-						return fmt.Sprintf("%s = sqlc.arg(%s)", s, s)
-					}), ",\n\t"),
-					lastUpdatedAtColumn, currentTimeExpression,
-					archivedAtColumn,
-					belongsToRecipeColumn, belongsToRecipeColumn,
-					idColumn, idColumn,
-				)),
 			},
-		}
+		)
 	default:
 		return nil
 	}

--- a/backend/cmd/tools/codegen/queries/mealplanning_recipes.go
+++ b/backend/cmd/tools/codegen/queries/mealplanning_recipes.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"fmt"
+	"slices"
 	"strings"
+
+	"github.com/primandproper/platform-go/v11/database/querygen"
 
 	"github.com/cristalhq/builq"
 )
@@ -48,8 +51,6 @@ func buildRecipesQueries(database string) []*Query {
 	switch database {
 	case postgres:
 
-		insertColumns := filterForInsert(recipesColumns, lastValidatedAtColumn)
-
 		fullSelectColumns := append(
 			applyToEach(recipesColumns, func(i int, s string) string {
 				return fmt.Sprintf("%s.%s", recipesTableName, s)
@@ -65,63 +66,37 @@ func buildRecipesQueries(database string) []*Query {
 			)...,
 		)
 
-		return []*Query{
-			{
-				Annotation: QueryAnnotation{
-					Name: "ArchiveRecipe",
-					Type: ExecRowsType,
+		return slices.Concat(
+			querygen.StandardCRUD(recipesTableName, recipesColumns,
+				querygen.WithEntity("Recipe", "Recipes"),
+				querygen.WithDatabaseOwned(lastValidatedAtColumn),
+				querygen.WithImmutable(nameColumn, slugColumn, "source", "source_isbn", descriptionColumn, "inspired_by_recipe_id", "min_estimated_portions", "max_estimated_portions", "portion_name", "plural_portion_name", eligibleForMealsColumn, "yields_component_type", createdByUserColumn),
+				querygen.WithQueryName(querygen.UpdateQuery, "UpdateRecipeStatus"),
+				querygen.WithOmitted(querygen.ArchiveQuery, querygen.GetQuery, querygen.ListQuery, querygen.MarkAsIndexedQuery),
+			),
+			[]*Query{
+				{
+					Annotation: QueryAnnotation{
+						Name: "ArchiveRecipe",
+						Type: ExecRowsType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET %s = %s WHERE %s IS NULL AND %s = sqlc.arg(%s) AND %s = sqlc.arg(%s);`,
+						recipesTableName,
+						archivedAtColumn,
+						currentTimeExpression,
+						archivedAtColumn,
+						createdByUserColumn,
+						createdByUserColumn,
+						idColumn,
+						idColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET %s = %s WHERE %s IS NULL AND %s = sqlc.arg(%s) AND %s = sqlc.arg(%s);`,
-					recipesTableName,
-					archivedAtColumn,
-					currentTimeExpression,
-					archivedAtColumn,
-					createdByUserColumn,
-					createdByUserColumn,
-					idColumn,
-					idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CreateRecipe",
-					Type: ExecType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`INSERT INTO %s (
-	%s
-) VALUES (
-	%s
-);`,
-					recipesTableName,
-					strings.Join(insertColumns, ",\n\t"),
-					strings.Join(applyToEach(insertColumns, func(i int, s string) string {
-						return fmt.Sprintf("sqlc.arg(%s)", s)
-					}), ",\n\t"),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CheckRecipeExistence",
-					Type: OneType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT EXISTS (
-	SELECT %s.%s
-	FROM %s
-	WHERE %s.%s IS NULL
-		AND %s.%s = sqlc.arg(%s)
-);`,
-					recipesTableName, idColumn,
-					recipesTableName,
-					recipesTableName, archivedAtColumn,
-					recipesTableName, idColumn, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetRecipeByID",
-					Type: ManyType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetRecipeByID",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s
 FROM %s
 	LEFT JOIN %s ON %s.%s=%s.%s AND %s.%s IS NULL
@@ -129,21 +104,21 @@ FROM %s
 WHERE %s.%s IS NULL
 	AND %s.%s = sqlc.arg(%s)
 ORDER BY %s.%s;`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					recipesTableName,
-					recipeStepsTableName, recipesTableName, idColumn, recipeStepsTableName, belongsToRecipeColumn, recipeStepsTableName, archivedAtColumn,
-					validPreparationsTableName, recipeStepsTableName, preparationIDColumn, validPreparationsTableName, idColumn,
-					recipesTableName, archivedAtColumn,
-					recipesTableName, idColumn, recipeIDColumn,
-					recipeStepsTableName, indexColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetRecipeByIDAndAuthorID",
-					Type: ManyType,
+						strings.Join(fullSelectColumns, ",\n\t"),
+						recipesTableName,
+						recipeStepsTableName, recipesTableName, idColumn, recipeStepsTableName, belongsToRecipeColumn, recipeStepsTableName, archivedAtColumn,
+						validPreparationsTableName, recipeStepsTableName, preparationIDColumn, validPreparationsTableName, idColumn,
+						recipesTableName, archivedAtColumn,
+						recipesTableName, idColumn, recipeIDColumn,
+						recipeStepsTableName, indexColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetRecipeByIDAndAuthorID",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s
 FROM %s
 	LEFT JOIN %s ON %s.%s=%s.%s AND %s.%s IS NULL
@@ -152,22 +127,22 @@ WHERE %s.%s IS NULL
 	AND %s.%s = sqlc.arg(%s)
 	AND %s.%s = sqlc.arg(%s)
 ORDER BY %s.%s;`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					recipesTableName,
-					recipeStepsTableName, recipesTableName, idColumn, recipeStepsTableName, belongsToRecipeColumn, recipeStepsTableName, archivedAtColumn,
-					validPreparationsTableName, recipeStepsTableName, preparationIDColumn, validPreparationsTableName, idColumn,
-					recipesTableName, archivedAtColumn,
-					recipesTableName, idColumn, recipeIDColumn,
-					recipesTableName, createdByUserColumn, createdByUserColumn,
-					recipeStepsTableName, indexColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetRecipes",
-					Type: ManyType,
+						strings.Join(fullSelectColumns, ",\n\t"),
+						recipesTableName,
+						recipeStepsTableName, recipesTableName, idColumn, recipeStepsTableName, belongsToRecipeColumn, recipeStepsTableName, archivedAtColumn,
+						validPreparationsTableName, recipeStepsTableName, preparationIDColumn, validPreparationsTableName, idColumn,
+						recipesTableName, archivedAtColumn,
+						recipesTableName, idColumn, recipeIDColumn,
+						recipesTableName, createdByUserColumn, createdByUserColumn,
+						recipeStepsTableName, indexColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetRecipes",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s
@@ -176,24 +151,24 @@ FROM %s
 	AND %s.%s = COALESCE(sqlc.narg(%s), 'approved')::recipe_status
 	%s
 %s;`,
-					strings.Join(applyToEach(recipesColumns, func(i int, s string) string {
-						return fmt.Sprintf("%s.%s", recipesTableName, s)
-					}), ",\n\t"),
-					buildFilterCountSelect(recipesTableName, true, true, []string{}),
-					buildTotalCountSelect(recipesTableName, true, []string{}),
-					recipesTableName,
-					recipesTableName, archivedAtColumn,
-					recipesTableName, statusColumn, statusColumn,
-					buildFilterConditions(recipesTableName, true, false),
-					buildCursorLimitClause(recipesTableName),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetRecipesCreatedByUser",
-					Type: ManyType,
+						strings.Join(applyToEach(recipesColumns, func(i int, s string) string {
+							return fmt.Sprintf("%s.%s", recipesTableName, s)
+						}), ",\n\t"),
+						buildFilterCountSelect(recipesTableName, true, true, []string{}),
+						buildTotalCountSelect(recipesTableName, true, []string{}),
+						recipesTableName,
+						recipesTableName, archivedAtColumn,
+						recipesTableName, statusColumn, statusColumn,
+						buildFilterConditions(recipesTableName, true, false),
+						buildCursorLimitClause(recipesTableName),
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetRecipesCreatedByUser",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s
@@ -202,24 +177,24 @@ FROM %s
 	%s.%s = sqlc.arg(%s)
 	%s
 %s;`,
-					strings.Join(applyToEach(recipesColumns, func(i int, s string) string {
-						return fmt.Sprintf("%s.%s", recipesTableName, s)
-					}), ",\n\t"),
-					buildFilterCountSelect(recipesTableName, true, true, []string{}, fmt.Sprintf("%s.%s = sqlc.arg(%s)", recipesTableName, createdByUserColumn, createdByUserColumn)),
-					buildTotalCountSelect(recipesTableName, true, []string{}, fmt.Sprintf("%s.%s = sqlc.arg(%s)", recipesTableName, createdByUserColumn, createdByUserColumn)),
-					recipesTableName,
-					recipesTableName, archivedAtColumn,
-					recipesTableName, createdByUserColumn, createdByUserColumn,
-					buildFilterConditions(recipesTableName, true, false, fmt.Sprintf("%s.%s = sqlc.arg(%s)", recipesTableName, createdByUserColumn, createdByUserColumn)),
-					buildCursorLimitClause(recipesTableName),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetRecipesWithIDs",
-					Type: ManyType,
+						strings.Join(applyToEach(recipesColumns, func(i int, s string) string {
+							return fmt.Sprintf("%s.%s", recipesTableName, s)
+						}), ",\n\t"),
+						buildFilterCountSelect(recipesTableName, true, true, []string{}, fmt.Sprintf("%s.%s = sqlc.arg(%s)", recipesTableName, createdByUserColumn, createdByUserColumn)),
+						buildTotalCountSelect(recipesTableName, true, []string{}, fmt.Sprintf("%s.%s = sqlc.arg(%s)", recipesTableName, createdByUserColumn, createdByUserColumn)),
+						recipesTableName,
+						recipesTableName, archivedAtColumn,
+						recipesTableName, createdByUserColumn, createdByUserColumn,
+						buildFilterConditions(recipesTableName, true, false, fmt.Sprintf("%s.%s = sqlc.arg(%s)", recipesTableName, createdByUserColumn, createdByUserColumn)),
+						buildCursorLimitClause(recipesTableName),
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetRecipesWithIDs",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s
 FROM %s
 	LEFT JOIN %s ON %s.%s=%s.%s AND %s.%s IS NULL
@@ -227,21 +202,21 @@ FROM %s
 WHERE %s.%s IS NULL
 	AND %s.%s = ANY(sqlc.arg(ids)::text[])
 ORDER BY %s.%s ASC;`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					recipesTableName,
-					recipeStepsTableName, recipesTableName, idColumn, recipeStepsTableName, belongsToRecipeColumn, recipeStepsTableName, archivedAtColumn,
-					validPreparationsTableName, recipeStepsTableName, preparationIDColumn, validPreparationsTableName, idColumn,
-					recipesTableName, archivedAtColumn,
-					recipesTableName, idColumn,
-					recipesTableName, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "RecipeSearch",
-					Type: ManyType,
+						strings.Join(fullSelectColumns, ",\n\t"),
+						recipesTableName,
+						recipeStepsTableName, recipesTableName, idColumn, recipeStepsTableName, belongsToRecipeColumn, recipeStepsTableName, archivedAtColumn,
+						validPreparationsTableName, recipeStepsTableName, preparationIDColumn, validPreparationsTableName, idColumn,
+						recipesTableName, archivedAtColumn,
+						recipesTableName, idColumn,
+						recipesTableName, idColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "RecipeSearch",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s
@@ -250,24 +225,24 @@ WHERE %s.%s IS NULL
 	AND %s.%s %s
 	%s
 %s;`,
-					strings.Join(applyToEach(recipesColumns, func(i int, s string) string {
-						return fmt.Sprintf("%s.%s", recipesTableName, s)
-					}), ",\n\t"),
-					buildFilterCountSelect(recipesTableName, true, true, []string{}),
-					buildTotalCountSelect(recipesTableName, true, []string{}),
-					recipesTableName,
-					recipesTableName, archivedAtColumn,
-					recipesTableName, nameColumn, buildILIKEForArgument("query"),
-					buildFilterConditions(recipesTableName, true, false),
-					buildCursorLimitClause(recipesTableName),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "SearchForMealEligibleRecipes",
-					Type: ManyType,
+						strings.Join(applyToEach(recipesColumns, func(i int, s string) string {
+							return fmt.Sprintf("%s.%s", recipesTableName, s)
+						}), ",\n\t"),
+						buildFilterCountSelect(recipesTableName, true, true, []string{}),
+						buildTotalCountSelect(recipesTableName, true, []string{}),
+						recipesTableName,
+						recipesTableName, archivedAtColumn,
+						recipesTableName, nameColumn, buildILIKEForArgument("query"),
+						buildFilterConditions(recipesTableName, true, false),
+						buildCursorLimitClause(recipesTableName),
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "SearchForMealEligibleRecipes",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s
@@ -278,26 +253,26 @@ WHERE %s.%s IS NULL
 	AND %s.%s %s
 	%s
 %s;`,
-					strings.Join(applyToEach(recipesColumns, func(i int, s string) string {
-						return fmt.Sprintf("%s.%s", recipesTableName, s)
-					}), ",\n\t"),
-					buildFilterCountSelect(recipesTableName, true, true, []string{}),
-					buildTotalCountSelect(recipesTableName, true, []string{}),
-					recipesTableName,
-					recipesTableName, archivedAtColumn,
-					recipesTableName, eligibleForMealsColumn,
-					recipesTableName, statusColumn,
-					recipesTableName, nameColumn, buildILIKEForArgument("query"),
-					buildFilterConditions(recipesTableName, true, false),
-					buildCursorLimitClause(recipesTableName),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "SearchForRecipesWithInstrumentOwnership",
-					Type: ManyType,
+						strings.Join(applyToEach(recipesColumns, func(i int, s string) string {
+							return fmt.Sprintf("%s.%s", recipesTableName, s)
+						}), ",\n\t"),
+						buildFilterCountSelect(recipesTableName, true, true, []string{}),
+						buildTotalCountSelect(recipesTableName, true, []string{}),
+						recipesTableName,
+						recipesTableName, archivedAtColumn,
+						recipesTableName, eligibleForMealsColumn,
+						recipesTableName, statusColumn,
+						recipesTableName, nameColumn, buildILIKEForArgument("query"),
+						buildFilterConditions(recipesTableName, true, false),
+						buildCursorLimitClause(recipesTableName),
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "SearchForRecipesWithInstrumentOwnership",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s
@@ -309,61 +284,54 @@ WHERE %s.%s IS NULL
 		SELECT 1 FROM recipe_step_instruments rsi
 		JOIN recipe_steps rs ON rsi.belongs_to_recipe_step = rs.id
 		WHERE rs.belongs_to_recipe = %s.%s
-			AND rsi.archived_at IS NULL
-			AND rs.archived_at IS NULL
-			AND rsi.optional = false
-			AND rsi.instrument_id IS NOT NULL
-			AND rsi.instrument_id NOT IN (
-				SELECT valid_instrument_id FROM account_instrument_ownerships
-				WHERE belongs_to_account = sqlc.arg(account_id) AND archived_at IS NULL
-			)
+				AND rsi.archived_at IS NULL
+				AND rs.archived_at IS NULL
+				AND rsi.optional = false
+				AND rsi.instrument_id IS NOT NULL
+				AND rsi.instrument_id NOT IN (
+					SELECT valid_instrument_id FROM account_instrument_ownerships
+					WHERE belongs_to_account = sqlc.arg(account_id) AND archived_at IS NULL
+				)
 	)
 %s;`,
-					strings.Join(applyToEach(recipesColumns, func(i int, s string) string {
-						return fmt.Sprintf("%s.%s", recipesTableName, s)
-					}), ",\n\t"),
-					buildFilterCountSelect(recipesTableName, true, true, []string{}),
-					buildTotalCountSelect(recipesTableName, true, []string{}),
-					recipesTableName,
-					recipesTableName, archivedAtColumn,
-					recipesTableName, nameColumn, buildILIKEForArgument("query"),
-					buildFilterConditions(recipesTableName, true, false),
-					recipesTableName, idColumn,
-					buildCursorLimitClause(recipesTableName),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "ScanRecipeIDsForReindex",
-					Type: ManyType,
+						strings.Join(applyToEach(recipesColumns, func(i int, s string) string {
+							return fmt.Sprintf("%s.%s", recipesTableName, s)
+						}), ",\n\t"),
+						buildFilterCountSelect(recipesTableName, true, true, []string{}),
+						buildTotalCountSelect(recipesTableName, true, []string{}),
+						recipesTableName,
+						recipesTableName, archivedAtColumn,
+						recipesTableName, nameColumn, buildILIKEForArgument("query"),
+						buildFilterConditions(recipesTableName, true, false),
+						recipesTableName, idColumn,
+						buildCursorLimitClause(recipesTableName),
+					)),
 				},
-				Content: buildReindexScanQuery(recipesTableName),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetRecipesNeedingIndexing",
-					Type: ManyType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT %s.%s
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetRecipesNeedingIndexing",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT %s.%s
 FROM %s
 WHERE %s.%s IS NULL
 	AND (
 		%s.%s IS NULL
 		OR %s.%s < %s - '24 hours'::INTERVAL
 	);`,
-					recipesTableName, idColumn,
-					recipesTableName,
-					recipesTableName, archivedAtColumn,
-					recipesTableName, lastIndexedAtColumn,
-					recipesTableName, lastIndexedAtColumn, currentTimeExpression,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetRecipeIDsForMeal",
-					Type: ManyType,
+						recipesTableName, idColumn,
+						recipesTableName,
+						recipesTableName, archivedAtColumn,
+						recipesTableName, lastIndexedAtColumn,
+						recipesTableName, lastIndexedAtColumn, currentTimeExpression,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT %s.%s
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetRecipeIDsForMeal",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT %s.%s
 FROM %s
 	JOIN %s ON %s.%s = %s.%s
 	JOIN %s ON %s.%s = %s.%s
@@ -372,72 +340,56 @@ WHERE
 	AND %s.%s = sqlc.arg(%s)
 GROUP BY %s.%s
 ORDER BY %s.%s;`,
-					recipesTableName, idColumn,
-					recipesTableName,
-					mealComponentsTableName, mealComponentsTableName, recipeIDColumn, recipesTableName, idColumn,
-					mealsTableName, mealComponentsTableName, belongsToMealColumn, mealsTableName, idColumn,
-					recipesTableName, archivedAtColumn,
-					mealsTableName, idColumn, mealIDColumn,
-					recipesTableName, idColumn,
-					recipesTableName, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "UpdateRecipe",
-					Type: ExecRowsType,
+						recipesTableName, idColumn,
+						recipesTableName,
+						mealComponentsTableName, mealComponentsTableName, recipeIDColumn, recipesTableName, idColumn,
+						mealsTableName, mealComponentsTableName, belongsToMealColumn, mealsTableName, idColumn,
+						recipesTableName, archivedAtColumn,
+						mealsTableName, idColumn, mealIDColumn,
+						recipesTableName, idColumn,
+						recipesTableName, idColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
+				{
+					Annotation: QueryAnnotation{
+						Name: "UpdateRecipe",
+						Type: ExecRowsType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
 	%s,
 	%s = %s
 WHERE %s IS NULL
 	AND %s = sqlc.arg(%s)
 	AND %s = sqlc.arg(%s);`,
-					recipesTableName,
-					strings.Join(applyToEach(filterForUpdate(recipesColumns, statusColumn, lastValidatedAtColumn, createdByUserColumn), func(i int, s string) string {
-						return fmt.Sprintf("%s = sqlc.arg(%s)", s, s)
-					}), ",\n\t"),
-					lastUpdatedAtColumn, currentTimeExpression,
-					archivedAtColumn,
-					createdByUserColumn, createdByUserColumn,
-					idColumn, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "UpdateRecipeStatus",
-					Type: ExecRowsType,
+						recipesTableName,
+						strings.Join(applyToEach(filterForUpdate(recipesColumns, statusColumn, lastValidatedAtColumn, createdByUserColumn), func(i int, s string) string {
+							return fmt.Sprintf("%s = sqlc.arg(%s)", s, s)
+						}), ",\n\t"),
+						lastUpdatedAtColumn, currentTimeExpression,
+						archivedAtColumn,
+						createdByUserColumn, createdByUserColumn,
+						idColumn, idColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
-	%s = sqlc.arg(%s),
-	%s = %s
-WHERE %s IS NULL
-	AND %s = sqlc.arg(%s);`,
-					recipesTableName,
-					statusColumn, statusColumn,
-					lastUpdatedAtColumn, currentTimeExpression,
-					archivedAtColumn,
-					idColumn, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "MarkRecipesAsIndexed",
-					Type: ExecRowsType,
-				},
-				// Bulk, and named for what querygen emits, so migrating this table to
-				// StandardCRUD deletes this declaration without renaming anything.
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
+				{
+					Annotation: QueryAnnotation{
+						Name: "MarkRecipesAsIndexed",
+						Type: ExecRowsType,
+					},
+					// Bulk, and named for what querygen emits, so migrating this table to
+					// StandardCRUD deletes this declaration without renaming anything.
+					Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
 	%s = %s
 WHERE %s = ANY(sqlc.arg(%s)::text[]);`,
-					recipesTableName,
-					lastIndexedAtColumn,
-					currentTimeExpression,
-					idColumn,
-					idsArg,
-				)),
+						recipesTableName,
+						lastIndexedAtColumn,
+						currentTimeExpression,
+						idColumn,
+						idsArg,
+					)),
+				},
 			},
-		}
+		)
 	default:
 		return nil
 	}

--- a/backend/cmd/tools/codegen/queries/mealplanning_user_ingredient_preferences.go
+++ b/backend/cmd/tools/codegen/queries/mealplanning_user_ingredient_preferences.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"fmt"
+	"slices"
 	"strings"
+
+	"github.com/primandproper/platform-go/v11/database/querygen"
 
 	"github.com/cristalhq/builq"
 )
@@ -33,8 +36,6 @@ func buildUserIngredientPreferencesQueries(database string) []*Query {
 	switch database {
 	case postgres:
 
-		insertColumns := filterForInsert(userIngredientPreferencesColumns)
-
 		fullSelectColumns := mergeColumns(
 			applyToEach(filterFromSlice(userIngredientPreferencesColumns, userIngredientPreferencesIngredientColumn), func(i int, s string) string {
 				return fmt.Sprintf("%s.%s", userIngredientPreferencesTableName, s)
@@ -45,65 +46,19 @@ func buildUserIngredientPreferencesQueries(database string) []*Query {
 			1,
 		)
 
-		return []*Query{
-			{
-				Annotation: QueryAnnotation{
-					Name: "ArchiveUserIngredientPreference",
-					Type: ExecRowsType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET %s = %s WHERE %s IS NULL AND %s = sqlc.arg(%s) AND %s = sqlc.arg(%s);`,
-					userIngredientPreferencesTableName,
-					archivedAtColumn,
-					currentTimeExpression,
-					archivedAtColumn,
-					belongsToUserColumn,
-					belongsToUserColumn,
-					idColumn,
-					idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CreateUserIngredientPreference",
-					Type: ExecType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`INSERT INTO %s (
-	%s
-) VALUES (
-	%s
-);`,
-					userIngredientPreferencesTableName,
-					strings.Join(insertColumns, ",\n\t"),
-					strings.Join(applyToEach(insertColumns, func(i int, s string) string {
-						return fmt.Sprintf("sqlc.arg(%s)", s)
-					}), ",\n\t"),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CheckUserIngredientPreferenceExistence",
-					Type: OneType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT EXISTS (
-	SELECT %s.%s
-	FROM %s
-	WHERE %s.%s IS NULL
-		AND %s.%s = sqlc.arg(%s)
-		AND %s.%s = sqlc.arg(%s)
-);`,
-					userIngredientPreferencesTableName, idColumn,
-					userIngredientPreferencesTableName,
-					userIngredientPreferencesTableName, archivedAtColumn,
-					userIngredientPreferencesTableName, idColumn, idColumn,
-					userIngredientPreferencesTableName, belongsToUserColumn, belongsToUserColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetUserIngredientPreferencesForUser",
-					Type: ManyType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+		return slices.Concat(
+			querygen.StandardCRUD(userIngredientPreferencesTableName, userIngredientPreferencesColumns,
+				querygen.WithEntity("UserIngredientPreference", "UserIngredientPreferences"),
+				querygen.WithOwnership(belongsToUserColumn),
+				querygen.WithOmitted(querygen.GetQuery, querygen.ListQuery),
+			),
+			[]*Query{
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetUserIngredientPreferencesForUser",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s
@@ -114,24 +69,24 @@ WHERE %s.%s IS NULL
 	AND %s.%s IS NULL
 	%s
 %s;`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					buildFilterCountSelect(userIngredientPreferencesTableName, true, true, []string{}),
-					buildTotalCountSelect(userIngredientPreferencesTableName, true, []string{}),
-					userIngredientPreferencesTableName,
-					validIngredientsTableName, validIngredientsTableName, idColumn, userIngredientPreferencesTableName, userIngredientPreferencesIngredientColumn,
-					userIngredientPreferencesTableName, archivedAtColumn,
-					userIngredientPreferencesTableName, belongsToUserColumn, belongsToUserColumn,
-					validIngredientsTableName, archivedAtColumn,
-					buildFilterConditions(userIngredientPreferencesTableName, true, false),
-					buildCursorLimitClause(userIngredientPreferencesTableName),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetUserIngredientPreference",
-					Type: OneType,
+						strings.Join(fullSelectColumns, ",\n\t"),
+						buildFilterCountSelect(userIngredientPreferencesTableName, true, true, []string{}),
+						buildTotalCountSelect(userIngredientPreferencesTableName, true, []string{}),
+						userIngredientPreferencesTableName,
+						validIngredientsTableName, validIngredientsTableName, idColumn, userIngredientPreferencesTableName, userIngredientPreferencesIngredientColumn,
+						userIngredientPreferencesTableName, archivedAtColumn,
+						userIngredientPreferencesTableName, belongsToUserColumn, belongsToUserColumn,
+						validIngredientsTableName, archivedAtColumn,
+						buildFilterConditions(userIngredientPreferencesTableName, true, false),
+						buildCursorLimitClause(userIngredientPreferencesTableName),
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetUserIngredientPreference",
+						Type: OneType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s
 FROM %s
 	JOIN %s ON %s.%s = %s.%s
@@ -139,37 +94,17 @@ WHERE %s.%s IS NULL
 	AND %s.%s IS NULL
 	AND %s.%s = sqlc.arg(%s)
 	AND %s.%s = sqlc.arg(%s);`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					userIngredientPreferencesTableName,
-					validIngredientsTableName, validIngredientsTableName, idColumn, userIngredientPreferencesTableName, userIngredientPreferencesIngredientColumn,
-					userIngredientPreferencesTableName, archivedAtColumn,
-					validIngredientsTableName, archivedAtColumn,
-					userIngredientPreferencesTableName, idColumn, idColumn,
-					userIngredientPreferencesTableName, belongsToUserColumn, belongsToUserColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "UpdateUserIngredientPreference",
-					Type: ExecRowsType,
+						strings.Join(fullSelectColumns, ",\n\t"),
+						userIngredientPreferencesTableName,
+						validIngredientsTableName, validIngredientsTableName, idColumn, userIngredientPreferencesTableName, userIngredientPreferencesIngredientColumn,
+						userIngredientPreferencesTableName, archivedAtColumn,
+						validIngredientsTableName, archivedAtColumn,
+						userIngredientPreferencesTableName, idColumn, idColumn,
+						userIngredientPreferencesTableName, belongsToUserColumn, belongsToUserColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
-	%s,
-	%s = %s
-WHERE %s IS NULL
-	AND %s = sqlc.arg(%s)
-	AND %s = sqlc.arg(%s);`,
-					userIngredientPreferencesTableName,
-					strings.Join(applyToEach(filterForUpdate(userIngredientPreferencesColumns, belongsToUserColumn), func(i int, s string) string {
-						return fmt.Sprintf("%s = sqlc.arg(%s)", s, s)
-					}), ",\n\t"),
-					lastUpdatedAtColumn, currentTimeExpression,
-					archivedAtColumn,
-					belongsToUserColumn, belongsToUserColumn,
-					idColumn, idColumn,
-				)),
 			},
-		}
+		)
 	default:
 		return nil
 	}

--- a/backend/cmd/tools/codegen/queries/mealplanning_valid_ingredient_groups.go
+++ b/backend/cmd/tools/codegen/queries/mealplanning_valid_ingredient_groups.go
@@ -32,8 +32,6 @@ func buildValidIngredientGroupsQueries(database string) []*Query {
 	switch database {
 	case postgres:
 
-		groupMemberInsertColumns := filterForInsert(validIngredientGroupMembersColumns)
-
 		fullMemberSelectColumns := mergeColumns(
 			applyToEach(filterFromSlice(validIngredientGroupMembersColumns, "valid_ingredient"), func(i int, s string) string {
 				return fmt.Sprintf("%s.%s", validIngredientGroupMembersTableName, s)
@@ -49,41 +47,12 @@ func buildValidIngredientGroupsQueries(database string) []*Query {
 				querygen.WithEntity("ValidIngredientGroup", "ValidIngredientGroups"),
 				querygen.WithOmitted(querygen.ListQuery),
 			),
+			querygen.StandardCRUD(validIngredientGroupMembersTableName, validIngredientGroupMembersColumns,
+				querygen.WithEntity("ValidIngredientGroupMember", "ValidIngredientGroupMembers"),
+				querygen.WithOwnership(belongsToGroupColumn),
+				querygen.WithOmitted(querygen.GetQuery, querygen.ExistsQuery, querygen.ListQuery, querygen.UpdateQuery),
+			),
 			[]*Query{
-				{
-					Annotation: QueryAnnotation{
-						Name: "ArchiveValidIngredientGroupMember",
-						Type: ExecRowsType,
-					},
-					Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
-	%s = %s
-WHERE %s IS NULL
-	AND %s = sqlc.arg(%s)
-	AND %s = sqlc.arg(%s);`,
-						validIngredientGroupMembersTableName,
-						archivedAtColumn, currentTimeExpression,
-						archivedAtColumn,
-						idColumn, idColumn,
-						belongsToGroupColumn, belongsToGroupColumn,
-					)),
-				},
-				{
-					Annotation: QueryAnnotation{
-						Name: "CreateValidIngredientGroupMember",
-						Type: ExecType,
-					},
-					Content: buildRawQuery((&builq.Builder{}).Addf(`INSERT INTO %s (
-	%s
-) VALUES (
-	%s
-);`,
-						validIngredientGroupMembersTableName,
-						strings.Join(groupMemberInsertColumns, ",\n\t"),
-						strings.Join(applyToEach(groupMemberInsertColumns, func(i int, s string) string {
-							return fmt.Sprintf("sqlc.arg(%s)", s)
-						}), ",\n\t"),
-					)),
-				},
 				{
 					Annotation: QueryAnnotation{
 						Name: "GetValidIngredientGroups",

--- a/backend/cmd/tools/codegen/queries/mealplanning_valid_ingredient_measurement_units.go
+++ b/backend/cmd/tools/codegen/queries/mealplanning_valid_ingredient_measurement_units.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"fmt"
+	"slices"
 	"strings"
+
+	"github.com/primandproper/platform-go/v11/database/querygen"
 
 	"github.com/cristalhq/builq"
 )
@@ -33,8 +36,6 @@ func buildValidIngredientMeasurementUnitsQueries(database string) []*Query {
 	switch database {
 	case postgres:
 
-		insertColumns := filterForInsert(validIngredientMeasurementUnitsColumns)
-
 		fullSelectColumns := mergeColumns(
 			applyToEach(filterFromSlice(validIngredientMeasurementUnitsColumns, "valid_ingredient_id", "valid_measurement_unit_id"), func(i int, s string) string {
 				return fmt.Sprintf("%s.%s as valid_ingredient_measurement_unit_%s", validIngredientMeasurementUnitsTableName, s, s)
@@ -49,61 +50,18 @@ func buildValidIngredientMeasurementUnitsQueries(database string) []*Query {
 			2,
 		)
 
-		return []*Query{
-			{
-				Annotation: QueryAnnotation{
-					Name: "ArchiveValidIngredientMeasurementUnit",
-					Type: ExecRowsType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET %s = %s WHERE %s IS NULL AND %s = sqlc.arg(%s);`,
-					validIngredientMeasurementUnitsTableName,
-					archivedAtColumn,
-					currentTimeExpression,
-					archivedAtColumn,
-					idColumn,
-					idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CreateValidIngredientMeasurementUnit",
-					Type: ExecType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`INSERT INTO %s (
-	%s
-) VALUES (
-	%s
-);`,
-					validIngredientMeasurementUnitsTableName,
-					strings.Join(insertColumns, ",\n\t"),
-					strings.Join(applyToEach(insertColumns, func(i int, s string) string {
-						return fmt.Sprintf("sqlc.arg(%s)", s)
-					}), ",\n\t"),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CheckValidIngredientMeasurementUnitExistence",
-					Type: OneType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT EXISTS (
-	SELECT %s.%s
-	FROM %s
-	WHERE %s.%s IS NULL
-		AND %s.%s = sqlc.arg(%s)
-);`,
-					validIngredientMeasurementUnitsTableName, idColumn,
-					validIngredientMeasurementUnitsTableName,
-					validIngredientMeasurementUnitsTableName, archivedAtColumn,
-					validIngredientMeasurementUnitsTableName, idColumn, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetValidIngredientMeasurementUnitsForIngredient",
-					Type: ManyType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+		return slices.Concat(
+			querygen.StandardCRUD(validIngredientMeasurementUnitsTableName, validIngredientMeasurementUnitsColumns,
+				querygen.WithEntity("ValidIngredientMeasurementUnit", "ValidIngredientMeasurementUnits"),
+				querygen.WithOmitted(querygen.GetQuery, querygen.ListQuery),
+			),
+			[]*Query{
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetValidIngredientMeasurementUnitsForIngredient",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s
@@ -117,30 +75,30 @@ WHERE
 	AND %s.%s = sqlc.arg(%s)
 	%s
 %s;`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					buildFilterCountSelect(validIngredientMeasurementUnitsTableName, true, true, []string{}),
-					buildTotalCountSelect(validIngredientMeasurementUnitsTableName, true, []string{}),
-					validIngredientMeasurementUnitsTableName,
-					validMeasurementUnitsTableName, validIngredientMeasurementUnitsTableName, validMeasurementUnitIDColumn, validMeasurementUnitsTableName, idColumn,
-					validIngredientsTableName, validIngredientMeasurementUnitsTableName, validIngredientIDColumn, validIngredientsTableName, idColumn,
-					validIngredientMeasurementUnitsTableName, archivedAtColumn,
-					validMeasurementUnitsTableName, archivedAtColumn,
-					validIngredientsTableName, archivedAtColumn,
-					validIngredientMeasurementUnitsTableName, validIngredientIDColumn, validIngredientIDColumn,
-					buildFilterConditions(
+						strings.Join(fullSelectColumns, ",\n\t"),
+						buildFilterCountSelect(validIngredientMeasurementUnitsTableName, true, true, []string{}),
+						buildTotalCountSelect(validIngredientMeasurementUnitsTableName, true, []string{}),
 						validIngredientMeasurementUnitsTableName,
-						true,
-						false,
-					),
-					buildCursorLimitClause(validIngredientMeasurementUnitsTableName),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetValidIngredientMeasurementUnitsForMeasurementUnit",
-					Type: ManyType,
+						validMeasurementUnitsTableName, validIngredientMeasurementUnitsTableName, validMeasurementUnitIDColumn, validMeasurementUnitsTableName, idColumn,
+						validIngredientsTableName, validIngredientMeasurementUnitsTableName, validIngredientIDColumn, validIngredientsTableName, idColumn,
+						validIngredientMeasurementUnitsTableName, archivedAtColumn,
+						validMeasurementUnitsTableName, archivedAtColumn,
+						validIngredientsTableName, archivedAtColumn,
+						validIngredientMeasurementUnitsTableName, validIngredientIDColumn, validIngredientIDColumn,
+						buildFilterConditions(
+							validIngredientMeasurementUnitsTableName,
+							true,
+							false,
+						),
+						buildCursorLimitClause(validIngredientMeasurementUnitsTableName),
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetValidIngredientMeasurementUnitsForMeasurementUnit",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s
@@ -154,26 +112,26 @@ WHERE
 	AND %s.%s = sqlc.arg(%s)
 	%s
 %s;`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					buildFilterCountSelect(validIngredientMeasurementUnitsTableName, true, true, []string{}),
-					buildTotalCountSelect(validIngredientMeasurementUnitsTableName, true, []string{}),
-					validIngredientMeasurementUnitsTableName,
-					validMeasurementUnitsTableName, validIngredientMeasurementUnitsTableName, validMeasurementUnitIDColumn, validMeasurementUnitsTableName, idColumn,
-					validIngredientsTableName, validIngredientMeasurementUnitsTableName, validIngredientIDColumn, validIngredientsTableName, idColumn,
-					validIngredientMeasurementUnitsTableName, archivedAtColumn,
-					validMeasurementUnitsTableName, archivedAtColumn,
-					validIngredientsTableName, archivedAtColumn,
-					validIngredientMeasurementUnitsTableName, validMeasurementUnitIDColumn, validMeasurementUnitIDColumn,
-					buildFilterConditions(validIngredientMeasurementUnitsTableName, true, false),
-					buildCursorLimitClause(validIngredientMeasurementUnitsTableName),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetValidIngredientMeasurementUnits",
-					Type: ManyType,
+						strings.Join(fullSelectColumns, ",\n\t"),
+						buildFilterCountSelect(validIngredientMeasurementUnitsTableName, true, true, []string{}),
+						buildTotalCountSelect(validIngredientMeasurementUnitsTableName, true, []string{}),
+						validIngredientMeasurementUnitsTableName,
+						validMeasurementUnitsTableName, validIngredientMeasurementUnitsTableName, validMeasurementUnitIDColumn, validMeasurementUnitsTableName, idColumn,
+						validIngredientsTableName, validIngredientMeasurementUnitsTableName, validIngredientIDColumn, validIngredientsTableName, idColumn,
+						validIngredientMeasurementUnitsTableName, archivedAtColumn,
+						validMeasurementUnitsTableName, archivedAtColumn,
+						validIngredientsTableName, archivedAtColumn,
+						validIngredientMeasurementUnitsTableName, validMeasurementUnitIDColumn, validMeasurementUnitIDColumn,
+						buildFilterConditions(validIngredientMeasurementUnitsTableName, true, false),
+						buildCursorLimitClause(validIngredientMeasurementUnitsTableName),
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetValidIngredientMeasurementUnits",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s
@@ -186,25 +144,25 @@ WHERE
 	AND %s.%s IS NULL
 	%s
 %s;`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					buildFilterCountSelect(validIngredientMeasurementUnitsTableName, true, true, []string{}),
-					buildTotalCountSelect(validIngredientMeasurementUnitsTableName, true, []string{}),
-					validIngredientMeasurementUnitsTableName,
-					validMeasurementUnitsTableName, validIngredientMeasurementUnitsTableName, validMeasurementUnitIDColumn, validMeasurementUnitsTableName, idColumn,
-					validIngredientsTableName, validIngredientMeasurementUnitsTableName, validIngredientIDColumn, validIngredientsTableName, idColumn,
-					validIngredientMeasurementUnitsTableName, archivedAtColumn,
-					validMeasurementUnitsTableName, archivedAtColumn,
-					validIngredientsTableName, archivedAtColumn,
-					buildFilterConditions(validIngredientMeasurementUnitsTableName, true, false),
-					buildCursorLimitClause(validIngredientMeasurementUnitsTableName),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetValidIngredientMeasurementUnit",
-					Type: OneType,
+						strings.Join(fullSelectColumns, ",\n\t"),
+						buildFilterCountSelect(validIngredientMeasurementUnitsTableName, true, true, []string{}),
+						buildTotalCountSelect(validIngredientMeasurementUnitsTableName, true, []string{}),
+						validIngredientMeasurementUnitsTableName,
+						validMeasurementUnitsTableName, validIngredientMeasurementUnitsTableName, validMeasurementUnitIDColumn, validMeasurementUnitsTableName, idColumn,
+						validIngredientsTableName, validIngredientMeasurementUnitsTableName, validIngredientIDColumn, validIngredientsTableName, idColumn,
+						validIngredientMeasurementUnitsTableName, archivedAtColumn,
+						validMeasurementUnitsTableName, archivedAtColumn,
+						validIngredientsTableName, archivedAtColumn,
+						buildFilterConditions(validIngredientMeasurementUnitsTableName, true, false),
+						buildCursorLimitClause(validIngredientMeasurementUnitsTableName),
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetValidIngredientMeasurementUnit",
+						Type: OneType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s
 FROM %s
 	JOIN %s ON %s.%s = %s.%s
@@ -214,22 +172,22 @@ WHERE
 	AND %s.%s IS NULL
 	AND %s.%s IS NULL
 	AND %s.%s = sqlc.arg(%s);`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					validIngredientMeasurementUnitsTableName,
-					validMeasurementUnitsTableName, validIngredientMeasurementUnitsTableName, validMeasurementUnitIDColumn, validMeasurementUnitsTableName, idColumn,
-					validIngredientsTableName, validIngredientMeasurementUnitsTableName, validIngredientIDColumn, validIngredientsTableName, idColumn,
-					validIngredientMeasurementUnitsTableName, archivedAtColumn,
-					validMeasurementUnitsTableName, archivedAtColumn,
-					validIngredientsTableName, archivedAtColumn,
-					validIngredientMeasurementUnitsTableName, idColumn, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetValidIngredientMeasurementUnitsByIDs",
-					Type: ManyType,
+						strings.Join(fullSelectColumns, ",\n\t"),
+						validIngredientMeasurementUnitsTableName,
+						validMeasurementUnitsTableName, validIngredientMeasurementUnitsTableName, validMeasurementUnitIDColumn, validMeasurementUnitsTableName, idColumn,
+						validIngredientsTableName, validIngredientMeasurementUnitsTableName, validIngredientIDColumn, validIngredientsTableName, idColumn,
+						validIngredientMeasurementUnitsTableName, archivedAtColumn,
+						validMeasurementUnitsTableName, archivedAtColumn,
+						validIngredientsTableName, archivedAtColumn,
+						validIngredientMeasurementUnitsTableName, idColumn, idColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetValidIngredientMeasurementUnitsByIDs",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s
 FROM %s
 	JOIN %s ON %s.%s = %s.%s
@@ -239,57 +197,37 @@ WHERE
 	AND %s.%s IS NULL
 	AND %s.%s IS NULL
 	AND %s.%s = ANY(sqlc.arg(ids)::text[]);`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					validIngredientMeasurementUnitsTableName,
-					validMeasurementUnitsTableName, validIngredientMeasurementUnitsTableName, validMeasurementUnitIDColumn, validMeasurementUnitsTableName, idColumn,
-					validIngredientsTableName, validIngredientMeasurementUnitsTableName, validIngredientIDColumn, validIngredientsTableName, idColumn,
-					validIngredientMeasurementUnitsTableName, archivedAtColumn,
-					validMeasurementUnitsTableName, archivedAtColumn,
-					validIngredientsTableName, archivedAtColumn,
-					validIngredientMeasurementUnitsTableName, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "ValidIngredientMeasurementUnitPairIsValid",
-					Type: OneType,
+						strings.Join(fullSelectColumns, ",\n\t"),
+						validIngredientMeasurementUnitsTableName,
+						validMeasurementUnitsTableName, validIngredientMeasurementUnitsTableName, validMeasurementUnitIDColumn, validMeasurementUnitsTableName, idColumn,
+						validIngredientsTableName, validIngredientMeasurementUnitsTableName, validIngredientIDColumn, validIngredientsTableName, idColumn,
+						validIngredientMeasurementUnitsTableName, archivedAtColumn,
+						validMeasurementUnitsTableName, archivedAtColumn,
+						validIngredientsTableName, archivedAtColumn,
+						validIngredientMeasurementUnitsTableName, idColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT EXISTS(
+				{
+					Annotation: QueryAnnotation{
+						Name: "ValidIngredientMeasurementUnitPairIsValid",
+						Type: OneType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT EXISTS(
 	SELECT %s
 	FROM %s
 	WHERE %s = sqlc.arg(%s)
 	AND %s = sqlc.arg(%s)
 	AND %s IS NULL
 );`,
-					idColumn,
-					validIngredientMeasurementUnitsTableName,
-					validMeasurementUnitIDColumn, validMeasurementUnitIDColumn,
-					validIngredientIDColumn, validIngredientIDColumn,
-					archivedAtColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "UpdateValidIngredientMeasurementUnit",
-					Type: ExecRowsType,
+						idColumn,
+						validIngredientMeasurementUnitsTableName,
+						validMeasurementUnitIDColumn, validMeasurementUnitIDColumn,
+						validIngredientIDColumn, validIngredientIDColumn,
+						archivedAtColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
-	%s,
-	%s = %s
-WHERE %s IS NULL
-	AND %s = sqlc.arg(%s);`,
-					validIngredientMeasurementUnitsTableName,
-					strings.Join(applyToEach(filterForUpdate(validIngredientMeasurementUnitsColumns), func(i int, s string) string {
-						return fmt.Sprintf("%s = sqlc.arg(%s)", s, s)
-					}), ",\n\t"),
-					lastUpdatedAtColumn,
-					currentTimeExpression,
-					archivedAtColumn,
-					idColumn,
-					idColumn,
-				)),
 			},
-		}
+		)
 	default:
 		return nil
 	}

--- a/backend/cmd/tools/codegen/queries/mealplanning_valid_ingredient_preparations.go
+++ b/backend/cmd/tools/codegen/queries/mealplanning_valid_ingredient_preparations.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"fmt"
+	"slices"
 	"strings"
+
+	"github.com/primandproper/platform-go/v11/database/querygen"
 
 	"github.com/cristalhq/builq"
 )
@@ -29,8 +32,6 @@ func buildValidIngredientPreparationsQueries(database string) []*Query {
 	switch database {
 	case postgres:
 
-		insertColumns := filterForInsert(validIngredientPreparationsColumns)
-
 		fullSelectColumns := mergeColumns(
 			mergeColumns(
 				applyToEach(filterFromSlice(validIngredientPreparationsColumns, "valid_preparation_id", "valid_ingredient_id"), func(i int, s string) string {
@@ -47,64 +48,18 @@ func buildValidIngredientPreparationsQueries(database string) []*Query {
 			2,
 		)
 
-		return []*Query{
-			{
-				Annotation: QueryAnnotation{
-					Name: "ArchiveValidIngredientPreparation",
-					Type: ExecRowsType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET %s = %s WHERE %s IS NULL AND %s = sqlc.arg(%s);`,
-					validIngredientPreparationsTableName,
-					archivedAtColumn,
-					currentTimeExpression,
-					archivedAtColumn,
-					idColumn,
-					idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CreateValidIngredientPreparation",
-					Type: ExecType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`INSERT INTO %s (
-	%s
-) VALUES (
-	%s
-);`,
-					validIngredientPreparationsTableName,
-					strings.Join(insertColumns, ",\n\t"),
-					strings.Join(applyToEach(insertColumns, func(i int, s string) string {
-						return fmt.Sprintf("sqlc.arg(%s)", s)
-					}), ",\n\t"),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CheckValidIngredientPreparationExistence",
-					Type: OneType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT EXISTS (
-	SELECT %s.%s
-	FROM %s
-	WHERE %s.%s IS NULL
-		AND %s.%s = sqlc.arg(%s)
-);`,
-					validIngredientPreparationsTableName, idColumn,
-					validIngredientPreparationsTableName,
-					validIngredientPreparationsTableName,
-					archivedAtColumn,
-					validIngredientPreparationsTableName,
-					idColumn,
-					idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetValidIngredientPreparationsForIngredient",
-					Type: ManyType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+		return slices.Concat(
+			querygen.StandardCRUD(validIngredientPreparationsTableName, validIngredientPreparationsColumns,
+				querygen.WithEntity("ValidIngredientPreparation", "ValidIngredientPreparations"),
+				querygen.WithOmitted(querygen.GetQuery, querygen.ListQuery),
+			),
+			[]*Query{
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetValidIngredientPreparationsForIngredient",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s
@@ -116,35 +71,35 @@ WHERE
 	AND %s.%s = sqlc.arg(%s)
 	%s
 %s;`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					buildFilterCountSelect(validIngredientPreparationsTableName, true, true, []string{}),
-					buildTotalCountSelect(validIngredientPreparationsTableName, true, []string{}),
-					validIngredientPreparationsTableName,
-					validIngredientsTableName,
-					validIngredientPreparationsTableName,
-					validIngredientIDColumn,
-					validIngredientsTableName,
-					idColumn,
-					validPreparationsTableName,
-					validIngredientPreparationsTableName,
-					validPreparationIDColumn,
-					validPreparationsTableName,
-					idColumn,
-					validIngredientPreparationsTableName,
-					archivedAtColumn,
-					validIngredientPreparationsTableName,
-					validIngredientIDColumn,
-					idColumn,
-					buildFilterConditions(validIngredientPreparationsTableName, true, false),
-					buildCursorLimitClause(validIngredientPreparationsTableName),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetValidIngredientPreparationsForPreparation",
-					Type: ManyType,
+						strings.Join(fullSelectColumns, ",\n\t"),
+						buildFilterCountSelect(validIngredientPreparationsTableName, true, true, []string{}),
+						buildTotalCountSelect(validIngredientPreparationsTableName, true, []string{}),
+						validIngredientPreparationsTableName,
+						validIngredientsTableName,
+						validIngredientPreparationsTableName,
+						validIngredientIDColumn,
+						validIngredientsTableName,
+						idColumn,
+						validPreparationsTableName,
+						validIngredientPreparationsTableName,
+						validPreparationIDColumn,
+						validPreparationsTableName,
+						idColumn,
+						validIngredientPreparationsTableName,
+						archivedAtColumn,
+						validIngredientPreparationsTableName,
+						validIngredientIDColumn,
+						idColumn,
+						buildFilterConditions(validIngredientPreparationsTableName, true, false),
+						buildCursorLimitClause(validIngredientPreparationsTableName),
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetValidIngredientPreparationsForPreparation",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s
@@ -156,35 +111,35 @@ WHERE
 	AND %s.%s = sqlc.arg(%s)
 	%s
 %s;`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					buildFilterCountSelect(validIngredientPreparationsTableName, true, true, []string{}),
-					buildTotalCountSelect(validIngredientPreparationsTableName, true, []string{}),
-					validIngredientPreparationsTableName,
-					validIngredientsTableName,
-					validIngredientPreparationsTableName,
-					validIngredientIDColumn,
-					validIngredientsTableName,
-					idColumn,
-					validPreparationsTableName,
-					validIngredientPreparationsTableName,
-					validPreparationIDColumn,
-					validPreparationsTableName,
-					idColumn,
-					validIngredientPreparationsTableName,
-					archivedAtColumn,
-					validIngredientPreparationsTableName,
-					validPreparationIDColumn,
-					idColumn,
-					buildFilterConditions(validIngredientPreparationsTableName, true, false),
-					buildCursorLimitClause(validIngredientPreparationsTableName),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetValidIngredientPreparations",
-					Type: ManyType,
+						strings.Join(fullSelectColumns, ",\n\t"),
+						buildFilterCountSelect(validIngredientPreparationsTableName, true, true, []string{}),
+						buildTotalCountSelect(validIngredientPreparationsTableName, true, []string{}),
+						validIngredientPreparationsTableName,
+						validIngredientsTableName,
+						validIngredientPreparationsTableName,
+						validIngredientIDColumn,
+						validIngredientsTableName,
+						idColumn,
+						validPreparationsTableName,
+						validIngredientPreparationsTableName,
+						validPreparationIDColumn,
+						validPreparationsTableName,
+						idColumn,
+						validIngredientPreparationsTableName,
+						archivedAtColumn,
+						validIngredientPreparationsTableName,
+						validPreparationIDColumn,
+						idColumn,
+						buildFilterConditions(validIngredientPreparationsTableName, true, false),
+						buildCursorLimitClause(validIngredientPreparationsTableName),
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetValidIngredientPreparations",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s
@@ -195,32 +150,32 @@ WHERE
 	%s.%s IS NULL
 	%s
 %s;`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					buildFilterCountSelect(validIngredientPreparationsTableName, true, true, []string{}),
-					buildTotalCountSelect(validIngredientPreparationsTableName, true, []string{}),
-					validIngredientPreparationsTableName,
-					validIngredientsTableName,
-					validIngredientPreparationsTableName,
-					validIngredientIDColumn,
-					validIngredientsTableName,
-					idColumn,
-					validPreparationsTableName,
-					validIngredientPreparationsTableName,
-					validPreparationIDColumn,
-					validPreparationsTableName,
-					idColumn,
-					validIngredientPreparationsTableName,
-					archivedAtColumn,
-					buildFilterConditions(validIngredientPreparationsTableName, true, false),
-					buildCursorLimitClause(validIngredientPreparationsTableName),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetValidIngredientPreparation",
-					Type: OneType,
+						strings.Join(fullSelectColumns, ",\n\t"),
+						buildFilterCountSelect(validIngredientPreparationsTableName, true, true, []string{}),
+						buildTotalCountSelect(validIngredientPreparationsTableName, true, []string{}),
+						validIngredientPreparationsTableName,
+						validIngredientsTableName,
+						validIngredientPreparationsTableName,
+						validIngredientIDColumn,
+						validIngredientsTableName,
+						idColumn,
+						validPreparationsTableName,
+						validIngredientPreparationsTableName,
+						validPreparationIDColumn,
+						validPreparationsTableName,
+						idColumn,
+						validIngredientPreparationsTableName,
+						archivedAtColumn,
+						buildFilterConditions(validIngredientPreparationsTableName, true, false),
+						buildCursorLimitClause(validIngredientPreparationsTableName),
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetValidIngredientPreparation",
+						Type: OneType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s
 FROM %s
 	JOIN %s ON %s.%s = %s.%s
@@ -230,35 +185,35 @@ WHERE
 	AND %s.%s IS NULL
 	AND %s.%s IS NULL
 	AND %s.%s = sqlc.arg(%s);`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					validIngredientPreparationsTableName,
-					validIngredientsTableName,
-					validIngredientPreparationsTableName,
-					validIngredientIDColumn,
-					validIngredientsTableName,
-					idColumn,
-					validPreparationsTableName,
-					validIngredientPreparationsTableName,
-					validPreparationIDColumn,
-					validPreparationsTableName,
-					idColumn,
-					validIngredientPreparationsTableName,
-					archivedAtColumn,
-					validIngredientsTableName,
-					archivedAtColumn,
-					validPreparationsTableName,
-					archivedAtColumn,
-					validIngredientPreparationsTableName,
-					idColumn,
-					idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetValidIngredientPreparationsByIDs",
-					Type: ManyType,
+						strings.Join(fullSelectColumns, ",\n\t"),
+						validIngredientPreparationsTableName,
+						validIngredientsTableName,
+						validIngredientPreparationsTableName,
+						validIngredientIDColumn,
+						validIngredientsTableName,
+						idColumn,
+						validPreparationsTableName,
+						validIngredientPreparationsTableName,
+						validPreparationIDColumn,
+						validPreparationsTableName,
+						idColumn,
+						validIngredientPreparationsTableName,
+						archivedAtColumn,
+						validIngredientsTableName,
+						archivedAtColumn,
+						validPreparationsTableName,
+						archivedAtColumn,
+						validIngredientPreparationsTableName,
+						idColumn,
+						idColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetValidIngredientPreparationsByIDs",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s
 FROM %s
 	JOIN %s ON %s.%s = %s.%s
@@ -268,55 +223,55 @@ WHERE
 	AND %s.%s IS NULL
 	AND %s.%s IS NULL
 	AND %s.%s = ANY(sqlc.arg(ids)::text[]);`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					validIngredientPreparationsTableName,
-					validIngredientsTableName,
-					validIngredientPreparationsTableName,
-					validIngredientIDColumn,
-					validIngredientsTableName,
-					idColumn,
-					validPreparationsTableName,
-					validIngredientPreparationsTableName,
-					validPreparationIDColumn,
-					validPreparationsTableName,
-					idColumn,
-					validIngredientPreparationsTableName,
-					archivedAtColumn,
-					validIngredientsTableName,
-					archivedAtColumn,
-					validPreparationsTableName,
-					archivedAtColumn,
-					validIngredientPreparationsTableName,
-					idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "ValidIngredientPreparationPairIsValid",
-					Type: OneType,
+						strings.Join(fullSelectColumns, ",\n\t"),
+						validIngredientPreparationsTableName,
+						validIngredientsTableName,
+						validIngredientPreparationsTableName,
+						validIngredientIDColumn,
+						validIngredientsTableName,
+						idColumn,
+						validPreparationsTableName,
+						validIngredientPreparationsTableName,
+						validPreparationIDColumn,
+						validPreparationsTableName,
+						idColumn,
+						validIngredientPreparationsTableName,
+						archivedAtColumn,
+						validIngredientsTableName,
+						archivedAtColumn,
+						validPreparationsTableName,
+						archivedAtColumn,
+						validIngredientPreparationsTableName,
+						idColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT EXISTS(
+				{
+					Annotation: QueryAnnotation{
+						Name: "ValidIngredientPreparationPairIsValid",
+						Type: OneType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT EXISTS(
 	SELECT %s
 	FROM %s
 	WHERE %s = sqlc.arg(%s)
 	AND %s = sqlc.arg(%s)
 	AND %s IS NULL
 );`,
-					idColumn,
-					validIngredientPreparationsTableName,
-					validIngredientIDColumn,
-					validIngredientIDColumn,
-					validPreparationIDColumn,
-					validPreparationIDColumn,
-					archivedAtColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "SearchValidIngredientPreparationsByPreparationAndIngredientName",
-					Type: ManyType,
+						idColumn,
+						validIngredientPreparationsTableName,
+						validIngredientIDColumn,
+						validIngredientIDColumn,
+						validPreparationIDColumn,
+						validPreparationIDColumn,
+						archivedAtColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "SearchValidIngredientPreparationsByPreparationAndIngredientName",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s
@@ -331,63 +286,43 @@ WHERE
 	AND %s.%s %s
 	%s
 %s;`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					buildFilterCountSelect(validIngredientPreparationsTableName, true, true, []string{}, fmt.Sprintf("%s.%s = sqlc.arg(%s)", validPreparationsTableName, idColumn, idColumn)),
-					buildTotalCountSelect(validIngredientPreparationsTableName, true, []string{}, fmt.Sprintf("%s.%s = sqlc.arg(%s)", validPreparationsTableName, idColumn, idColumn)),
-					validIngredientPreparationsTableName,
-					validIngredientsTableName,
-					validIngredientPreparationsTableName,
-					validIngredientIDColumn,
-					validIngredientsTableName,
-					idColumn,
-					validPreparationsTableName,
-					validIngredientPreparationsTableName,
-					validPreparationIDColumn,
-					validPreparationsTableName,
-					idColumn,
-					validIngredientPreparationsTableName,
-					archivedAtColumn,
-					validIngredientsTableName,
-					archivedAtColumn,
-					validPreparationsTableName,
-					archivedAtColumn,
-					validPreparationsTableName,
-					idColumn,
-					idColumn,
-					validIngredientsTableName,
-					nameColumn,
-					buildILIKEForArgument("name_query"),
-					buildFilterConditions(
+						strings.Join(fullSelectColumns, ",\n\t"),
+						buildFilterCountSelect(validIngredientPreparationsTableName, true, true, []string{}, fmt.Sprintf("%s.%s = sqlc.arg(%s)", validPreparationsTableName, idColumn, idColumn)),
+						buildTotalCountSelect(validIngredientPreparationsTableName, true, []string{}, fmt.Sprintf("%s.%s = sqlc.arg(%s)", validPreparationsTableName, idColumn, idColumn)),
 						validIngredientPreparationsTableName,
-						true,
-						true,
-						fmt.Sprintf("%s.%s = sqlc.arg(%s)", validPreparationsTableName, idColumn, idColumn),
-					),
-					buildCursorLimitClause(validIngredientPreparationsTableName),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "UpdateValidIngredientPreparation",
-					Type: ExecRowsType,
+						validIngredientsTableName,
+						validIngredientPreparationsTableName,
+						validIngredientIDColumn,
+						validIngredientsTableName,
+						idColumn,
+						validPreparationsTableName,
+						validIngredientPreparationsTableName,
+						validPreparationIDColumn,
+						validPreparationsTableName,
+						idColumn,
+						validIngredientPreparationsTableName,
+						archivedAtColumn,
+						validIngredientsTableName,
+						archivedAtColumn,
+						validPreparationsTableName,
+						archivedAtColumn,
+						validPreparationsTableName,
+						idColumn,
+						idColumn,
+						validIngredientsTableName,
+						nameColumn,
+						buildILIKEForArgument("name_query"),
+						buildFilterConditions(
+							validIngredientPreparationsTableName,
+							true,
+							true,
+							fmt.Sprintf("%s.%s = sqlc.arg(%s)", validPreparationsTableName, idColumn, idColumn),
+						),
+						buildCursorLimitClause(validIngredientPreparationsTableName),
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
-	%s,
-	%s = %s
-WHERE %s IS NULL
-	AND %s = sqlc.arg(%s);`,
-					validIngredientPreparationsTableName,
-					strings.Join(applyToEach(filterForUpdate(validIngredientPreparationsColumns), func(i int, s string) string {
-						return fmt.Sprintf("%s = sqlc.arg(%s)", s, s)
-					}), ",\n\t"),
-					lastUpdatedAtColumn,
-					currentTimeExpression,
-					archivedAtColumn,
-					idColumn,
-					idColumn,
-				)),
 			},
-		}
+		)
 	default:
 		return nil
 	}

--- a/backend/cmd/tools/codegen/queries/mealplanning_valid_ingredient_state_ingredients.go
+++ b/backend/cmd/tools/codegen/queries/mealplanning_valid_ingredient_state_ingredients.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"fmt"
+	"slices"
 	"strings"
+
+	"github.com/primandproper/platform-go/v11/database/querygen"
 
 	"github.com/cristalhq/builq"
 )
@@ -32,8 +35,6 @@ func buildValidIngredientStateIngredientsQueries(database string) []*Query {
 	switch database {
 	case postgres:
 
-		insertColumns := filterForInsert(validIngredientStateIngredientsColumns)
-
 		fullSelectColumns := mergeColumns(
 			applyToEach(filterFromSlice(validIngredientStateIngredientsColumns, "valid_ingredient_id", "valid_measurement_unit_id"), func(i int, s string) string {
 				return fmt.Sprintf("%s.%s as valid_ingredient_state_ingredient_%s", validIngredientStateIngredientsTableName, s, s)
@@ -48,61 +49,18 @@ func buildValidIngredientStateIngredientsQueries(database string) []*Query {
 			2,
 		)
 
-		return []*Query{
-			{
-				Annotation: QueryAnnotation{
-					Name: "ArchiveValidIngredientStateIngredient",
-					Type: ExecRowsType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET %s = %s WHERE %s IS NULL AND %s = sqlc.arg(%s);`,
-					validIngredientStateIngredientsTableName,
-					archivedAtColumn,
-					currentTimeExpression,
-					archivedAtColumn,
-					idColumn,
-					idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CreateValidIngredientStateIngredient",
-					Type: ExecType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`INSERT INTO %s (
-	%s
-) VALUES (
-	%s
-);`,
-					validIngredientStateIngredientsTableName,
-					strings.Join(insertColumns, ",\n\t"),
-					strings.Join(applyToEach(insertColumns, func(i int, s string) string {
-						return fmt.Sprintf("sqlc.arg(%s)", s)
-					}), ",\n\t"),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CheckValidIngredientStateIngredientExistence",
-					Type: OneType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT EXISTS (
-	SELECT %s.%s
-	FROM %s
-	WHERE %s.%s IS NULL
-		AND %s.%s = sqlc.arg(%s)
-);`,
-					validIngredientStateIngredientsTableName, idColumn,
-					validIngredientStateIngredientsTableName,
-					validIngredientStateIngredientsTableName, archivedAtColumn,
-					validIngredientStateIngredientsTableName, idColumn, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetValidIngredientStateIngredientsForIngredient",
-					Type: ManyType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+		return slices.Concat(
+			querygen.StandardCRUD(validIngredientStateIngredientsTableName, validIngredientStateIngredientsColumns,
+				querygen.WithEntity("ValidIngredientStateIngredient", "ValidIngredientStateIngredients"),
+				querygen.WithOmitted(querygen.GetQuery, querygen.ListQuery),
+			),
+			[]*Query{
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetValidIngredientStateIngredientsForIngredient",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s
@@ -116,26 +74,26 @@ WHERE
 	AND %s.%s = sqlc.arg(%s)
 	%s
 %s;`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					buildFilterCountSelect(validIngredientStateIngredientsTableName, true, true, []string{}),
-					buildTotalCountSelect(validIngredientStateIngredientsTableName, true, []string{}),
-					validIngredientStateIngredientsTableName,
-					validIngredientsTableName, validIngredientStateIngredientsTableName, validIngredientColumn, validIngredientsTableName, idColumn,
-					validIngredientStatesTableName, validIngredientStateIngredientsTableName, validIngredientStateColumn, validIngredientStatesTableName, idColumn,
-					validIngredientStateIngredientsTableName, archivedAtColumn,
-					validIngredientsTableName, archivedAtColumn,
-					validIngredientStatesTableName, archivedAtColumn,
-					validIngredientStateIngredientsTableName, validIngredientColumn, validIngredientColumn,
-					buildFilterConditions(validIngredientStateIngredientsTableName, true, false),
-					buildCursorLimitClause(validIngredientStateIngredientsTableName),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetValidIngredientStateIngredientsForIngredientState",
-					Type: ManyType,
+						strings.Join(fullSelectColumns, ",\n\t"),
+						buildFilterCountSelect(validIngredientStateIngredientsTableName, true, true, []string{}),
+						buildTotalCountSelect(validIngredientStateIngredientsTableName, true, []string{}),
+						validIngredientStateIngredientsTableName,
+						validIngredientsTableName, validIngredientStateIngredientsTableName, validIngredientColumn, validIngredientsTableName, idColumn,
+						validIngredientStatesTableName, validIngredientStateIngredientsTableName, validIngredientStateColumn, validIngredientStatesTableName, idColumn,
+						validIngredientStateIngredientsTableName, archivedAtColumn,
+						validIngredientsTableName, archivedAtColumn,
+						validIngredientStatesTableName, archivedAtColumn,
+						validIngredientStateIngredientsTableName, validIngredientColumn, validIngredientColumn,
+						buildFilterConditions(validIngredientStateIngredientsTableName, true, false),
+						buildCursorLimitClause(validIngredientStateIngredientsTableName),
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetValidIngredientStateIngredientsForIngredientState",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s
@@ -149,26 +107,26 @@ WHERE
 	AND %s.%s = sqlc.arg(%s)
 	%s
 %s;`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					buildFilterCountSelect(validIngredientStateIngredientsTableName, true, true, []string{}),
-					buildTotalCountSelect(validIngredientStateIngredientsTableName, true, []string{}),
-					validIngredientStateIngredientsTableName,
-					validIngredientsTableName, validIngredientStateIngredientsTableName, validIngredientColumn, validIngredientsTableName, idColumn,
-					validIngredientStatesTableName, validIngredientStateIngredientsTableName, validIngredientStateColumn, validIngredientStatesTableName, idColumn,
-					validIngredientStateIngredientsTableName, archivedAtColumn,
-					validIngredientsTableName, archivedAtColumn,
-					validIngredientStatesTableName, archivedAtColumn,
-					validIngredientStateIngredientsTableName, validIngredientStateColumn, validIngredientStateColumn,
-					buildFilterConditions(validIngredientStateIngredientsTableName, true, false),
-					buildCursorLimitClause(validIngredientStateIngredientsTableName),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetValidIngredientStateIngredients",
-					Type: ManyType,
+						strings.Join(fullSelectColumns, ",\n\t"),
+						buildFilterCountSelect(validIngredientStateIngredientsTableName, true, true, []string{}),
+						buildTotalCountSelect(validIngredientStateIngredientsTableName, true, []string{}),
+						validIngredientStateIngredientsTableName,
+						validIngredientsTableName, validIngredientStateIngredientsTableName, validIngredientColumn, validIngredientsTableName, idColumn,
+						validIngredientStatesTableName, validIngredientStateIngredientsTableName, validIngredientStateColumn, validIngredientStatesTableName, idColumn,
+						validIngredientStateIngredientsTableName, archivedAtColumn,
+						validIngredientsTableName, archivedAtColumn,
+						validIngredientStatesTableName, archivedAtColumn,
+						validIngredientStateIngredientsTableName, validIngredientStateColumn, validIngredientStateColumn,
+						buildFilterConditions(validIngredientStateIngredientsTableName, true, false),
+						buildCursorLimitClause(validIngredientStateIngredientsTableName),
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetValidIngredientStateIngredients",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s
@@ -181,25 +139,25 @@ WHERE
 	AND %s.%s IS NULL
 	%s
 %s;`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					buildFilterCountSelect(validIngredientStateIngredientsTableName, true, true, []string{}),
-					buildTotalCountSelect(validIngredientStateIngredientsTableName, true, []string{}),
-					validIngredientStateIngredientsTableName,
-					validIngredientsTableName, validIngredientStateIngredientsTableName, validIngredientColumn, validIngredientsTableName, idColumn,
-					validIngredientStatesTableName, validIngredientStateIngredientsTableName, validIngredientStateColumn, validIngredientStatesTableName, idColumn,
-					validIngredientStateIngredientsTableName, archivedAtColumn,
-					validIngredientsTableName, archivedAtColumn,
-					validIngredientStatesTableName, archivedAtColumn,
-					buildFilterConditions(validIngredientStateIngredientsTableName, true, false),
-					buildCursorLimitClause(validIngredientStateIngredientsTableName),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetValidIngredientStateIngredient",
-					Type: OneType,
+						strings.Join(fullSelectColumns, ",\n\t"),
+						buildFilterCountSelect(validIngredientStateIngredientsTableName, true, true, []string{}),
+						buildTotalCountSelect(validIngredientStateIngredientsTableName, true, []string{}),
+						validIngredientStateIngredientsTableName,
+						validIngredientsTableName, validIngredientStateIngredientsTableName, validIngredientColumn, validIngredientsTableName, idColumn,
+						validIngredientStatesTableName, validIngredientStateIngredientsTableName, validIngredientStateColumn, validIngredientStatesTableName, idColumn,
+						validIngredientStateIngredientsTableName, archivedAtColumn,
+						validIngredientsTableName, archivedAtColumn,
+						validIngredientStatesTableName, archivedAtColumn,
+						buildFilterConditions(validIngredientStateIngredientsTableName, true, false),
+						buildCursorLimitClause(validIngredientStateIngredientsTableName),
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetValidIngredientStateIngredient",
+						Type: OneType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s
 FROM %s
 	JOIN %s ON %s.%s = %s.%s
@@ -209,22 +167,22 @@ WHERE
 	AND %s.%s IS NULL
 	AND %s.%s IS NULL
 	AND %s.%s = sqlc.arg(%s);`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					validIngredientStateIngredientsTableName,
-					validIngredientsTableName, validIngredientStateIngredientsTableName, validIngredientColumn, validIngredientsTableName, idColumn,
-					validIngredientStatesTableName, validIngredientStateIngredientsTableName, validIngredientStateColumn, validIngredientStatesTableName, idColumn,
-					validIngredientStateIngredientsTableName, archivedAtColumn,
-					validIngredientsTableName, archivedAtColumn,
-					validIngredientStatesTableName, archivedAtColumn,
-					validIngredientStateIngredientsTableName, idColumn, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetValidIngredientStateIngredientsWithIDs",
-					Type: ManyType,
+						strings.Join(fullSelectColumns, ",\n\t"),
+						validIngredientStateIngredientsTableName,
+						validIngredientsTableName, validIngredientStateIngredientsTableName, validIngredientColumn, validIngredientsTableName, idColumn,
+						validIngredientStatesTableName, validIngredientStateIngredientsTableName, validIngredientStateColumn, validIngredientStatesTableName, idColumn,
+						validIngredientStateIngredientsTableName, archivedAtColumn,
+						validIngredientsTableName, archivedAtColumn,
+						validIngredientStatesTableName, archivedAtColumn,
+						validIngredientStateIngredientsTableName, idColumn, idColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetValidIngredientStateIngredientsWithIDs",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s
 FROM %s
 	JOIN %s ON %s.%s = %s.%s
@@ -234,57 +192,37 @@ WHERE
 	AND %s.%s IS NULL
 	AND %s.%s IS NULL
 	AND %s.%s = ANY(sqlc.arg(ids)::text[]);`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					validIngredientStateIngredientsTableName,
-					validIngredientsTableName, validIngredientStateIngredientsTableName, validIngredientColumn, validIngredientsTableName, idColumn,
-					validIngredientStatesTableName, validIngredientStateIngredientsTableName, validIngredientStateColumn, validIngredientStatesTableName, idColumn,
-					validIngredientStateIngredientsTableName, archivedAtColumn,
-					validIngredientsTableName, archivedAtColumn,
-					validIngredientStatesTableName, archivedAtColumn,
-					validIngredientStateIngredientsTableName, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CheckValidityOfValidIngredientStateIngredientPair",
-					Type: OneType,
+						strings.Join(fullSelectColumns, ",\n\t"),
+						validIngredientStateIngredientsTableName,
+						validIngredientsTableName, validIngredientStateIngredientsTableName, validIngredientColumn, validIngredientsTableName, idColumn,
+						validIngredientStatesTableName, validIngredientStateIngredientsTableName, validIngredientStateColumn, validIngredientStatesTableName, idColumn,
+						validIngredientStateIngredientsTableName, archivedAtColumn,
+						validIngredientsTableName, archivedAtColumn,
+						validIngredientStatesTableName, archivedAtColumn,
+						validIngredientStateIngredientsTableName, idColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT EXISTS(
+				{
+					Annotation: QueryAnnotation{
+						Name: "CheckValidityOfValidIngredientStateIngredientPair",
+						Type: OneType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT EXISTS(
 	SELECT %s.%s
 	FROM %s
 	WHERE %s = sqlc.arg(%s)
 	AND %s = sqlc.arg(%s)
 	AND %s IS NULL
 );`,
-					validIngredientStateIngredientsTableName, idColumn,
-					validIngredientStateIngredientsTableName,
-					validIngredientColumn, validIngredientColumn,
-					validIngredientStateColumn, validIngredientStateColumn,
-					archivedAtColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "UpdateValidIngredientStateIngredient",
-					Type: ExecRowsType,
+						validIngredientStateIngredientsTableName, idColumn,
+						validIngredientStateIngredientsTableName,
+						validIngredientColumn, validIngredientColumn,
+						validIngredientStateColumn, validIngredientStateColumn,
+						archivedAtColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
-	%s,
-	%s = %s
-WHERE %s IS NULL
-	AND %s = sqlc.arg(%s);`,
-					validIngredientStateIngredientsTableName,
-					strings.Join(applyToEach(filterForUpdate(validIngredientStateIngredientsColumns), func(i int, s string) string {
-						return fmt.Sprintf("%s = sqlc.arg(%s)", s, s)
-					}), ",\n\t"),
-					lastUpdatedAtColumn,
-					currentTimeExpression,
-					archivedAtColumn,
-					idColumn,
-					idColumn,
-				)),
 			},
-		}
+		)
 	default:
 		return nil
 	}

--- a/backend/cmd/tools/codegen/queries/mealplanning_valid_measurement_unit_conversions.go
+++ b/backend/cmd/tools/codegen/queries/mealplanning_valid_measurement_unit_conversions.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"fmt"
+	"slices"
 	"strings"
+
+	"github.com/primandproper/platform-go/v11/database/querygen"
 
 	"github.com/cristalhq/builq"
 )
@@ -35,8 +38,6 @@ func buildValidMeasurementUnitConversionsQueries(database string) []*Query {
 	switch database {
 	case postgres:
 
-		insertColumns := filterForInsert(validMeasurementUnitConversionsColumns)
-
 		fullSelectColumns := mergeColumns(
 			applyToEach(validMeasurementUnitConversionsColumns, func(i int, s string) string {
 				return fmt.Sprintf("%s.%s as valid_measurement_unit_conversion_%s", validMeasurementUnitConversionsTableName, s, s)
@@ -57,61 +58,18 @@ func buildValidMeasurementUnitConversionsQueries(database string) []*Query {
 			1,
 		)
 
-		return []*Query{
-			{
-				Annotation: QueryAnnotation{
-					Name: "ArchiveValidMeasurementUnitConversion",
-					Type: ExecRowsType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET %s = %s WHERE %s IS NULL AND %s = sqlc.arg(%s);`,
-					validMeasurementUnitConversionsTableName,
-					archivedAtColumn,
-					currentTimeExpression,
-					archivedAtColumn,
-					idColumn,
-					idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CreateValidMeasurementUnitConversion",
-					Type: ExecType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`INSERT INTO %s (
-	%s
-) VALUES (
-	%s
-);`,
-					validMeasurementUnitConversionsTableName,
-					strings.Join(insertColumns, ",\n\t"),
-					strings.Join(applyToEach(insertColumns, func(i int, s string) string {
-						return fmt.Sprintf("sqlc.arg(%s)", s)
-					}), ",\n\t"),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CheckValidMeasurementUnitConversionExistence",
-					Type: OneType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT EXISTS (
-	SELECT %s.%s
-	FROM %s
-	WHERE %s.%s IS NULL
-		AND %s.%s = sqlc.arg(%s)
-);`,
-					validMeasurementUnitConversionsTableName, idColumn,
-					validMeasurementUnitConversionsTableName,
-					validMeasurementUnitConversionsTableName, archivedAtColumn,
-					validMeasurementUnitConversionsTableName, idColumn, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetValidMeasurementUnitConversionsForMeasurementUnit",
-					Type: ManyType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+		return slices.Concat(
+			querygen.StandardCRUD(validMeasurementUnitConversionsTableName, validMeasurementUnitConversionsColumns,
+				querygen.WithEntity("ValidMeasurementUnitConversion", "ValidMeasurementUnitConversions"),
+				querygen.WithOmitted(querygen.GetQuery, querygen.ListQuery),
+			),
+			[]*Query{
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetValidMeasurementUnitConversionsForMeasurementUnit",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s
@@ -126,35 +84,35 @@ WHERE
 	AND %s_to.%s IS NULL
 	%s
 %s;`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					buildFilterCountSelect(validMeasurementUnitConversionsTableName, true, true, []string{
-						fmt.Sprintf("%s AS %s_from ON %s.%s = %s_from.%s", validMeasurementUnitsTableName, validMeasurementUnitsTableName, validMeasurementUnitConversionsTableName, validMeasurementUnitConversionsFromUnitColumn, validMeasurementUnitsTableName, idColumn),
-						fmt.Sprintf("%s AS %s_to ON %s.%s = %s_to.%s", validMeasurementUnitsTableName, validMeasurementUnitsTableName, validMeasurementUnitConversionsTableName, validMeasurementUnitConversionsToUnitColumn, validMeasurementUnitsTableName, idColumn),
-						fmt.Sprintf("%s ON %s.%s = %s.%s", validIngredientsTableName, validMeasurementUnitConversionsTableName, validMeasurementUnitConversionsOnlyForIngredientColumn, validIngredientsTableName, idColumn),
-					}, fmt.Sprintf("(%s_from.%s = sqlc.arg(%s) OR %s_to.%s = sqlc.arg(%s))", validMeasurementUnitsTableName, idColumn, idColumn, validMeasurementUnitsTableName, idColumn, idColumn), fmt.Sprintf("%s_from.%s IS NULL", validMeasurementUnitsTableName, archivedAtColumn), fmt.Sprintf("%s_to.%s IS NULL", validMeasurementUnitsTableName, archivedAtColumn)),
-					buildTotalCountSelect(validMeasurementUnitConversionsTableName, true, []string{
-						fmt.Sprintf("%s AS %s_from ON %s.%s = %s_from.%s", validMeasurementUnitsTableName, validMeasurementUnitsTableName, validMeasurementUnitConversionsTableName, validMeasurementUnitConversionsFromUnitColumn, validMeasurementUnitsTableName, idColumn),
-						fmt.Sprintf("%s AS %s_to ON %s.%s = %s_to.%s", validMeasurementUnitsTableName, validMeasurementUnitsTableName, validMeasurementUnitConversionsTableName, validMeasurementUnitConversionsToUnitColumn, validMeasurementUnitsTableName, idColumn),
-						fmt.Sprintf("%s ON %s.%s = %s.%s", validIngredientsTableName, validMeasurementUnitConversionsTableName, validMeasurementUnitConversionsOnlyForIngredientColumn, validIngredientsTableName, idColumn),
-					}, fmt.Sprintf("(%s_from.%s = sqlc.arg(%s) OR %s_to.%s = sqlc.arg(%s))", validMeasurementUnitsTableName, idColumn, idColumn, validMeasurementUnitsTableName, idColumn, idColumn), fmt.Sprintf("%s_from.%s IS NULL", validMeasurementUnitsTableName, archivedAtColumn), fmt.Sprintf("%s_to.%s IS NULL", validMeasurementUnitsTableName, archivedAtColumn)),
-					validMeasurementUnitConversionsTableName,
-					validMeasurementUnitsTableName, validMeasurementUnitsTableName, validMeasurementUnitConversionsTableName, validMeasurementUnitConversionsFromUnitColumn, validMeasurementUnitsTableName, idColumn,
-					validMeasurementUnitsTableName, validMeasurementUnitsTableName, validMeasurementUnitConversionsTableName, validMeasurementUnitConversionsToUnitColumn, validMeasurementUnitsTableName, idColumn,
-					validIngredientsTableName, validMeasurementUnitConversionsTableName, validMeasurementUnitConversionsOnlyForIngredientColumn, validIngredientsTableName, idColumn,
-					validMeasurementUnitsTableName, idColumn, idColumn, validMeasurementUnitsTableName, idColumn, idColumn,
-					validMeasurementUnitConversionsTableName, archivedAtColumn,
-					validMeasurementUnitsTableName, archivedAtColumn,
-					validMeasurementUnitsTableName, archivedAtColumn,
-					buildFilterConditions(validMeasurementUnitConversionsTableName, true, true),
-					buildCursorLimitClause(validMeasurementUnitConversionsTableName),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetValidMeasurementUnitConversion",
-					Type: OneType,
+						strings.Join(fullSelectColumns, ",\n\t"),
+						buildFilterCountSelect(validMeasurementUnitConversionsTableName, true, true, []string{
+							fmt.Sprintf("%s AS %s_from ON %s.%s = %s_from.%s", validMeasurementUnitsTableName, validMeasurementUnitsTableName, validMeasurementUnitConversionsTableName, validMeasurementUnitConversionsFromUnitColumn, validMeasurementUnitsTableName, idColumn),
+							fmt.Sprintf("%s AS %s_to ON %s.%s = %s_to.%s", validMeasurementUnitsTableName, validMeasurementUnitsTableName, validMeasurementUnitConversionsTableName, validMeasurementUnitConversionsToUnitColumn, validMeasurementUnitsTableName, idColumn),
+							fmt.Sprintf("%s ON %s.%s = %s.%s", validIngredientsTableName, validMeasurementUnitConversionsTableName, validMeasurementUnitConversionsOnlyForIngredientColumn, validIngredientsTableName, idColumn),
+						}, fmt.Sprintf("(%s_from.%s = sqlc.arg(%s) OR %s_to.%s = sqlc.arg(%s))", validMeasurementUnitsTableName, idColumn, idColumn, validMeasurementUnitsTableName, idColumn, idColumn), fmt.Sprintf("%s_from.%s IS NULL", validMeasurementUnitsTableName, archivedAtColumn), fmt.Sprintf("%s_to.%s IS NULL", validMeasurementUnitsTableName, archivedAtColumn)),
+						buildTotalCountSelect(validMeasurementUnitConversionsTableName, true, []string{
+							fmt.Sprintf("%s AS %s_from ON %s.%s = %s_from.%s", validMeasurementUnitsTableName, validMeasurementUnitsTableName, validMeasurementUnitConversionsTableName, validMeasurementUnitConversionsFromUnitColumn, validMeasurementUnitsTableName, idColumn),
+							fmt.Sprintf("%s AS %s_to ON %s.%s = %s_to.%s", validMeasurementUnitsTableName, validMeasurementUnitsTableName, validMeasurementUnitConversionsTableName, validMeasurementUnitConversionsToUnitColumn, validMeasurementUnitsTableName, idColumn),
+							fmt.Sprintf("%s ON %s.%s = %s.%s", validIngredientsTableName, validMeasurementUnitConversionsTableName, validMeasurementUnitConversionsOnlyForIngredientColumn, validIngredientsTableName, idColumn),
+						}, fmt.Sprintf("(%s_from.%s = sqlc.arg(%s) OR %s_to.%s = sqlc.arg(%s))", validMeasurementUnitsTableName, idColumn, idColumn, validMeasurementUnitsTableName, idColumn, idColumn), fmt.Sprintf("%s_from.%s IS NULL", validMeasurementUnitsTableName, archivedAtColumn), fmt.Sprintf("%s_to.%s IS NULL", validMeasurementUnitsTableName, archivedAtColumn)),
+						validMeasurementUnitConversionsTableName,
+						validMeasurementUnitsTableName, validMeasurementUnitsTableName, validMeasurementUnitConversionsTableName, validMeasurementUnitConversionsFromUnitColumn, validMeasurementUnitsTableName, idColumn,
+						validMeasurementUnitsTableName, validMeasurementUnitsTableName, validMeasurementUnitConversionsTableName, validMeasurementUnitConversionsToUnitColumn, validMeasurementUnitsTableName, idColumn,
+						validIngredientsTableName, validMeasurementUnitConversionsTableName, validMeasurementUnitConversionsOnlyForIngredientColumn, validIngredientsTableName, idColumn,
+						validMeasurementUnitsTableName, idColumn, idColumn, validMeasurementUnitsTableName, idColumn, idColumn,
+						validMeasurementUnitConversionsTableName, archivedAtColumn,
+						validMeasurementUnitsTableName, archivedAtColumn,
+						validMeasurementUnitsTableName, archivedAtColumn,
+						buildFilterConditions(validMeasurementUnitConversionsTableName, true, true),
+						buildCursorLimitClause(validMeasurementUnitConversionsTableName),
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetValidMeasurementUnitConversion",
+						Type: OneType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s
 FROM %s
 	JOIN %s AS %s_from ON %s.%s = %s_from.%s
@@ -165,23 +123,23 @@ WHERE
 	AND %s.%s IS NULL
 	AND %s_from.%s IS NULL
 	AND %s_to.%s IS NULL;`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					validMeasurementUnitConversionsTableName,
-					validMeasurementUnitsTableName, validMeasurementUnitsTableName, validMeasurementUnitConversionsTableName, validMeasurementUnitConversionsFromUnitColumn, validMeasurementUnitsTableName, idColumn,
-					validMeasurementUnitsTableName, validMeasurementUnitsTableName, validMeasurementUnitConversionsTableName, validMeasurementUnitConversionsToUnitColumn, validMeasurementUnitsTableName, idColumn,
-					validIngredientsTableName, validMeasurementUnitConversionsTableName, validMeasurementUnitConversionsOnlyForIngredientColumn, validIngredientsTableName, idColumn,
-					validMeasurementUnitConversionsTableName, idColumn, idColumn,
-					validMeasurementUnitConversionsTableName, archivedAtColumn,
-					validMeasurementUnitsTableName, archivedAtColumn,
-					validMeasurementUnitsTableName, archivedAtColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetValidMeasurementUnitConversionsForIngredients",
-					Type: ManyType,
+						strings.Join(fullSelectColumns, ",\n\t"),
+						validMeasurementUnitConversionsTableName,
+						validMeasurementUnitsTableName, validMeasurementUnitsTableName, validMeasurementUnitConversionsTableName, validMeasurementUnitConversionsFromUnitColumn, validMeasurementUnitsTableName, idColumn,
+						validMeasurementUnitsTableName, validMeasurementUnitsTableName, validMeasurementUnitConversionsTableName, validMeasurementUnitConversionsToUnitColumn, validMeasurementUnitsTableName, idColumn,
+						validIngredientsTableName, validMeasurementUnitConversionsTableName, validMeasurementUnitConversionsOnlyForIngredientColumn, validIngredientsTableName, idColumn,
+						validMeasurementUnitConversionsTableName, idColumn, idColumn,
+						validMeasurementUnitConversionsTableName, archivedAtColumn,
+						validMeasurementUnitsTableName, archivedAtColumn,
+						validMeasurementUnitsTableName, archivedAtColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetValidMeasurementUnitConversionsForIngredients",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s
 FROM %s
 	JOIN %s AS %s_from ON %s.%s = %s_from.%s
@@ -192,45 +150,24 @@ WHERE
 	AND %s.%s IS NULL
 	AND %s_from.%s IS NULL
 	AND %s_to.%s IS NULL;`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					validMeasurementUnitConversionsTableName,
-					validMeasurementUnitsTableName, validMeasurementUnitsTableName, validMeasurementUnitConversionsTableName, validMeasurementUnitConversionsFromUnitColumn, validMeasurementUnitsTableName, idColumn,
-					validMeasurementUnitsTableName, validMeasurementUnitsTableName, validMeasurementUnitConversionsTableName, validMeasurementUnitConversionsToUnitColumn, validMeasurementUnitsTableName, idColumn,
-					validIngredientsTableName, validMeasurementUnitConversionsTableName, validMeasurementUnitConversionsOnlyForIngredientColumn, validIngredientsTableName, idColumn,
-					validMeasurementUnitConversionsTableName, validMeasurementUnitConversionsOnlyForIngredientColumn,
-					validMeasurementUnitConversionsTableName, validMeasurementUnitConversionsOnlyForIngredientColumn,
-					validMeasurementUnitConversionsTableName, archivedAtColumn,
-					validMeasurementUnitsTableName, archivedAtColumn,
-					validMeasurementUnitsTableName, archivedAtColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "UpdateValidMeasurementUnitConversion",
-					Type: ExecRowsType,
+						strings.Join(fullSelectColumns, ",\n\t"),
+						validMeasurementUnitConversionsTableName,
+						validMeasurementUnitsTableName, validMeasurementUnitsTableName, validMeasurementUnitConversionsTableName, validMeasurementUnitConversionsFromUnitColumn, validMeasurementUnitsTableName, idColumn,
+						validMeasurementUnitsTableName, validMeasurementUnitsTableName, validMeasurementUnitConversionsTableName, validMeasurementUnitConversionsToUnitColumn, validMeasurementUnitsTableName, idColumn,
+						validIngredientsTableName, validMeasurementUnitConversionsTableName, validMeasurementUnitConversionsOnlyForIngredientColumn, validIngredientsTableName, idColumn,
+						validMeasurementUnitConversionsTableName, validMeasurementUnitConversionsOnlyForIngredientColumn,
+						validMeasurementUnitConversionsTableName, validMeasurementUnitConversionsOnlyForIngredientColumn,
+						validMeasurementUnitConversionsTableName, archivedAtColumn,
+						validMeasurementUnitsTableName, archivedAtColumn,
+						validMeasurementUnitsTableName, archivedAtColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
-	%s,
-	%s = %s
-WHERE %s IS NULL
-	AND %s = sqlc.arg(%s);`,
-					validMeasurementUnitConversionsTableName,
-					strings.Join(applyToEach(filterForUpdate(validMeasurementUnitConversionsColumns), func(i int, s string) string {
-						return fmt.Sprintf("%s = sqlc.arg(%s)", s, s)
-					}), ",\n\t"),
-					lastUpdatedAtColumn,
-					currentTimeExpression,
-					archivedAtColumn,
-					idColumn,
-					idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetMeasurementUnitConversionMismatches",
-					Type: ManyType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`WITH ingredient_units AS (
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetMeasurementUnitConversionMismatches",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`WITH ingredient_units AS (
 	SELECT DISTINCT
 		vimu.valid_ingredient_id,
 		vimu.valid_measurement_unit_id
@@ -260,8 +197,9 @@ LEFT JOIN valid_measurement_unit_conversions c ON c.from_unit = unit_pairs.from_
 	AND (c.only_for_ingredient IS NULL OR c.only_for_ingredient = unit_pairs.valid_ingredient_id)
 	AND c.archived_at IS NULL
 WHERE c.id IS NULL;`)),
+				},
 			},
-		}
+		)
 	default:
 		return nil
 	}

--- a/backend/cmd/tools/codegen/queries/mealplanning_valid_prep_task_configs.go
+++ b/backend/cmd/tools/codegen/queries/mealplanning_valid_prep_task_configs.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"fmt"
+	"slices"
 	"strings"
+
+	"github.com/primandproper/platform-go/v11/database/querygen"
 
 	"github.com/cristalhq/builq"
 )
@@ -36,8 +39,6 @@ func buildValidPrepTaskConfigsQueries(database string) []*Query {
 	switch database {
 	case postgres:
 
-		insertColumns := filterForInsert(validPrepTaskConfigsColumns)
-
 		fullSelectColumns := mergeColumns(
 			mergeColumns(
 				applyToEach(filterFromSlice(validPrepTaskConfigsColumns, "valid_preparation_id", "valid_ingredient_id"), func(i int, s string) string {
@@ -54,71 +55,19 @@ func buildValidPrepTaskConfigsQueries(database string) []*Query {
 			2,
 		)
 
-		return []*Query{
-			{
-				Annotation: QueryAnnotation{
-					Name: "ArchiveValidPrepTaskConfig",
-					Type: ExecRowsType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET %s = %s WHERE %s IS NULL AND %s = sqlc.arg(%s);`,
-					validPrepTaskConfigsTableName,
-					archivedAtColumn,
-					currentTimeExpression,
-					archivedAtColumn,
-					idColumn,
-					idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CreateValidPrepTaskConfig",
-					Type: ExecType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`INSERT INTO %s (
-	%s
-) VALUES (
-	%s
-);`,
-					validPrepTaskConfigsTableName,
-					strings.Join(insertColumns, ",\n\t"),
-					strings.Join(applyToEach(insertColumns, func(i int, s string) string {
-						switch s {
-						case "maximum_storage_duration_in_seconds",
-							"minimum_storage_temperature_in_celsius",
-							"maximum_storage_temperature_in_celsius":
-							return fmt.Sprintf("sqlc.narg(%s)", s)
-						default:
-							return fmt.Sprintf("sqlc.arg(%s)", s)
-						}
-					}), ",\n\t"),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CheckValidPrepTaskConfigExistence",
-					Type: OneType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT EXISTS (
-	SELECT %s.%s
-	FROM %s
-	WHERE %s.%s IS NULL
-		AND %s.%s = sqlc.arg(%s)
-);`,
-					validPrepTaskConfigsTableName, idColumn,
-					validPrepTaskConfigsTableName,
-					validPrepTaskConfigsTableName,
-					archivedAtColumn,
-					validPrepTaskConfigsTableName,
-					idColumn,
-					idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetValidPrepTaskConfigsForIngredient",
-					Type: ManyType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+		return slices.Concat(
+			querygen.StandardCRUD(validPrepTaskConfigsTableName, validPrepTaskConfigsColumns,
+				querygen.WithEntity("ValidPrepTaskConfig", "ValidPrepTaskConfigs"),
+				querygen.WithNullable("maximum_storage_duration_in_seconds", "maximum_storage_temperature_in_celsius", "minimum_storage_temperature_in_celsius"),
+				querygen.WithOmitted(querygen.GetQuery, querygen.ListQuery),
+			),
+			[]*Query{
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetValidPrepTaskConfigsForIngredient",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s
@@ -130,35 +79,35 @@ WHERE
 	AND %s.%s = sqlc.arg(%s)
 	%s
 %s;`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					buildFilterCountSelect(validPrepTaskConfigsTableName, true, true, []string{}),
-					buildTotalCountSelect(validPrepTaskConfigsTableName, true, []string{}),
-					validPrepTaskConfigsTableName,
-					validIngredientsTableName,
-					validPrepTaskConfigsTableName,
-					validIngredientIDColumn,
-					validIngredientsTableName,
-					idColumn,
-					validPreparationsTableName,
-					validPrepTaskConfigsTableName,
-					validPreparationIDColumn,
-					validPreparationsTableName,
-					idColumn,
-					validPrepTaskConfigsTableName,
-					archivedAtColumn,
-					validPrepTaskConfigsTableName,
-					validIngredientIDColumn,
-					idColumn,
-					buildFilterConditions(validPrepTaskConfigsTableName, true, false),
-					buildCursorLimitClause(validPrepTaskConfigsTableName),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetValidPrepTaskConfigsForPreparation",
-					Type: ManyType,
+						strings.Join(fullSelectColumns, ",\n\t"),
+						buildFilterCountSelect(validPrepTaskConfigsTableName, true, true, []string{}),
+						buildTotalCountSelect(validPrepTaskConfigsTableName, true, []string{}),
+						validPrepTaskConfigsTableName,
+						validIngredientsTableName,
+						validPrepTaskConfigsTableName,
+						validIngredientIDColumn,
+						validIngredientsTableName,
+						idColumn,
+						validPreparationsTableName,
+						validPrepTaskConfigsTableName,
+						validPreparationIDColumn,
+						validPreparationsTableName,
+						idColumn,
+						validPrepTaskConfigsTableName,
+						archivedAtColumn,
+						validPrepTaskConfigsTableName,
+						validIngredientIDColumn,
+						idColumn,
+						buildFilterConditions(validPrepTaskConfigsTableName, true, false),
+						buildCursorLimitClause(validPrepTaskConfigsTableName),
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetValidPrepTaskConfigsForPreparation",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s
@@ -170,35 +119,35 @@ WHERE
 	AND %s.%s = sqlc.arg(%s)
 	%s
 %s;`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					buildFilterCountSelect(validPrepTaskConfigsTableName, true, true, []string{}),
-					buildTotalCountSelect(validPrepTaskConfigsTableName, true, []string{}),
-					validPrepTaskConfigsTableName,
-					validIngredientsTableName,
-					validPrepTaskConfigsTableName,
-					validIngredientIDColumn,
-					validIngredientsTableName,
-					idColumn,
-					validPreparationsTableName,
-					validPrepTaskConfigsTableName,
-					validPreparationIDColumn,
-					validPreparationsTableName,
-					idColumn,
-					validPrepTaskConfigsTableName,
-					archivedAtColumn,
-					validPrepTaskConfigsTableName,
-					validPreparationIDColumn,
-					idColumn,
-					buildFilterConditions(validPrepTaskConfigsTableName, true, false),
-					buildCursorLimitClause(validPrepTaskConfigsTableName),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetValidPrepTaskConfigsForIngredientAndPreparation",
-					Type: ManyType,
+						strings.Join(fullSelectColumns, ",\n\t"),
+						buildFilterCountSelect(validPrepTaskConfigsTableName, true, true, []string{}),
+						buildTotalCountSelect(validPrepTaskConfigsTableName, true, []string{}),
+						validPrepTaskConfigsTableName,
+						validIngredientsTableName,
+						validPrepTaskConfigsTableName,
+						validIngredientIDColumn,
+						validIngredientsTableName,
+						idColumn,
+						validPreparationsTableName,
+						validPrepTaskConfigsTableName,
+						validPreparationIDColumn,
+						validPreparationsTableName,
+						idColumn,
+						validPrepTaskConfigsTableName,
+						archivedAtColumn,
+						validPrepTaskConfigsTableName,
+						validPreparationIDColumn,
+						idColumn,
+						buildFilterConditions(validPrepTaskConfigsTableName, true, false),
+						buildCursorLimitClause(validPrepTaskConfigsTableName),
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetValidPrepTaskConfigsForIngredientAndPreparation",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s
@@ -211,38 +160,38 @@ WHERE
 	AND %s.%s = sqlc.arg(%s)
 	%s
 %s;`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					buildFilterCountSelect(validPrepTaskConfigsTableName, true, true, []string{}),
-					buildTotalCountSelect(validPrepTaskConfigsTableName, true, []string{}),
-					validPrepTaskConfigsTableName,
-					validIngredientsTableName,
-					validPrepTaskConfigsTableName,
-					validIngredientIDColumn,
-					validIngredientsTableName,
-					idColumn,
-					validPreparationsTableName,
-					validPrepTaskConfigsTableName,
-					validPreparationIDColumn,
-					validPreparationsTableName,
-					idColumn,
-					validPrepTaskConfigsTableName,
-					archivedAtColumn,
-					validPrepTaskConfigsTableName,
-					validIngredientIDColumn,
-					validIngredientIDColumn,
-					validPrepTaskConfigsTableName,
-					validPreparationIDColumn,
-					validPreparationIDColumn,
-					buildFilterConditions(validPrepTaskConfigsTableName, true, false),
-					buildCursorLimitClause(validPrepTaskConfigsTableName),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetValidPrepTaskConfigs",
-					Type: ManyType,
+						strings.Join(fullSelectColumns, ",\n\t"),
+						buildFilterCountSelect(validPrepTaskConfigsTableName, true, true, []string{}),
+						buildTotalCountSelect(validPrepTaskConfigsTableName, true, []string{}),
+						validPrepTaskConfigsTableName,
+						validIngredientsTableName,
+						validPrepTaskConfigsTableName,
+						validIngredientIDColumn,
+						validIngredientsTableName,
+						idColumn,
+						validPreparationsTableName,
+						validPrepTaskConfigsTableName,
+						validPreparationIDColumn,
+						validPreparationsTableName,
+						idColumn,
+						validPrepTaskConfigsTableName,
+						archivedAtColumn,
+						validPrepTaskConfigsTableName,
+						validIngredientIDColumn,
+						validIngredientIDColumn,
+						validPrepTaskConfigsTableName,
+						validPreparationIDColumn,
+						validPreparationIDColumn,
+						buildFilterConditions(validPrepTaskConfigsTableName, true, false),
+						buildCursorLimitClause(validPrepTaskConfigsTableName),
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetValidPrepTaskConfigs",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s
@@ -253,32 +202,32 @@ WHERE
 	%s.%s IS NULL
 	%s
 %s;`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					buildFilterCountSelect(validPrepTaskConfigsTableName, true, true, []string{}),
-					buildTotalCountSelect(validPrepTaskConfigsTableName, true, []string{}),
-					validPrepTaskConfigsTableName,
-					validIngredientsTableName,
-					validPrepTaskConfigsTableName,
-					validIngredientIDColumn,
-					validIngredientsTableName,
-					idColumn,
-					validPreparationsTableName,
-					validPrepTaskConfigsTableName,
-					validPreparationIDColumn,
-					validPreparationsTableName,
-					idColumn,
-					validPrepTaskConfigsTableName,
-					archivedAtColumn,
-					buildFilterConditions(validPrepTaskConfigsTableName, true, false),
-					buildCursorLimitClause(validPrepTaskConfigsTableName),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetValidPrepTaskConfig",
-					Type: OneType,
+						strings.Join(fullSelectColumns, ",\n\t"),
+						buildFilterCountSelect(validPrepTaskConfigsTableName, true, true, []string{}),
+						buildTotalCountSelect(validPrepTaskConfigsTableName, true, []string{}),
+						validPrepTaskConfigsTableName,
+						validIngredientsTableName,
+						validPrepTaskConfigsTableName,
+						validIngredientIDColumn,
+						validIngredientsTableName,
+						idColumn,
+						validPreparationsTableName,
+						validPrepTaskConfigsTableName,
+						validPreparationIDColumn,
+						validPreparationsTableName,
+						idColumn,
+						validPrepTaskConfigsTableName,
+						archivedAtColumn,
+						buildFilterConditions(validPrepTaskConfigsTableName, true, false),
+						buildCursorLimitClause(validPrepTaskConfigsTableName),
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetValidPrepTaskConfig",
+						Type: OneType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s
 FROM %s
 	JOIN %s ON %s.%s = %s.%s
@@ -288,58 +237,31 @@ WHERE
 	AND %s.%s IS NULL
 	AND %s.%s IS NULL
 	AND %s.%s = sqlc.arg(%s);`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					validPrepTaskConfigsTableName,
-					validIngredientsTableName,
-					validPrepTaskConfigsTableName,
-					validIngredientIDColumn,
-					validIngredientsTableName,
-					idColumn,
-					validPreparationsTableName,
-					validPrepTaskConfigsTableName,
-					validPreparationIDColumn,
-					validPreparationsTableName,
-					idColumn,
-					validPrepTaskConfigsTableName,
-					archivedAtColumn,
-					validIngredientsTableName,
-					archivedAtColumn,
-					validPreparationsTableName,
-					archivedAtColumn,
-					validPrepTaskConfigsTableName,
-					idColumn,
-					idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "UpdateValidPrepTaskConfig",
-					Type: ExecRowsType,
+						strings.Join(fullSelectColumns, ",\n\t"),
+						validPrepTaskConfigsTableName,
+						validIngredientsTableName,
+						validPrepTaskConfigsTableName,
+						validIngredientIDColumn,
+						validIngredientsTableName,
+						idColumn,
+						validPreparationsTableName,
+						validPrepTaskConfigsTableName,
+						validPreparationIDColumn,
+						validPreparationsTableName,
+						idColumn,
+						validPrepTaskConfigsTableName,
+						archivedAtColumn,
+						validIngredientsTableName,
+						archivedAtColumn,
+						validPreparationsTableName,
+						archivedAtColumn,
+						validPrepTaskConfigsTableName,
+						idColumn,
+						idColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
-	%s,
-	%s = %s
-WHERE %s IS NULL
-	AND %s = sqlc.arg(%s);`,
-					validPrepTaskConfigsTableName,
-					strings.Join(applyToEach(filterForUpdate(validPrepTaskConfigsColumns), func(i int, s string) string {
-						switch s {
-						case "maximum_storage_duration_in_seconds",
-							"minimum_storage_temperature_in_celsius",
-							"maximum_storage_temperature_in_celsius":
-							return fmt.Sprintf("%s = sqlc.narg(%s)", s, s)
-						default:
-							return fmt.Sprintf("%s = sqlc.arg(%s)", s, s)
-						}
-					}), ",\n\t"),
-					lastUpdatedAtColumn,
-					currentTimeExpression,
-					archivedAtColumn,
-					idColumn,
-					idColumn,
-				)),
 			},
-		}
+		)
 	default:
 		return nil
 	}

--- a/backend/cmd/tools/codegen/queries/mealplanning_valid_preparation_instruments.go
+++ b/backend/cmd/tools/codegen/queries/mealplanning_valid_preparation_instruments.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"fmt"
+	"slices"
 	"strings"
+
+	"github.com/primandproper/platform-go/v11/database/querygen"
 
 	"github.com/cristalhq/builq"
 )
@@ -29,8 +32,6 @@ func buildValidPreparationInstrumentsQueries(database string) []*Query {
 	switch database {
 	case postgres:
 
-		insertColumns := filterForInsert(validPreparationInstrumentsColumns)
-
 		fullSelectColumns := mergeColumns(
 			mergeColumns(
 				applyToEach(filterFromSlice(validPreparationInstrumentsColumns, "valid_preparation_id", "valid_instrument_id"), func(i int, s string) string {
@@ -47,64 +48,18 @@ func buildValidPreparationInstrumentsQueries(database string) []*Query {
 			2,
 		)
 
-		return []*Query{
-			{
-				Annotation: QueryAnnotation{
-					Name: "ArchiveValidPreparationInstrument",
-					Type: ExecRowsType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET %s = %s WHERE %s IS NULL AND %s = sqlc.arg(%s);`,
-					validPreparationInstrumentsTableName,
-					archivedAtColumn,
-					currentTimeExpression,
-					archivedAtColumn,
-					idColumn,
-					idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CreateValidPreparationInstrument",
-					Type: ExecType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`INSERT INTO %s (
-	%s
-) VALUES (
-	%s
-);`,
-					validPreparationInstrumentsTableName,
-					strings.Join(insertColumns, ",\n\t"),
-					strings.Join(applyToEach(insertColumns, func(i int, s string) string {
-						return fmt.Sprintf("sqlc.arg(%s)", s)
-					}), ",\n\t"),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CheckValidPreparationInstrumentExistence",
-					Type: OneType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT EXISTS (
-	SELECT %s.%s
-	FROM %s
-	WHERE %s.%s IS NULL
-		AND %s.%s = sqlc.arg(%s)
-);`,
-					validPreparationInstrumentsTableName, idColumn,
-					validPreparationInstrumentsTableName,
-					validPreparationInstrumentsTableName,
-					archivedAtColumn,
-					validPreparationInstrumentsTableName,
-					idColumn,
-					idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetValidPreparationInstrumentsForInstrument",
-					Type: ManyType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+		return slices.Concat(
+			querygen.StandardCRUD(validPreparationInstrumentsTableName, validPreparationInstrumentsColumns,
+				querygen.WithEntity("ValidPreparationInstrument", "ValidPreparationInstruments"),
+				querygen.WithOmitted(querygen.GetQuery, querygen.ListQuery),
+			),
+			[]*Query{
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetValidPreparationInstrumentsForInstrument",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s
@@ -122,54 +77,54 @@ GROUP BY
 	%s.%s,
 	%s.%s
 %s;`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					buildFilterCountSelect(
+						strings.Join(fullSelectColumns, ",\n\t"),
+						buildFilterCountSelect(
+							validPreparationInstrumentsTableName,
+							true,
+							true,
+							[]string{
+								"valid_instruments ON valid_preparation_instruments.valid_instrument_id = valid_instruments.id",
+								"valid_preparations ON valid_preparation_instruments.valid_preparation_id = valid_preparations.id",
+							},
+							fmt.Sprintf("%s.%s IS NULL", validInstrumentsTableName, archivedAtColumn),
+							fmt.Sprintf("%s.%s IS NULL", validPreparationsTableName, archivedAtColumn),
+							fmt.Sprintf("%s.%s = sqlc.arg(%s)", validPreparationInstrumentsTableName, validInstrumentIDColumn, idColumn),
+						),
+						buildTotalCountSelect(
+							validPreparationInstrumentsTableName,
+							true,
+							[]string{
+								"valid_instruments ON valid_preparation_instruments.valid_instrument_id = valid_instruments.id",
+								"valid_preparations ON valid_preparation_instruments.valid_preparation_id = valid_preparations.id",
+							},
+							fmt.Sprintf("%s.%s IS NULL", validInstrumentsTableName, archivedAtColumn),
+							fmt.Sprintf("%s.%s IS NULL", validPreparationsTableName, archivedAtColumn),
+							fmt.Sprintf("%s.%s = sqlc.arg(%s)", validPreparationInstrumentsTableName, validInstrumentIDColumn, idColumn),
+						),
 						validPreparationInstrumentsTableName,
-						true,
-						true,
-						[]string{
-							"valid_instruments ON valid_preparation_instruments.valid_instrument_id = valid_instruments.id",
-							"valid_preparations ON valid_preparation_instruments.valid_preparation_id = valid_preparations.id",
-						},
-						fmt.Sprintf("%s.%s IS NULL", validInstrumentsTableName, archivedAtColumn),
-						fmt.Sprintf("%s.%s IS NULL", validPreparationsTableName, archivedAtColumn),
-						fmt.Sprintf("%s.%s = sqlc.arg(%s)", validPreparationInstrumentsTableName, validInstrumentIDColumn, idColumn),
-					),
-					buildTotalCountSelect(
-						validPreparationInstrumentsTableName,
-						true,
-						[]string{
-							"valid_instruments ON valid_preparation_instruments.valid_instrument_id = valid_instruments.id",
-							"valid_preparations ON valid_preparation_instruments.valid_preparation_id = valid_preparations.id",
-						},
-						fmt.Sprintf("%s.%s IS NULL", validInstrumentsTableName, archivedAtColumn),
-						fmt.Sprintf("%s.%s IS NULL", validPreparationsTableName, archivedAtColumn),
-						fmt.Sprintf("%s.%s = sqlc.arg(%s)", validPreparationInstrumentsTableName, validInstrumentIDColumn, idColumn),
-					),
-					validPreparationInstrumentsTableName,
-					validInstrumentsTableName, validPreparationInstrumentsTableName, validInstrumentIDColumn, validInstrumentsTableName, idColumn,
-					validPreparationsTableName, validPreparationInstrumentsTableName, validPreparationIDColumn, validPreparationsTableName, idColumn,
-					validPreparationInstrumentsTableName, archivedAtColumn,
-					validPreparationInstrumentsTableName, validInstrumentIDColumn, idColumn, ///
-					validInstrumentsTableName, archivedAtColumn,
-					validPreparationsTableName, archivedAtColumn,
-					buildFilterConditions(
-						validPreparationInstrumentsTableName,
-						true,
-						true,
-					),
-					validPreparationInstrumentsTableName, idColumn,
-					validPreparationsTableName, idColumn,
-					validInstrumentsTableName, idColumn,
-					buildCursorLimitClause(validPreparationInstrumentsTableName),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetValidPreparationInstrumentsForPreparation",
-					Type: ManyType,
+						validInstrumentsTableName, validPreparationInstrumentsTableName, validInstrumentIDColumn, validInstrumentsTableName, idColumn,
+						validPreparationsTableName, validPreparationInstrumentsTableName, validPreparationIDColumn, validPreparationsTableName, idColumn,
+						validPreparationInstrumentsTableName, archivedAtColumn,
+						validPreparationInstrumentsTableName, validInstrumentIDColumn, idColumn, ///
+						validInstrumentsTableName, archivedAtColumn,
+						validPreparationsTableName, archivedAtColumn,
+						buildFilterConditions(
+							validPreparationInstrumentsTableName,
+							true,
+							true,
+						),
+						validPreparationInstrumentsTableName, idColumn,
+						validPreparationsTableName, idColumn,
+						validInstrumentsTableName, idColumn,
+						buildCursorLimitClause(validPreparationInstrumentsTableName),
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetValidPreparationInstrumentsForPreparation",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s
@@ -187,54 +142,54 @@ GROUP BY
 	%s.%s,
 	%s.%s
 %s;`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					buildFilterCountSelect(
+						strings.Join(fullSelectColumns, ",\n\t"),
+						buildFilterCountSelect(
+							validPreparationInstrumentsTableName,
+							true,
+							true,
+							[]string{
+								"valid_instruments ON valid_preparation_instruments.valid_instrument_id = valid_instruments.id",
+								"valid_preparations ON valid_preparation_instruments.valid_preparation_id = valid_preparations.id",
+							},
+							fmt.Sprintf("%s.%s IS NULL", validInstrumentsTableName, archivedAtColumn),
+							fmt.Sprintf("%s.%s IS NULL", validPreparationsTableName, archivedAtColumn),
+							fmt.Sprintf("%s.%s = sqlc.arg(%s)", validPreparationInstrumentsTableName, validPreparationIDColumn, idColumn),
+						),
+						buildTotalCountSelect(
+							validPreparationInstrumentsTableName,
+							true,
+							[]string{
+								"valid_instruments ON valid_preparation_instruments.valid_instrument_id = valid_instruments.id",
+								"valid_preparations ON valid_preparation_instruments.valid_preparation_id = valid_preparations.id",
+							},
+							fmt.Sprintf("%s.%s IS NULL", validInstrumentsTableName, archivedAtColumn),
+							fmt.Sprintf("%s.%s IS NULL", validPreparationsTableName, archivedAtColumn),
+							fmt.Sprintf("%s.%s = sqlc.arg(%s)", validPreparationInstrumentsTableName, validPreparationIDColumn, idColumn),
+						),
 						validPreparationInstrumentsTableName,
-						true,
-						true,
-						[]string{
-							"valid_instruments ON valid_preparation_instruments.valid_instrument_id = valid_instruments.id",
-							"valid_preparations ON valid_preparation_instruments.valid_preparation_id = valid_preparations.id",
-						},
-						fmt.Sprintf("%s.%s IS NULL", validInstrumentsTableName, archivedAtColumn),
-						fmt.Sprintf("%s.%s IS NULL", validPreparationsTableName, archivedAtColumn),
-						fmt.Sprintf("%s.%s = sqlc.arg(%s)", validPreparationInstrumentsTableName, validPreparationIDColumn, idColumn),
-					),
-					buildTotalCountSelect(
-						validPreparationInstrumentsTableName,
-						true,
-						[]string{
-							"valid_instruments ON valid_preparation_instruments.valid_instrument_id = valid_instruments.id",
-							"valid_preparations ON valid_preparation_instruments.valid_preparation_id = valid_preparations.id",
-						},
-						fmt.Sprintf("%s.%s IS NULL", validInstrumentsTableName, archivedAtColumn),
-						fmt.Sprintf("%s.%s IS NULL", validPreparationsTableName, archivedAtColumn),
-						fmt.Sprintf("%s.%s = sqlc.arg(%s)", validPreparationInstrumentsTableName, validPreparationIDColumn, idColumn),
-					),
-					validPreparationInstrumentsTableName,
-					validInstrumentsTableName, validPreparationInstrumentsTableName, validInstrumentIDColumn, validInstrumentsTableName, idColumn,
-					validPreparationsTableName, validPreparationInstrumentsTableName, validPreparationIDColumn, validPreparationsTableName, idColumn,
-					validPreparationInstrumentsTableName, archivedAtColumn,
-					validPreparationInstrumentsTableName, validPreparationIDColumn, idColumn, ///
-					validInstrumentsTableName, archivedAtColumn,
-					validPreparationsTableName, archivedAtColumn,
-					buildFilterConditions(
-						validPreparationInstrumentsTableName,
-						true,
-						true,
-					),
-					validPreparationInstrumentsTableName, idColumn,
-					validPreparationsTableName, idColumn,
-					validInstrumentsTableName, idColumn,
-					buildCursorLimitClause(validPreparationInstrumentsTableName),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetValidPreparationInstruments",
-					Type: ManyType,
+						validInstrumentsTableName, validPreparationInstrumentsTableName, validInstrumentIDColumn, validInstrumentsTableName, idColumn,
+						validPreparationsTableName, validPreparationInstrumentsTableName, validPreparationIDColumn, validPreparationsTableName, idColumn,
+						validPreparationInstrumentsTableName, archivedAtColumn,
+						validPreparationInstrumentsTableName, validPreparationIDColumn, idColumn, ///
+						validInstrumentsTableName, archivedAtColumn,
+						validPreparationsTableName, archivedAtColumn,
+						buildFilterConditions(
+							validPreparationInstrumentsTableName,
+							true,
+							true,
+						),
+						validPreparationInstrumentsTableName, idColumn,
+						validPreparationsTableName, idColumn,
+						validInstrumentsTableName, idColumn,
+						buildCursorLimitClause(validPreparationInstrumentsTableName),
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetValidPreparationInstruments",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s
@@ -251,51 +206,51 @@ GROUP BY
 	%s.%s,
 	%s.%s
 %s;`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					buildFilterCountSelect(
+						strings.Join(fullSelectColumns, ",\n\t"),
+						buildFilterCountSelect(
+							validPreparationInstrumentsTableName,
+							true,
+							true,
+							[]string{
+								"valid_instruments ON valid_preparation_instruments.valid_instrument_id = valid_instruments.id",
+								"valid_preparations ON valid_preparation_instruments.valid_preparation_id = valid_preparations.id",
+							},
+							fmt.Sprintf("%s.%s IS NULL", validInstrumentsTableName, archivedAtColumn),
+							fmt.Sprintf("%s.%s IS NULL", validPreparationsTableName, archivedAtColumn),
+						),
+						buildTotalCountSelect(
+							validPreparationInstrumentsTableName,
+							true,
+							[]string{
+								"valid_instruments ON valid_preparation_instruments.valid_instrument_id = valid_instruments.id",
+								"valid_preparations ON valid_preparation_instruments.valid_preparation_id = valid_preparations.id",
+							},
+							fmt.Sprintf("%s.%s IS NULL", validInstrumentsTableName, archivedAtColumn),
+							fmt.Sprintf("%s.%s IS NULL", validPreparationsTableName, archivedAtColumn),
+						),
 						validPreparationInstrumentsTableName,
-						true,
-						true,
-						[]string{
-							"valid_instruments ON valid_preparation_instruments.valid_instrument_id = valid_instruments.id",
-							"valid_preparations ON valid_preparation_instruments.valid_preparation_id = valid_preparations.id",
-						},
-						fmt.Sprintf("%s.%s IS NULL", validInstrumentsTableName, archivedAtColumn),
-						fmt.Sprintf("%s.%s IS NULL", validPreparationsTableName, archivedAtColumn),
-					),
-					buildTotalCountSelect(
-						validPreparationInstrumentsTableName,
-						true,
-						[]string{
-							"valid_instruments ON valid_preparation_instruments.valid_instrument_id = valid_instruments.id",
-							"valid_preparations ON valid_preparation_instruments.valid_preparation_id = valid_preparations.id",
-						},
-						fmt.Sprintf("%s.%s IS NULL", validInstrumentsTableName, archivedAtColumn),
-						fmt.Sprintf("%s.%s IS NULL", validPreparationsTableName, archivedAtColumn),
-					),
-					validPreparationInstrumentsTableName,
-					validInstrumentsTableName, validPreparationInstrumentsTableName, validInstrumentIDColumn, validInstrumentsTableName, idColumn,
-					validPreparationsTableName, validPreparationInstrumentsTableName, validPreparationIDColumn, validPreparationsTableName, idColumn,
-					validPreparationInstrumentsTableName, archivedAtColumn,
-					validInstrumentsTableName, archivedAtColumn,
-					validPreparationsTableName, archivedAtColumn,
-					buildFilterConditions(
-						validPreparationInstrumentsTableName,
-						true,
-						true,
-					),
-					validPreparationInstrumentsTableName, idColumn,
-					validPreparationsTableName, idColumn,
-					validInstrumentsTableName, idColumn,
-					buildCursorLimitClause(validPreparationInstrumentsTableName),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetValidPreparationInstrument",
-					Type: OneType,
+						validInstrumentsTableName, validPreparationInstrumentsTableName, validInstrumentIDColumn, validInstrumentsTableName, idColumn,
+						validPreparationsTableName, validPreparationInstrumentsTableName, validPreparationIDColumn, validPreparationsTableName, idColumn,
+						validPreparationInstrumentsTableName, archivedAtColumn,
+						validInstrumentsTableName, archivedAtColumn,
+						validPreparationsTableName, archivedAtColumn,
+						buildFilterConditions(
+							validPreparationInstrumentsTableName,
+							true,
+							true,
+						),
+						validPreparationInstrumentsTableName, idColumn,
+						validPreparationsTableName, idColumn,
+						validInstrumentsTableName, idColumn,
+						buildCursorLimitClause(validPreparationInstrumentsTableName),
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetValidPreparationInstrument",
+						Type: OneType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s
 FROM
 	%s
@@ -306,22 +261,22 @@ WHERE
 	AND %s.%s IS NULL
 	AND %s.%s IS NULL
 	AND %s.%s = sqlc.arg(%s);`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					validPreparationInstrumentsTableName,
-					validInstrumentsTableName, validPreparationInstrumentsTableName, validInstrumentIDColumn, validInstrumentsTableName, idColumn,
-					validPreparationsTableName, validPreparationInstrumentsTableName, validPreparationIDColumn, validPreparationsTableName, idColumn,
-					validPreparationInstrumentsTableName, archivedAtColumn,
-					validInstrumentsTableName, archivedAtColumn,
-					validPreparationsTableName, archivedAtColumn,
-					validPreparationInstrumentsTableName, idColumn, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetValidPreparationInstrumentsByIDs",
-					Type: ManyType,
+						strings.Join(fullSelectColumns, ",\n\t"),
+						validPreparationInstrumentsTableName,
+						validInstrumentsTableName, validPreparationInstrumentsTableName, validInstrumentIDColumn, validInstrumentsTableName, idColumn,
+						validPreparationsTableName, validPreparationInstrumentsTableName, validPreparationIDColumn, validPreparationsTableName, idColumn,
+						validPreparationInstrumentsTableName, archivedAtColumn,
+						validInstrumentsTableName, archivedAtColumn,
+						validPreparationsTableName, archivedAtColumn,
+						validPreparationInstrumentsTableName, idColumn, idColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetValidPreparationInstrumentsByIDs",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s
 FROM
 	%s
@@ -332,57 +287,37 @@ WHERE
 	AND %s.%s IS NULL
 	AND %s.%s IS NULL
 	AND %s.%s = ANY(sqlc.arg(ids)::text[]);`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					validPreparationInstrumentsTableName,
-					validInstrumentsTableName, validPreparationInstrumentsTableName, validInstrumentIDColumn, validInstrumentsTableName, idColumn,
-					validPreparationsTableName, validPreparationInstrumentsTableName, validPreparationIDColumn, validPreparationsTableName, idColumn,
-					validPreparationInstrumentsTableName, archivedAtColumn,
-					validInstrumentsTableName, archivedAtColumn,
-					validPreparationsTableName, archivedAtColumn,
-					validPreparationInstrumentsTableName, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "ValidPreparationInstrumentPairIsValid",
-					Type: OneType,
+						strings.Join(fullSelectColumns, ",\n\t"),
+						validPreparationInstrumentsTableName,
+						validInstrumentsTableName, validPreparationInstrumentsTableName, validInstrumentIDColumn, validInstrumentsTableName, idColumn,
+						validPreparationsTableName, validPreparationInstrumentsTableName, validPreparationIDColumn, validPreparationsTableName, idColumn,
+						validPreparationInstrumentsTableName, archivedAtColumn,
+						validInstrumentsTableName, archivedAtColumn,
+						validPreparationsTableName, archivedAtColumn,
+						validPreparationInstrumentsTableName, idColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT EXISTS(
+				{
+					Annotation: QueryAnnotation{
+						Name: "ValidPreparationInstrumentPairIsValid",
+						Type: OneType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT EXISTS(
 	SELECT %s.%s
 	FROM %s
 	WHERE %s = sqlc.arg(%s)
 	AND %s = sqlc.arg(%s)
 	AND %s IS NULL
 );`,
-					validPreparationInstrumentsTableName, idColumn,
-					validPreparationInstrumentsTableName,
-					validInstrumentIDColumn, validInstrumentIDColumn,
-					validPreparationIDColumn, validPreparationIDColumn,
-					archivedAtColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "UpdateValidPreparationInstrument",
-					Type: ExecRowsType,
+						validPreparationInstrumentsTableName, idColumn,
+						validPreparationInstrumentsTableName,
+						validInstrumentIDColumn, validInstrumentIDColumn,
+						validPreparationIDColumn, validPreparationIDColumn,
+						archivedAtColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
-	%s,
-	%s = %s
-WHERE %s IS NULL
-	AND %s = sqlc.arg(%s);`,
-					validPreparationInstrumentsTableName,
-					strings.Join(applyToEach(filterForUpdate(validPreparationInstrumentsColumns), func(i int, s string) string {
-						return fmt.Sprintf("%s = sqlc.arg(%s)", s, s)
-					}), ",\n\t"),
-					lastUpdatedAtColumn,
-					currentTimeExpression,
-					archivedAtColumn,
-					idColumn,
-					idColumn,
-				)),
 			},
-		}
+		)
 	default:
 		return nil
 	}

--- a/backend/cmd/tools/codegen/queries/mealplanning_valid_preparation_vessels.go
+++ b/backend/cmd/tools/codegen/queries/mealplanning_valid_preparation_vessels.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"fmt"
+	"slices"
 	"strings"
+
+	"github.com/primandproper/platform-go/v11/database/querygen"
 
 	"github.com/cristalhq/builq"
 )
@@ -29,8 +32,6 @@ func buildValidPreparationVesselsQueries(database string) []*Query {
 	switch database {
 	case postgres:
 
-		insertColumns := filterForInsert(validPreparationVesselsColumns)
-
 		fullSelectColumns := append(
 			mergeColumns(
 				applyToEach(filterFromSlice(validPreparationVesselsColumns, "valid_preparation_id", "valid_vessel_id"), func(i int, s string) string {
@@ -52,61 +53,18 @@ func buildValidPreparationVesselsQueries(database string) []*Query {
 			)...,
 		)
 
-		return []*Query{
-			{
-				Annotation: QueryAnnotation{
-					Name: "ArchiveValidPreparationVessel",
-					Type: ExecRowsType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET %s = %s WHERE %s IS NULL AND %s = sqlc.arg(%s);`,
-					validPreparationVesselsTableName,
-					archivedAtColumn,
-					currentTimeExpression,
-					archivedAtColumn,
-					idColumn,
-					idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CreateValidPreparationVessel",
-					Type: ExecType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`INSERT INTO %s (
-	%s
-) VALUES (
-	%s
-);`,
-					validPreparationVesselsTableName,
-					strings.Join(insertColumns, ",\n\t"),
-					strings.Join(applyToEach(insertColumns, func(i int, s string) string {
-						return fmt.Sprintf("sqlc.arg(%s)", s)
-					}), ",\n\t"),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CheckValidPreparationVesselExistence",
-					Type: OneType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT EXISTS (
-	SELECT %s.%s
-	FROM %s
-	WHERE %s.%s IS NULL
-		AND %s.%s = sqlc.arg(%s)
-);`,
-					validPreparationVesselsTableName, idColumn,
-					validPreparationVesselsTableName,
-					validPreparationVesselsTableName, archivedAtColumn,
-					validPreparationVesselsTableName, idColumn, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetValidPreparationVesselsForPreparation",
-					Type: ManyType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+		return slices.Concat(
+			querygen.StandardCRUD(validPreparationVesselsTableName, validPreparationVesselsColumns,
+				querygen.WithEntity("ValidPreparationVessel", "ValidPreparationVessels"),
+				querygen.WithOmitted(querygen.GetQuery, querygen.ListQuery),
+			),
+			[]*Query{
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetValidPreparationVesselsForPreparation",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s
@@ -122,28 +80,28 @@ WHERE
 	AND %s.%s = sqlc.arg(%s)
 	%s
 %s;`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					buildFilterCountSelect(validPreparationVesselsTableName, true, true, []string{}),
-					buildTotalCountSelect(validPreparationVesselsTableName, true, []string{}),
-					validPreparationVesselsTableName,
-					validVesselsTableName, validPreparationVesselsTableName, validVesselIDColumn, validVesselsTableName, idColumn,
-					validPreparationsTableName, validPreparationVesselsTableName, validPreparationIDColumn, validPreparationsTableName, idColumn,
-					validMeasurementUnitsTableName, validVesselsTableName, capacityUnitColumn, validMeasurementUnitsTableName, idColumn,
-					validPreparationVesselsTableName, archivedAtColumn,
-					validVesselsTableName, archivedAtColumn,
-					validPreparationsTableName, archivedAtColumn,
-					validMeasurementUnitsTableName, archivedAtColumn,
-					validPreparationVesselsTableName, validPreparationIDColumn, idColumn,
-					buildFilterConditions(validPreparationVesselsTableName, true, false),
-					buildCursorLimitClause(validPreparationVesselsTableName),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetValidPreparationVesselsForVessel",
-					Type: ManyType,
+						strings.Join(fullSelectColumns, ",\n\t"),
+						buildFilterCountSelect(validPreparationVesselsTableName, true, true, []string{}),
+						buildTotalCountSelect(validPreparationVesselsTableName, true, []string{}),
+						validPreparationVesselsTableName,
+						validVesselsTableName, validPreparationVesselsTableName, validVesselIDColumn, validVesselsTableName, idColumn,
+						validPreparationsTableName, validPreparationVesselsTableName, validPreparationIDColumn, validPreparationsTableName, idColumn,
+						validMeasurementUnitsTableName, validVesselsTableName, capacityUnitColumn, validMeasurementUnitsTableName, idColumn,
+						validPreparationVesselsTableName, archivedAtColumn,
+						validVesselsTableName, archivedAtColumn,
+						validPreparationsTableName, archivedAtColumn,
+						validMeasurementUnitsTableName, archivedAtColumn,
+						validPreparationVesselsTableName, validPreparationIDColumn, idColumn,
+						buildFilterConditions(validPreparationVesselsTableName, true, false),
+						buildCursorLimitClause(validPreparationVesselsTableName),
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetValidPreparationVesselsForVessel",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s
@@ -159,29 +117,29 @@ WHERE
 	AND %s.%s = sqlc.arg(%s)
 	%s
 %s;`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					buildFilterCountSelect(validPreparationVesselsTableName, true, true, []string{}),
-					buildTotalCountSelect(validPreparationVesselsTableName, true, []string{}),
-					validPreparationVesselsTableName,
+						strings.Join(fullSelectColumns, ",\n\t"),
+						buildFilterCountSelect(validPreparationVesselsTableName, true, true, []string{}),
+						buildTotalCountSelect(validPreparationVesselsTableName, true, []string{}),
+						validPreparationVesselsTableName,
 
-					validVesselsTableName, validPreparationVesselsTableName, validVesselIDColumn, validVesselsTableName, idColumn,
-					validPreparationsTableName, validPreparationVesselsTableName, validPreparationIDColumn, validPreparationsTableName, idColumn,
-					validMeasurementUnitsTableName, validVesselsTableName, capacityUnitColumn, validMeasurementUnitsTableName, idColumn,
-					validPreparationVesselsTableName, archivedAtColumn,
-					validVesselsTableName, archivedAtColumn,
-					validPreparationsTableName, archivedAtColumn,
-					validMeasurementUnitsTableName, archivedAtColumn,
-					validPreparationVesselsTableName, validVesselIDColumn, idColumn,
-					buildFilterConditions(validPreparationVesselsTableName, true, false),
-					buildCursorLimitClause(validPreparationVesselsTableName),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetValidPreparationVessels",
-					Type: ManyType,
+						validVesselsTableName, validPreparationVesselsTableName, validVesselIDColumn, validVesselsTableName, idColumn,
+						validPreparationsTableName, validPreparationVesselsTableName, validPreparationIDColumn, validPreparationsTableName, idColumn,
+						validMeasurementUnitsTableName, validVesselsTableName, capacityUnitColumn, validMeasurementUnitsTableName, idColumn,
+						validPreparationVesselsTableName, archivedAtColumn,
+						validVesselsTableName, archivedAtColumn,
+						validPreparationsTableName, archivedAtColumn,
+						validMeasurementUnitsTableName, archivedAtColumn,
+						validPreparationVesselsTableName, validVesselIDColumn, idColumn,
+						buildFilterConditions(validPreparationVesselsTableName, true, false),
+						buildCursorLimitClause(validPreparationVesselsTableName),
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetValidPreparationVessels",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s
@@ -196,27 +154,27 @@ WHERE
 	AND %s.%s IS NULL
 	%s
 %s;`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					buildFilterCountSelect(validPreparationVesselsTableName, true, true, []string{}),
-					buildTotalCountSelect(validPreparationVesselsTableName, true, []string{}),
-					validPreparationVesselsTableName,
-					validVesselsTableName, validPreparationVesselsTableName, validVesselIDColumn, validVesselsTableName, idColumn,
-					validPreparationsTableName, validPreparationVesselsTableName, validPreparationIDColumn, validPreparationsTableName, idColumn,
-					validMeasurementUnitsTableName, validVesselsTableName, capacityUnitColumn, validMeasurementUnitsTableName, idColumn,
-					validPreparationVesselsTableName, archivedAtColumn,
-					validVesselsTableName, archivedAtColumn,
-					validPreparationsTableName, archivedAtColumn,
-					validMeasurementUnitsTableName, archivedAtColumn,
-					buildFilterConditions(validPreparationVesselsTableName, true, false),
-					buildCursorLimitClause(validPreparationVesselsTableName),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetValidPreparationVessel",
-					Type: OneType,
+						strings.Join(fullSelectColumns, ",\n\t"),
+						buildFilterCountSelect(validPreparationVesselsTableName, true, true, []string{}),
+						buildTotalCountSelect(validPreparationVesselsTableName, true, []string{}),
+						validPreparationVesselsTableName,
+						validVesselsTableName, validPreparationVesselsTableName, validVesselIDColumn, validVesselsTableName, idColumn,
+						validPreparationsTableName, validPreparationVesselsTableName, validPreparationIDColumn, validPreparationsTableName, idColumn,
+						validMeasurementUnitsTableName, validVesselsTableName, capacityUnitColumn, validMeasurementUnitsTableName, idColumn,
+						validPreparationVesselsTableName, archivedAtColumn,
+						validVesselsTableName, archivedAtColumn,
+						validPreparationsTableName, archivedAtColumn,
+						validMeasurementUnitsTableName, archivedAtColumn,
+						buildFilterConditions(validPreparationVesselsTableName, true, false),
+						buildCursorLimitClause(validPreparationVesselsTableName),
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetValidPreparationVessel",
+						Type: OneType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s
 FROM %s
 	JOIN %s ON %s.%s = %s.%s
@@ -228,24 +186,24 @@ WHERE
 	AND %s.%s IS NULL
 	AND %s.%s IS NULL
 	AND %s.%s = sqlc.arg(%s);`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					validPreparationVesselsTableName,
-					validVesselsTableName, validPreparationVesselsTableName, validVesselIDColumn, validVesselsTableName, idColumn,
-					validPreparationsTableName, validPreparationVesselsTableName, validPreparationIDColumn, validPreparationsTableName, idColumn,
-					validMeasurementUnitsTableName, validVesselsTableName, capacityUnitColumn, validMeasurementUnitsTableName, idColumn,
-					validPreparationVesselsTableName, archivedAtColumn,
-					validVesselsTableName, archivedAtColumn,
-					validPreparationsTableName, archivedAtColumn,
-					validMeasurementUnitsTableName, archivedAtColumn,
-					validPreparationVesselsTableName, idColumn, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetValidPreparationVesselsByIDs",
-					Type: ManyType,
+						strings.Join(fullSelectColumns, ",\n\t"),
+						validPreparationVesselsTableName,
+						validVesselsTableName, validPreparationVesselsTableName, validVesselIDColumn, validVesselsTableName, idColumn,
+						validPreparationsTableName, validPreparationVesselsTableName, validPreparationIDColumn, validPreparationsTableName, idColumn,
+						validMeasurementUnitsTableName, validVesselsTableName, capacityUnitColumn, validMeasurementUnitsTableName, idColumn,
+						validPreparationVesselsTableName, archivedAtColumn,
+						validVesselsTableName, archivedAtColumn,
+						validPreparationsTableName, archivedAtColumn,
+						validMeasurementUnitsTableName, archivedAtColumn,
+						validPreparationVesselsTableName, idColumn, idColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetValidPreparationVesselsByIDs",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s
 FROM %s
 	JOIN %s ON %s.%s = %s.%s
@@ -257,61 +215,41 @@ WHERE
 	AND %s.%s IS NULL
 	AND %s.%s IS NULL
 	AND %s.%s = ANY(sqlc.arg(ids)::text[]);`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					validPreparationVesselsTableName,
-					validVesselsTableName, validPreparationVesselsTableName, validVesselIDColumn, validVesselsTableName, idColumn,
-					validPreparationsTableName, validPreparationVesselsTableName, validPreparationIDColumn, validPreparationsTableName, idColumn,
-					validMeasurementUnitsTableName, validVesselsTableName, capacityUnitColumn, validMeasurementUnitsTableName, idColumn,
-					validPreparationVesselsTableName, archivedAtColumn,
-					validVesselsTableName, archivedAtColumn,
-					validPreparationsTableName, archivedAtColumn,
-					validMeasurementUnitsTableName, archivedAtColumn,
-					validPreparationVesselsTableName, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "ValidPreparationVesselPairIsValid",
-					Type: OneType,
+						strings.Join(fullSelectColumns, ",\n\t"),
+						validPreparationVesselsTableName,
+						validVesselsTableName, validPreparationVesselsTableName, validVesselIDColumn, validVesselsTableName, idColumn,
+						validPreparationsTableName, validPreparationVesselsTableName, validPreparationIDColumn, validPreparationsTableName, idColumn,
+						validMeasurementUnitsTableName, validVesselsTableName, capacityUnitColumn, validMeasurementUnitsTableName, idColumn,
+						validPreparationVesselsTableName, archivedAtColumn,
+						validVesselsTableName, archivedAtColumn,
+						validPreparationsTableName, archivedAtColumn,
+						validMeasurementUnitsTableName, archivedAtColumn,
+						validPreparationVesselsTableName, idColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT EXISTS(
+				{
+					Annotation: QueryAnnotation{
+						Name: "ValidPreparationVesselPairIsValid",
+						Type: OneType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT EXISTS(
 	SELECT %s
 	FROM %s
 	WHERE %s = sqlc.arg(%s)
 	AND %s = sqlc.arg(%s)
 	AND %s IS NULL
 );`,
-					idColumn,
-					validPreparationVesselsTableName,
-					validVesselIDColumn,
-					validVesselIDColumn,
-					validPreparationIDColumn,
-					validPreparationIDColumn,
-					archivedAtColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "UpdateValidPreparationVessel",
-					Type: ExecRowsType,
+						idColumn,
+						validPreparationVesselsTableName,
+						validVesselIDColumn,
+						validVesselIDColumn,
+						validPreparationIDColumn,
+						validPreparationIDColumn,
+						archivedAtColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
-	%s,
-	%s = %s
-WHERE %s IS NULL
-	AND %s = sqlc.arg(%s);`,
-					validPreparationVesselsTableName,
-					strings.Join(applyToEach(filterForUpdate(validPreparationVesselsColumns), func(i int, s string) string {
-						return fmt.Sprintf("%s = sqlc.arg(%s)", s, s)
-					}), ",\n\t"),
-					lastUpdatedAtColumn,
-					currentTimeExpression,
-					archivedAtColumn,
-					idColumn,
-					idColumn,
-				)),
 			},
-		}
+		)
 	default:
 		return nil
 	}

--- a/backend/cmd/tools/codegen/queries/notifications_user_notifications.go
+++ b/backend/cmd/tools/codegen/queries/notifications_user_notifications.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"fmt"
+	"slices"
 	"strings"
+
+	"github.com/primandproper/platform-go/v11/database/querygen"
 
 	"github.com/cristalhq/builq"
 )
@@ -32,116 +35,105 @@ func buildUserNotificationQueries(database string) []*Query {
 	switch database {
 	case postgres:
 
-		insertColumns := filterForInsert(userNotificationsColumns, "status")
 		fullSelectColumns := applyToEach(userNotificationsColumns, func(_ int, s string) string {
 			return fullColumnName(userNotificationsTableName, s)
 		})
 
-		return []*Query{
-			{
-				Annotation: QueryAnnotation{
-					Name: "CreateUserNotification",
-					Type: ExecType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`INSERT INTO %s (
-	%s
-) VALUES (
-	%s
-);`,
-					userNotificationsTableName,
-					strings.Join(insertColumns, ",\n\t"),
-					strings.Join(applyToEach(insertColumns, func(_ int, s string) string {
-						return fmt.Sprintf("sqlc.arg(%s)", s)
-					}), ",\n\t"),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetUserNotification",
-					Type: OneType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+		return slices.Concat(
+			querygen.StandardCRUD(userNotificationsTableName, userNotificationsColumns,
+				querygen.WithEntity("UserNotification", "UserNotifications"),
+				querygen.WithDatabaseOwned("status"),
+				querygen.WithOmitted(querygen.ExistsQuery, querygen.GetQuery, querygen.ListQuery, querygen.UpdateQuery),
+			),
+			[]*Query{
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetUserNotification",
+						Type: OneType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s
 FROM %s
 WHERE %s = sqlc.arg(%s)
 AND %s.%s = sqlc.arg(%s);`,
-					strings.Join(applyToEach(userNotificationsColumns, func(i int, s string) string {
-						return fmt.Sprintf("%s.%s", userNotificationsTableName, s)
-					}), ",\n\t"),
-					userNotificationsTableName,
-					belongsToUserColumn, belongsToUserColumn,
-					userNotificationsTableName, idColumn, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CheckUserNotificationExistence",
-					Type: OneType,
+						strings.Join(applyToEach(userNotificationsColumns, func(i int, s string) string {
+							return fmt.Sprintf("%s.%s", userNotificationsTableName, s)
+						}), ",\n\t"),
+						userNotificationsTableName,
+						belongsToUserColumn, belongsToUserColumn,
+						userNotificationsTableName, idColumn, idColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT EXISTS(
+				{
+					Annotation: QueryAnnotation{
+						Name: "CheckUserNotificationExistence",
+						Type: OneType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT EXISTS(
 	SELECT %s.%s
 	FROM %s
 	WHERE %s.%s = sqlc.arg(%s)
 	AND %s.%s = sqlc.arg(%s)
 );`,
-					userNotificationsTableName, idColumn,
-					userNotificationsTableName,
-					userNotificationsTableName, idColumn, idColumn,
-					userNotificationsTableName, belongsToUserColumn, belongsToUserColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetUserNotificationsForUser",
-					Type: ManyType,
+						userNotificationsTableName, idColumn,
+						userNotificationsTableName,
+						userNotificationsTableName, idColumn, idColumn,
+						userNotificationsTableName, belongsToUserColumn, belongsToUserColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetUserNotificationsForUser",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s
 FROM %s
 WHERE %s%s
 %s;`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					buildFilterCountSelect(
+						strings.Join(fullSelectColumns, ",\n\t"),
+						buildFilterCountSelect(
+							userNotificationsTableName,
+							true,
+							false,
+							nil,
+							fmt.Sprintf("user_notifications.status != '%s'", userNotificationStatusDismissed),
+							"user_notifications.belongs_to_user = sqlc.arg(user_id)",
+						),
+						buildTotalCountSelect(
+							userNotificationsTableName,
+							false,
+							nil,
+							fmt.Sprintf("user_notifications.status != '%s'", userNotificationStatusDismissed),
+							"user_notifications.belongs_to_user = sqlc.arg(user_id)",
+						),
 						userNotificationsTableName,
-						true,
-						false,
-						nil,
-						fmt.Sprintf("user_notifications.status != '%s'", userNotificationStatusDismissed),
-						"user_notifications.belongs_to_user = sqlc.arg(user_id)",
-					),
-					buildTotalCountSelect(
-						userNotificationsTableName,
-						false,
-						nil,
-						fmt.Sprintf("user_notifications.status != '%s'", userNotificationStatusDismissed),
-						"user_notifications.belongs_to_user = sqlc.arg(user_id)",
-					),
-					userNotificationsTableName,
-					fmt.Sprintf("user_notifications.status != '%s'\n\t", userNotificationStatusDismissed),
-					buildFilterConditions(userNotificationsTableName, true, false, "user_notifications.belongs_to_user = sqlc.arg(user_id)"),
-					buildCursorLimitClause(userNotificationsTableName),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "UpdateUserNotification",
-					Type: ExecRowsType,
+						fmt.Sprintf("user_notifications.status != '%s'\n\t", userNotificationStatusDismissed),
+						buildFilterConditions(userNotificationsTableName, true, false, "user_notifications.belongs_to_user = sqlc.arg(user_id)"),
+						buildCursorLimitClause(userNotificationsTableName),
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
+				{
+					Annotation: QueryAnnotation{
+						Name: "UpdateUserNotification",
+						Type: ExecRowsType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
 	%s,
 	%s = %s
 WHERE %s = sqlc.arg(%s);`,
-					userNotificationsTableName,
-					strings.Join(applyToEach(filterForUpdate(userNotificationsColumns, contentColumn, belongsToUserColumn), func(i int, s string) string {
-						return fmt.Sprintf("%s = sqlc.arg(%s)", s, s)
-					}), ",\n\t"),
-					lastUpdatedAtColumn, currentTimeExpression,
-					idColumn, idColumn,
-				)),
+						userNotificationsTableName,
+						strings.Join(applyToEach(filterForUpdate(userNotificationsColumns, contentColumn, belongsToUserColumn), func(i int, s string) string {
+							return fmt.Sprintf("%s = sqlc.arg(%s)", s, s)
+						}), ",\n\t"),
+						lastUpdatedAtColumn, currentTimeExpression,
+						idColumn, idColumn,
+					)),
+				},
 			},
-		}
+		)
 	default:
 		return nil
 	}

--- a/backend/cmd/tools/codegen/queries/oauth_oauth2_clients.go
+++ b/backend/cmd/tools/codegen/queries/oauth_oauth2_clients.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"fmt"
+	"slices"
 	"strings"
+
+	"github.com/primandproper/platform-go/v11/database/querygen"
 
 	"github.com/cristalhq/builq"
 )
@@ -29,91 +32,44 @@ var oauth2ClientsColumns = []string{
 func buildOAuth2ClientsQueries(database string) []*Query {
 	switch database {
 	case postgres:
-		insertColumns := filterForInsert(oauth2ClientsColumns)
 
-		return []*Query{
-			{
-				Annotation: QueryAnnotation{
-					Name: "ArchiveOAuth2Client",
-					Type: ExecRowsType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
-	%s = %s
-WHERE %s IS NULL
-	AND %s = sqlc.arg(%s);`,
-					oauth2ClientsTableName,
-					archivedAtColumn,
-					currentTimeExpression,
-					archivedAtColumn,
-					idColumn,
-					idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CreateOAuth2Client",
-					Type: ExecType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`INSERT INTO %s (
-	%s
-) VALUES (
-	%s
-);`,
-					oauth2ClientsTableName,
-					strings.Join(insertColumns, ",\n\t"),
-					strings.Join(applyToEach(insertColumns, func(_ int, s string) string {
-						return fmt.Sprintf("sqlc.arg(%s)", s)
-					}), ",\n\t"),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetOAuth2ClientByClientID",
-					Type: OneType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+		return slices.Concat(
+			querygen.StandardCRUD(oauth2ClientsTableName, oauth2ClientsColumns,
+				querygen.WithEntity("OAuth2Client", "OAuth2Clients"),
+				querygen.WithQueryName(querygen.GetQuery, "GetOAuth2ClientByDatabaseID"),
+				querygen.WithOmitted(querygen.ExistsQuery, querygen.ListQuery, querygen.UpdateQuery),
+			),
+			[]*Query{
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetOAuth2ClientByClientID",
+						Type: OneType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s
 FROM %s
 WHERE %s.%s IS NULL
 	AND %s.%s = sqlc.arg(%s);`,
-					strings.Join(applyToEach(oauth2ClientsColumns, func(_ int, s string) string {
-						return fmt.Sprintf("%s.%s", oauth2ClientsTableName, s)
-					}), ",\n\t"),
-					oauth2ClientsTableName,
-					oauth2ClientsTableName, archivedAtColumn,
-					oauth2ClientsTableName, clientIDColumn, clientIDColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetOAuth2ClientByDatabaseID",
-					Type: OneType,
+						strings.Join(applyToEach(oauth2ClientsColumns, func(_ int, s string) string {
+							return fmt.Sprintf("%s.%s", oauth2ClientsTableName, s)
+						}), ",\n\t"),
+						oauth2ClientsTableName,
+						oauth2ClientsTableName, archivedAtColumn,
+						oauth2ClientsTableName, clientIDColumn, clientIDColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
-	%s
-FROM %s
-WHERE %s.%s IS NULL
-	AND %s.%s = sqlc.arg(%s);`,
-					strings.Join(applyToEach(oauth2ClientsColumns, func(_ int, s string) string {
-						return fmt.Sprintf("%s.%s", oauth2ClientsTableName, s)
-					}), ",\n\t"),
-					oauth2ClientsTableName,
-					oauth2ClientsTableName, archivedAtColumn,
-					oauth2ClientsTableName, idColumn, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetOAuth2Clients",
-					Type: ManyType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetOAuth2Clients",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	(
 		SELECT COUNT(%s.%s)
 		FROM %s
 		WHERE %s.%s IS NULL
-			%s
+				%s
 	) as filtered_count,
 	%s
 FROM %s
@@ -121,32 +77,33 @@ WHERE %s.%s IS NULL
 	%s
 %s;
 `,
-					strings.Join(applyToEach(oauth2ClientsColumns, func(_ int, s string) string {
-						return fmt.Sprintf("%s.%s", oauth2ClientsTableName, s)
-					}), ",\n\t"),
-					oauth2ClientsTableName, idColumn,
-					oauth2ClientsTableName,
-					oauth2ClientsTableName, archivedAtColumn,
-					strings.Join(strings.Split(
+						strings.Join(applyToEach(oauth2ClientsColumns, func(_ int, s string) string {
+							return fmt.Sprintf("%s.%s", oauth2ClientsTableName, s)
+						}), ",\n\t"),
+						oauth2ClientsTableName, idColumn,
+						oauth2ClientsTableName,
+						oauth2ClientsTableName, archivedAtColumn,
+						strings.Join(strings.Split(
+							buildFilterConditions(
+								oauth2ClientsTableName,
+								false,
+								true,
+							), "\n"),
+							"\n\t\t",
+						),
+						buildTotalCountSelect(usersTableName, true, []string{}),
+						oauth2ClientsTableName,
+						oauth2ClientsTableName, archivedAtColumn,
 						buildFilterConditions(
 							oauth2ClientsTableName,
 							false,
 							true,
-						), "\n"),
-						"\n\t\t",
-					),
-					buildTotalCountSelect(usersTableName, true, []string{}),
-					oauth2ClientsTableName,
-					oauth2ClientsTableName, archivedAtColumn,
-					buildFilterConditions(
-						oauth2ClientsTableName,
-						false,
-						true,
-					),
-					buildCursorLimitClause(oauth2ClientsTableName),
-				)),
+						),
+						buildCursorLimitClause(oauth2ClientsTableName),
+					)),
+				},
 			},
-		}
+		)
 	default:
 		return nil
 	}

--- a/backend/cmd/tools/codegen/queries/payments_products.go
+++ b/backend/cmd/tools/codegen/queries/payments_products.go
@@ -1,8 +1,10 @@
 package main
 
 import (
-	"fmt"
+	"slices"
 	"strings"
+
+	"github.com/primandproper/platform-go/v11/database/querygen"
 
 	"github.com/cristalhq/builq"
 )
@@ -32,97 +34,51 @@ var productsColumns = []string{
 func buildPaymentsProductsQueries(database string) []*Query {
 	switch database {
 	case postgres:
-		insertColumns := filterForInsert(productsColumns)
 		fullSelectColumns := applyToEach(productsColumns, func(_ int, s string) string {
 			return fullColumnName(productsTableName, s)
 		})
 
-		return []*Query{
-			{
-				Annotation: QueryAnnotation{
-					Name: "ArchiveProduct",
-					Type: ExecRowsType,
+		return slices.Concat(
+			querygen.StandardCRUD(productsTableName, productsColumns,
+				querygen.WithEntity("Product", "Products"),
+				querygen.WithOmitted(querygen.ArchiveQuery, querygen.ListQuery),
+			),
+			[]*Query{
+				{
+					Annotation: QueryAnnotation{
+						Name: "ArchiveProduct",
+						Type: ExecRowsType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET %s = %s, %s = %s WHERE %s IS NULL AND %s = sqlc.arg(%s);`,
+						productsTableName,
+						archivedAtColumn, currentTimeExpression,
+						lastUpdatedAtColumn, currentTimeExpression,
+						archivedAtColumn,
+						idColumn, idColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET %s = %s, %s = %s WHERE %s IS NULL AND %s = sqlc.arg(%s);`,
-					productsTableName,
-					archivedAtColumn, currentTimeExpression,
-					lastUpdatedAtColumn, currentTimeExpression,
-					archivedAtColumn,
-					idColumn, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CreateProduct",
-					Type: ExecType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`INSERT INTO %s (
-	%s
-) VALUES (
-	%s
-);`,
-					productsTableName,
-					strings.Join(insertColumns, ",\n\t"),
-					strings.Join(applyToEach(insertColumns, func(_ int, s string) string {
-						return fmt.Sprintf("sqlc.arg(%s)", s)
-					}), ",\n\t"),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CheckProductExistence",
-					Type: OneType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT EXISTS (
-	SELECT %s.%s
-	FROM %s
-	WHERE %s.%s IS NULL
-	AND %s.%s = sqlc.arg(%s)
-);`,
-					productsTableName, idColumn,
-					productsTableName,
-					productsTableName, archivedAtColumn,
-					productsTableName, idColumn, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetProduct",
-					Type: OneType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
-	%s
-FROM %s
-WHERE %s.%s IS NULL
-AND %s.%s = sqlc.arg(%s);`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					productsTableName,
-					productsTableName, archivedAtColumn,
-					productsTableName, idColumn, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetProductByExternalID",
-					Type: OneType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetProductByExternalID",
+						Type: OneType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s
 FROM %s
 WHERE %s.%s IS NULL
 AND %s.external_product_id = sqlc.arg(external_product_id);`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					productsTableName,
-					productsTableName, archivedAtColumn,
-					productsTableName,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetProducts",
-					Type: ManyType,
+						strings.Join(fullSelectColumns, ",\n\t"),
+						productsTableName,
+						productsTableName, archivedAtColumn,
+						productsTableName,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetProducts",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s
@@ -130,21 +86,21 @@ FROM %s
 WHERE %s.%s IS NULL
 	%s
 %s;`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					buildFilterCountSelect(productsTableName, true, true, []string{}),
-					buildTotalCountSelect(productsTableName, true, []string{}),
-					productsTableName,
-					productsTableName, archivedAtColumn,
-					buildFilterConditions(productsTableName, true, true),
-					buildCursorLimitClause(productsTableName),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "SearchForProducts",
-					Type: ManyType,
+						strings.Join(fullSelectColumns, ",\n\t"),
+						buildFilterCountSelect(productsTableName, true, true, []string{}),
+						buildTotalCountSelect(productsTableName, true, []string{}),
+						productsTableName,
+						productsTableName, archivedAtColumn,
+						buildFilterConditions(productsTableName, true, true),
+						buildCursorLimitClause(productsTableName),
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "SearchForProducts",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s
@@ -153,36 +109,18 @@ WHERE %s.%s IS NULL
 	AND %s.%s %s
 	%s
 %s;`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					buildFilterCountSelect(productsTableName, true, true, []string{}),
-					buildTotalCountSelect(productsTableName, true, []string{}),
-					productsTableName,
-					productsTableName, archivedAtColumn,
-					productsTableName, nameColumn, buildILIKEForArgument("name_query"),
-					buildFilterConditions(productsTableName, true, true),
-					buildCursorLimitClause(productsTableName),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "UpdateProduct",
-					Type: ExecRowsType,
+						strings.Join(fullSelectColumns, ",\n\t"),
+						buildFilterCountSelect(productsTableName, true, true, []string{}),
+						buildTotalCountSelect(productsTableName, true, []string{}),
+						productsTableName,
+						productsTableName, archivedAtColumn,
+						productsTableName, nameColumn, buildILIKEForArgument("name_query"),
+						buildFilterConditions(productsTableName, true, true),
+						buildCursorLimitClause(productsTableName),
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
-	%s,
-	%s = %s
-WHERE %s IS NULL
-	AND %s = sqlc.arg(%s);`,
-					productsTableName,
-					strings.Join(applyToEach(filterForUpdate(productsColumns), func(_ int, s string) string {
-						return fmt.Sprintf("%s = sqlc.arg(%s)", s, s)
-					}), ",\n\t"),
-					lastUpdatedAtColumn, currentTimeExpression,
-					archivedAtColumn,
-					idColumn, idColumn,
-				)),
 			},
-		}
+		)
 	default:
 		return nil
 	}

--- a/backend/cmd/tools/codegen/queries/payments_purchases.go
+++ b/backend/cmd/tools/codegen/queries/payments_purchases.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"fmt"
+	"slices"
 	"strings"
+
+	"github.com/primandproper/platform-go/v11/database/querygen"
 
 	"github.com/cristalhq/builq"
 )
@@ -31,52 +34,23 @@ var purchasesColumns = []string{
 func buildPaymentsPurchasesQueries(database string) []*Query {
 	switch database {
 	case postgres:
-		insertColumns := filterForInsert(purchasesColumns)
 		fullSelectColumns := applyToEach(purchasesColumns, func(_ int, s string) string {
 			return fullColumnName(purchasesTableName, s)
 		})
 		accountCondition := fmt.Sprintf("%s.%s = sqlc.arg(%s)", purchasesTableName, belongsToAccountColumn, belongsToAccountColumn)
 
-		return []*Query{
-			{
-				Annotation: QueryAnnotation{
-					Name: "CreatePurchase",
-					Type: ExecType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`INSERT INTO %s (
-	%s
-) VALUES (
-	%s
-);`,
-					purchasesTableName,
-					strings.Join(insertColumns, ",\n\t"),
-					strings.Join(applyToEach(insertColumns, func(_ int, s string) string {
-						return fmt.Sprintf("sqlc.arg(%s)", s)
-					}), ",\n\t"),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetPurchase",
-					Type: OneType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
-	%s
-FROM %s
-WHERE %s.%s IS NULL
-AND %s.%s = sqlc.arg(%s);`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					purchasesTableName,
-					purchasesTableName, archivedAtColumn,
-					purchasesTableName, idColumn, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetPurchasesForAccount",
-					Type: ManyType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+		return slices.Concat(
+			querygen.StandardCRUD(purchasesTableName, purchasesColumns,
+				querygen.WithEntity("Purchase", "Purchases"),
+				querygen.WithOmitted(querygen.ArchiveQuery, querygen.ExistsQuery, querygen.ListQuery, querygen.UpdateQuery),
+			),
+			[]*Query{
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetPurchasesForAccount",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s
@@ -85,17 +59,18 @@ WHERE %s.%s IS NULL
 	AND %s
 	%s
 %s;`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					buildFilterCountSelect(purchasesTableName, true, true, nil, accountCondition),
-					buildTotalCountSelect(purchasesTableName, true, nil, accountCondition),
-					purchasesTableName,
-					purchasesTableName, archivedAtColumn,
-					accountCondition,
-					buildFilterConditions(purchasesTableName, true, false, accountCondition),
-					buildCursorLimitClause(purchasesTableName),
-				)),
+						strings.Join(fullSelectColumns, ",\n\t"),
+						buildFilterCountSelect(purchasesTableName, true, true, nil, accountCondition),
+						buildTotalCountSelect(purchasesTableName, true, nil, accountCondition),
+						purchasesTableName,
+						purchasesTableName, archivedAtColumn,
+						accountCondition,
+						buildFilterConditions(purchasesTableName, true, false, accountCondition),
+						buildCursorLimitClause(purchasesTableName),
+					)),
+				},
 			},
-		}
+		)
 	default:
 		return nil
 	}

--- a/backend/cmd/tools/codegen/queries/payments_subscriptions.go
+++ b/backend/cmd/tools/codegen/queries/payments_subscriptions.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"fmt"
+	"slices"
 	"strings"
+
+	"github.com/primandproper/platform-go/v11/database/querygen"
 
 	"github.com/cristalhq/builq"
 )
@@ -32,81 +35,53 @@ var subscriptionsColumns = []string{
 func buildPaymentsSubscriptionsQueries(database string) []*Query {
 	switch database {
 	case postgres:
-		insertColumns := filterForInsert(subscriptionsColumns)
 		fullSelectColumns := applyToEach(subscriptionsColumns, func(_ int, s string) string {
 			return fullColumnName(subscriptionsTableName, s)
 		})
 		accountCondition := fmt.Sprintf("%s.%s = sqlc.arg(%s)", subscriptionsTableName, belongsToAccountColumn, belongsToAccountColumn)
 
-		return []*Query{
-			{
-				Annotation: QueryAnnotation{
-					Name: "ArchiveSubscription",
-					Type: ExecRowsType,
+		return slices.Concat(
+			querygen.StandardCRUD(subscriptionsTableName, subscriptionsColumns,
+				querygen.WithEntity("Subscription", "Subscriptions"),
+				querygen.WithImmutable(belongsToAccountColumn, "product_id"),
+				querygen.WithOmitted(querygen.ArchiveQuery, querygen.ExistsQuery, querygen.ListQuery),
+			),
+			[]*Query{
+				{
+					Annotation: QueryAnnotation{
+						Name: "ArchiveSubscription",
+						Type: ExecRowsType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET %s = %s, %s = %s WHERE %s IS NULL AND %s = sqlc.arg(%s);`,
+						subscriptionsTableName,
+						archivedAtColumn, currentTimeExpression,
+						lastUpdatedAtColumn, currentTimeExpression,
+						archivedAtColumn,
+						idColumn, idColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET %s = %s, %s = %s WHERE %s IS NULL AND %s = sqlc.arg(%s);`,
-					subscriptionsTableName,
-					archivedAtColumn, currentTimeExpression,
-					lastUpdatedAtColumn, currentTimeExpression,
-					archivedAtColumn,
-					idColumn, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CreateSubscription",
-					Type: ExecType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`INSERT INTO %s (
-	%s
-) VALUES (
-	%s
-);`,
-					subscriptionsTableName,
-					strings.Join(insertColumns, ",\n\t"),
-					strings.Join(applyToEach(insertColumns, func(_ int, s string) string {
-						return fmt.Sprintf("sqlc.arg(%s)", s)
-					}), ",\n\t"),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetSubscription",
-					Type: OneType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetSubscriptionByExternalID",
+						Type: OneType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s
 FROM %s
 WHERE %s.%s IS NULL
 AND %s.%s = sqlc.arg(%s);`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					subscriptionsTableName,
-					subscriptionsTableName, archivedAtColumn,
-					subscriptionsTableName, idColumn, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetSubscriptionByExternalID",
-					Type: OneType,
+						strings.Join(fullSelectColumns, ",\n\t"),
+						subscriptionsTableName,
+						subscriptionsTableName, archivedAtColumn,
+						subscriptionsTableName, externalSubscriptionIDColumn, externalSubscriptionIDColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
-	%s
-FROM %s
-WHERE %s.%s IS NULL
-AND %s.%s = sqlc.arg(%s);`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					subscriptionsTableName,
-					subscriptionsTableName, archivedAtColumn,
-					subscriptionsTableName, externalSubscriptionIDColumn, externalSubscriptionIDColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetSubscriptionsForAccount",
-					Type: ManyType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetSubscriptionsForAccount",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s
@@ -115,49 +90,31 @@ WHERE %s.%s IS NULL
 	AND %s
 	%s
 %s;`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					buildFilterCountSelect(subscriptionsTableName, true, true, nil, accountCondition),
-					buildTotalCountSelect(subscriptionsTableName, true, nil, accountCondition),
-					subscriptionsTableName,
-					subscriptionsTableName, archivedAtColumn,
-					accountCondition,
-					buildFilterConditions(subscriptionsTableName, true, false, accountCondition),
-					buildCursorLimitClause(subscriptionsTableName),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "UpdateSubscription",
-					Type: ExecRowsType,
+						strings.Join(fullSelectColumns, ",\n\t"),
+						buildFilterCountSelect(subscriptionsTableName, true, true, nil, accountCondition),
+						buildTotalCountSelect(subscriptionsTableName, true, nil, accountCondition),
+						subscriptionsTableName,
+						subscriptionsTableName, archivedAtColumn,
+						accountCondition,
+						buildFilterConditions(subscriptionsTableName, true, false, accountCondition),
+						buildCursorLimitClause(subscriptionsTableName),
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
-	%s,
-	%s = %s
-WHERE %s IS NULL
-	AND %s = sqlc.arg(%s);`,
-					subscriptionsTableName,
-					strings.Join(applyToEach(filterForUpdate(subscriptionsColumns, belongsToAccountColumn, "product_id"), func(_ int, s string) string {
-						return fmt.Sprintf("%s = sqlc.arg(%s)", s, s)
-					}), ",\n\t"),
-					lastUpdatedAtColumn, currentTimeExpression,
-					archivedAtColumn,
-					idColumn, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "UpdateSubscriptionStatus",
-					Type: ExecRowsType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET status = sqlc.arg(status), %s = %s
+				{
+					Annotation: QueryAnnotation{
+						Name: "UpdateSubscriptionStatus",
+						Type: ExecRowsType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET status = sqlc.arg(status), %s = %s
 WHERE %s IS NULL AND %s = sqlc.arg(%s);`,
-					subscriptionsTableName,
-					lastUpdatedAtColumn, currentTimeExpression,
-					archivedAtColumn,
-					idColumn, idColumn,
-				)),
+						subscriptionsTableName,
+						lastUpdatedAtColumn, currentTimeExpression,
+						archivedAtColumn,
+						idColumn, idColumn,
+					)),
+				},
 			},
-		}
+		)
 	default:
 		return nil
 	}

--- a/backend/cmd/tools/codegen/queries/payments_transactions.go
+++ b/backend/cmd/tools/codegen/queries/payments_transactions.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"fmt"
+	"slices"
 	"strings"
+
+	"github.com/primandproper/platform-go/v11/database/querygen"
 
 	"github.com/cristalhq/builq"
 )
@@ -30,36 +33,23 @@ var paymentTransactionsColumns = []string{
 func buildPaymentsTransactionsQueries(database string) []*Query {
 	switch database {
 	case postgres:
-		insertColumns := filterForInsert(paymentTransactionsColumns)
 		fullSelectColumns := applyToEach(paymentTransactionsColumns, func(_ int, s string) string {
 			return fullColumnName(paymentTransactionsTableName, s)
 		})
 		accountCondition := fmt.Sprintf("%s.%s = sqlc.arg(%s)", paymentTransactionsTableName, belongsToAccountColumn, belongsToAccountColumn)
 
-		return []*Query{
-			{
-				Annotation: QueryAnnotation{
-					Name: "CreatePaymentTransaction",
-					Type: ExecType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`INSERT INTO %s (
-	%s
-) VALUES (
-	%s
-);`,
-					paymentTransactionsTableName,
-					strings.Join(insertColumns, ",\n\t"),
-					strings.Join(applyToEach(insertColumns, func(_ int, s string) string {
-						return fmt.Sprintf("sqlc.arg(%s)", s)
-					}), ",\n\t"),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetPaymentTransactionsForAccount",
-					Type: ManyType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+		return slices.Concat(
+			querygen.StandardCRUD(paymentTransactionsTableName, paymentTransactionsColumns,
+				querygen.WithEntity("PaymentTransaction", "PaymentTransactions"),
+				querygen.WithOmitted(querygen.ExistsQuery, querygen.GetQuery, querygen.ListQuery, querygen.UpdateQuery),
+			),
+			[]*Query{
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetPaymentTransactionsForAccount",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s
@@ -67,16 +57,17 @@ FROM %s
 WHERE %s
 	%s
 %s;`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					buildFilterCountSelect(paymentTransactionsTableName, false, false, nil, accountCondition),
-					buildTotalCountSelect(paymentTransactionsTableName, false, nil, accountCondition),
-					paymentTransactionsTableName,
-					accountCondition,
-					buildFilterConditions(paymentTransactionsTableName, false, false, accountCondition),
-					buildCursorLimitClause(paymentTransactionsTableName),
-				)),
+						strings.Join(fullSelectColumns, ",\n\t"),
+						buildFilterCountSelect(paymentTransactionsTableName, false, false, nil, accountCondition),
+						buildTotalCountSelect(paymentTransactionsTableName, false, nil, accountCondition),
+						paymentTransactionsTableName,
+						accountCondition,
+						buildFilterConditions(paymentTransactionsTableName, false, false, accountCondition),
+						buildCursorLimitClause(paymentTransactionsTableName),
+					)),
+				},
 			},
-		}
+		)
 	default:
 		return nil
 	}

--- a/backend/cmd/tools/codegen/queries/settings_service_setting_configurations.go
+++ b/backend/cmd/tools/codegen/queries/settings_service_setting_configurations.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"fmt"
+	"slices"
 	"strings"
+
+	"github.com/primandproper/platform-go/v11/database/querygen"
 
 	"github.com/cristalhq/builq"
 )
@@ -34,8 +37,6 @@ func buildServiceSettingConfigurationQueries(database string) []*Query {
 	switch database {
 	case postgres:
 
-		insertColumns := filterForInsert(serviceSettingConfigurationsColumns)
-
 		selectColumnsWithServiceSettingColumns := mergeColumns(
 			applyToEach(filterFromSlice(serviceSettingConfigurationsColumns, "service_setting_id"), func(i int, s string) string {
 				return fmt.Sprintf("%s.%s", serviceSettingConfigurationsTableName, s)
@@ -46,84 +47,38 @@ func buildServiceSettingConfigurationQueries(database string) []*Query {
 			3,
 		)
 
-		return []*Query{
-			{
-				Annotation: QueryAnnotation{
-					Name: "ArchiveServiceSettingConfiguration",
-					Type: ExecRowsType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
-	%s = %s
-WHERE %s IS NULL
-	AND %s = sqlc.arg(%s);`,
-					serviceSettingConfigurationsTableName,
-					archivedAtColumn,
-					currentTimeExpression,
-					archivedAtColumn,
-					idColumn,
-					idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CreateServiceSettingConfiguration",
-					Type: ExecType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`INSERT INTO %s (
-	%s
-) VALUES (
-	%s
-);`,
-					serviceSettingConfigurationsTableName,
-					strings.Join(insertColumns, ",\n\t"),
-					strings.Join(applyToEach(insertColumns, func(_ int, s string) string {
-						return fmt.Sprintf("sqlc.arg(%s)", s)
-					}), ",\n\t"),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CheckServiceSettingConfigurationExistence",
-					Type: OneType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT EXISTS (
-	SELECT %s.%s
-	FROM %s
-	WHERE %s.%s IS NULL
-		AND %s.%s = sqlc.arg(%s)
-);`,
-					serviceSettingConfigurationsTableName, idColumn,
-					serviceSettingConfigurationsTableName,
-					serviceSettingConfigurationsTableName, archivedAtColumn,
-					serviceSettingConfigurationsTableName, idColumn, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetServiceSettingConfigurationByID",
-					Type: OneType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+		return slices.Concat(
+			querygen.StandardCRUD(serviceSettingConfigurationsTableName, serviceSettingConfigurationsColumns,
+				querygen.WithEntity("ServiceSettingConfiguration", "ServiceSettingConfigurations"),
+				querygen.WithOmitted(querygen.GetQuery, querygen.ListQuery),
+			),
+			[]*Query{
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetServiceSettingConfigurationByID",
+						Type: OneType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s
 FROM %s
 	JOIN %s ON %s.%s=%s.%s
 WHERE %s.%s IS NULL
 	AND %s.%s IS NULL
 	AND %s.%s = sqlc.arg(%s);`,
-					strings.Join(selectColumnsWithServiceSettingColumns, ",\n\t"),
-					serviceSettingConfigurationsTableName,
-					serviceSettingsTableName, serviceSettingConfigurationsTableName, serviceSettingIDColumn, serviceSettingsTableName, idColumn,
-					serviceSettingsTableName, archivedAtColumn,
-					serviceSettingConfigurationsTableName, archivedAtColumn,
-					serviceSettingConfigurationsTableName, idColumn, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetServiceSettingConfigurationForAccountBySettingName",
-					Type: OneType,
+						strings.Join(selectColumnsWithServiceSettingColumns, ",\n\t"),
+						serviceSettingConfigurationsTableName,
+						serviceSettingsTableName, serviceSettingConfigurationsTableName, serviceSettingIDColumn, serviceSettingsTableName, idColumn,
+						serviceSettingsTableName, archivedAtColumn,
+						serviceSettingConfigurationsTableName, archivedAtColumn,
+						serviceSettingConfigurationsTableName, idColumn, idColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetServiceSettingConfigurationForAccountBySettingName",
+						Type: OneType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s
 FROM %s
 	JOIN %s ON %s.%s=%s.%s
@@ -131,21 +86,21 @@ WHERE %s.%s IS NULL
 	AND %s.%s IS NULL
 	AND %s.%s = sqlc.arg(%s)
 	AND %s.%s = sqlc.arg(%s);`,
-					strings.Join(selectColumnsWithServiceSettingColumns, ",\n\t"),
-					serviceSettingConfigurationsTableName,
-					serviceSettingsTableName, serviceSettingConfigurationsTableName, serviceSettingIDColumn, serviceSettingsTableName, idColumn,
-					serviceSettingsTableName, archivedAtColumn,
-					serviceSettingConfigurationsTableName, archivedAtColumn,
-					serviceSettingsTableName, nameColumn, nameColumn,
-					serviceSettingConfigurationsTableName, belongsToAccountColumn, belongsToAccountColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetServiceSettingConfigurationForUserBySettingName",
-					Type: OneType,
+						strings.Join(selectColumnsWithServiceSettingColumns, ",\n\t"),
+						serviceSettingConfigurationsTableName,
+						serviceSettingsTableName, serviceSettingConfigurationsTableName, serviceSettingIDColumn, serviceSettingsTableName, idColumn,
+						serviceSettingsTableName, archivedAtColumn,
+						serviceSettingConfigurationsTableName, archivedAtColumn,
+						serviceSettingsTableName, nameColumn, nameColumn,
+						serviceSettingConfigurationsTableName, belongsToAccountColumn, belongsToAccountColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetServiceSettingConfigurationForUserBySettingName",
+						Type: OneType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s
 FROM %s
 	JOIN %s ON %s.%s=%s.%s
@@ -153,21 +108,21 @@ WHERE %s.%s IS NULL
 	AND %s.%s IS NULL
 	AND %s.%s = sqlc.arg(%s)
 	AND %s.%s = sqlc.arg(%s);`,
-					strings.Join(selectColumnsWithServiceSettingColumns, ",\n\t"),
-					serviceSettingConfigurationsTableName,
-					serviceSettingsTableName, serviceSettingConfigurationsTableName, serviceSettingIDColumn, serviceSettingsTableName, idColumn,
-					serviceSettingsTableName, archivedAtColumn,
-					serviceSettingConfigurationsTableName, archivedAtColumn,
-					serviceSettingsTableName, nameColumn, nameColumn,
-					serviceSettingConfigurationsTableName, belongsToUserColumn, belongsToUserColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetServiceSettingConfigurationsForAccount",
-					Type: ManyType,
+						strings.Join(selectColumnsWithServiceSettingColumns, ",\n\t"),
+						serviceSettingConfigurationsTableName,
+						serviceSettingsTableName, serviceSettingConfigurationsTableName, serviceSettingIDColumn, serviceSettingsTableName, idColumn,
+						serviceSettingsTableName, archivedAtColumn,
+						serviceSettingConfigurationsTableName, archivedAtColumn,
+						serviceSettingsTableName, nameColumn, nameColumn,
+						serviceSettingConfigurationsTableName, belongsToUserColumn, belongsToUserColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetServiceSettingConfigurationsForAccount",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s
@@ -178,28 +133,28 @@ WHERE %s.%s IS NULL
 	AND %s.%s = sqlc.arg(%s)
 	%s
 %s;`,
-					strings.Join(selectColumnsWithServiceSettingColumns, ",\n\t"),
-					buildFilterCountSelect(serviceSettingConfigurationsTableName, true, true, []string{}, fmt.Sprintf("%s.%s = sqlc.arg(%s)", serviceSettingConfigurationsTableName, belongsToAccountColumn, belongsToAccountColumn)),
-					buildTotalCountSelect(serviceSettingConfigurationsTableName, true, []string{}, fmt.Sprintf("%s.%s = sqlc.arg(%s)", serviceSettingConfigurationsTableName, belongsToAccountColumn, belongsToAccountColumn)),
-					serviceSettingConfigurationsTableName,
-					serviceSettingsTableName, serviceSettingConfigurationsTableName, serviceSettingIDColumn, serviceSettingsTableName, idColumn,
-					serviceSettingsTableName, archivedAtColumn,
-					serviceSettingConfigurationsTableName, archivedAtColumn,
-					serviceSettingConfigurationsTableName, belongsToAccountColumn, belongsToAccountColumn,
-					buildFilterConditions(
+						strings.Join(selectColumnsWithServiceSettingColumns, ",\n\t"),
+						buildFilterCountSelect(serviceSettingConfigurationsTableName, true, true, []string{}, fmt.Sprintf("%s.%s = sqlc.arg(%s)", serviceSettingConfigurationsTableName, belongsToAccountColumn, belongsToAccountColumn)),
+						buildTotalCountSelect(serviceSettingConfigurationsTableName, true, []string{}, fmt.Sprintf("%s.%s = sqlc.arg(%s)", serviceSettingConfigurationsTableName, belongsToAccountColumn, belongsToAccountColumn)),
 						serviceSettingConfigurationsTableName,
-						true,
-						true,
-					),
-					buildCursorLimitClause(serviceSettingConfigurationsTableName),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetServiceSettingConfigurationsForUser",
-					Type: ManyType,
+						serviceSettingsTableName, serviceSettingConfigurationsTableName, serviceSettingIDColumn, serviceSettingsTableName, idColumn,
+						serviceSettingsTableName, archivedAtColumn,
+						serviceSettingConfigurationsTableName, archivedAtColumn,
+						serviceSettingConfigurationsTableName, belongsToAccountColumn, belongsToAccountColumn,
+						buildFilterConditions(
+							serviceSettingConfigurationsTableName,
+							true,
+							true,
+						),
+						buildCursorLimitClause(serviceSettingConfigurationsTableName),
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetServiceSettingConfigurationsForUser",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s
@@ -210,42 +165,24 @@ WHERE %s.%s IS NULL
 	AND %s.%s = sqlc.arg(%s)
 	%s
 %s;`,
-					strings.Join(selectColumnsWithServiceSettingColumns, ",\n\t"),
-					buildFilterCountSelect(serviceSettingConfigurationsTableName, true, true, []string{}, fmt.Sprintf("%s.%s = sqlc.arg(%s)", serviceSettingConfigurationsTableName, belongsToUserColumn, belongsToUserColumn)),
-					buildTotalCountSelect(serviceSettingConfigurationsTableName, true, []string{}, fmt.Sprintf("%s.%s = sqlc.arg(%s)", serviceSettingConfigurationsTableName, belongsToUserColumn, belongsToUserColumn)),
-					serviceSettingConfigurationsTableName,
-					serviceSettingsTableName, serviceSettingConfigurationsTableName, serviceSettingIDColumn, serviceSettingsTableName, idColumn,
-					serviceSettingsTableName, archivedAtColumn,
-					serviceSettingConfigurationsTableName, archivedAtColumn,
-					serviceSettingConfigurationsTableName, belongsToUserColumn, belongsToUserColumn,
-					buildFilterConditions(
+						strings.Join(selectColumnsWithServiceSettingColumns, ",\n\t"),
+						buildFilterCountSelect(serviceSettingConfigurationsTableName, true, true, []string{}, fmt.Sprintf("%s.%s = sqlc.arg(%s)", serviceSettingConfigurationsTableName, belongsToUserColumn, belongsToUserColumn)),
+						buildTotalCountSelect(serviceSettingConfigurationsTableName, true, []string{}, fmt.Sprintf("%s.%s = sqlc.arg(%s)", serviceSettingConfigurationsTableName, belongsToUserColumn, belongsToUserColumn)),
 						serviceSettingConfigurationsTableName,
-						true,
-						true,
-					),
-					buildCursorLimitClause(serviceSettingConfigurationsTableName),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "UpdateServiceSettingConfiguration",
-					Type: ExecRowsType,
+						serviceSettingsTableName, serviceSettingConfigurationsTableName, serviceSettingIDColumn, serviceSettingsTableName, idColumn,
+						serviceSettingsTableName, archivedAtColumn,
+						serviceSettingConfigurationsTableName, archivedAtColumn,
+						serviceSettingConfigurationsTableName, belongsToUserColumn, belongsToUserColumn,
+						buildFilterConditions(
+							serviceSettingConfigurationsTableName,
+							true,
+							true,
+						),
+						buildCursorLimitClause(serviceSettingConfigurationsTableName),
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
-	%s,
-	%s = %s
-WHERE %s IS NULL
-	AND %s = sqlc.arg(%s);`,
-					serviceSettingConfigurationsTableName,
-					strings.Join(applyToEach(filterForUpdate(serviceSettingConfigurationsColumns), func(i int, s string) string {
-						return fmt.Sprintf("%s = sqlc.arg(%s)", s, s)
-					}), ",\n\t"),
-					lastUpdatedAtColumn, currentTimeExpression,
-					archivedAtColumn,
-					idColumn, idColumn,
-				)),
 			},
-		}
+		)
 	default:
 		return nil
 	}

--- a/backend/cmd/tools/codegen/queries/settings_service_settings.go
+++ b/backend/cmd/tools/codegen/queries/settings_service_settings.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"fmt"
+	"slices"
 	"strings"
+
+	"github.com/primandproper/platform-go/v11/database/querygen"
 
 	"github.com/cristalhq/builq"
 )
@@ -32,62 +35,31 @@ func buildServiceSettingQueries(database string) []*Query {
 	switch database {
 	case postgres:
 
-		insertColumns := filterForInsert(serviceSettingsColumns)
-
-		return []*Query{
-			{
-				Annotation: QueryAnnotation{
-					Name: "ArchiveServiceSetting",
-					Type: ExecRowsType,
+		return slices.Concat(
+			querygen.StandardCRUD(serviceSettingsTableName, serviceSettingsColumns,
+				querygen.WithEntity("ServiceSetting", "ServiceSettings"),
+				querygen.WithOmitted(querygen.ArchiveQuery, querygen.ListQuery, querygen.UpdateQuery),
+			),
+			[]*Query{
+				{
+					Annotation: QueryAnnotation{
+						Name: "ArchiveServiceSetting",
+						Type: ExecRowsType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET %s = %s WHERE %s = sqlc.arg(%s);`,
+						serviceSettingsTableName,
+						archivedAtColumn,
+						currentTimeExpression,
+						idColumn,
+						idColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET %s = %s WHERE %s = sqlc.arg(%s);`,
-					serviceSettingsTableName,
-					archivedAtColumn,
-					currentTimeExpression,
-					idColumn,
-					idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CreateServiceSetting",
-					Type: ExecType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`INSERT INTO %s (
-	%s
-) VALUES (
-	%s
-);`,
-					serviceSettingsTableName,
-					strings.Join(insertColumns, ",\n\t"),
-					strings.Join(applyToEach(insertColumns, func(_ int, s string) string {
-						return fmt.Sprintf("sqlc.arg(%s)", s)
-					}), ",\n\t"),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CheckServiceSettingExistence",
-					Type: OneType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT EXISTS (
-	SELECT %s.%s
-	FROM %s
-	WHERE %s.%s IS NULL
-	AND %s.%s = sqlc.arg(%s)
-);`,
-					serviceSettingsTableName, idColumn,
-					serviceSettingsTableName,
-					serviceSettingsTableName, archivedAtColumn,
-					serviceSettingsTableName, idColumn, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetServiceSettings",
-					Type: ManyType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetServiceSettings",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s
@@ -95,45 +67,27 @@ FROM %s
 WHERE %s.%s IS NULL
 	%s
 %s;`,
-					strings.Join(applyToEach(serviceSettingsColumns, func(i int, s string) string {
-						return fmt.Sprintf("%s.%s", serviceSettingsTableName, s)
-					}), ",\n\t"),
-					buildFilterCountSelect(serviceSettingsTableName, true, true, []string{}),
-					buildTotalCountSelect(serviceSettingsTableName, true, []string{}),
-					serviceSettingsTableName,
-					serviceSettingsTableName, archivedAtColumn,
-					buildFilterConditions(
+						strings.Join(applyToEach(serviceSettingsColumns, func(i int, s string) string {
+							return fmt.Sprintf("%s.%s", serviceSettingsTableName, s)
+						}), ",\n\t"),
+						buildFilterCountSelect(serviceSettingsTableName, true, true, []string{}),
+						buildTotalCountSelect(serviceSettingsTableName, true, []string{}),
 						serviceSettingsTableName,
-						true,
-						true,
-					),
-					buildCursorLimitClause(serviceSettingsTableName),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetServiceSetting",
-					Type: OneType,
+						serviceSettingsTableName, archivedAtColumn,
+						buildFilterConditions(
+							serviceSettingsTableName,
+							true,
+							true,
+						),
+						buildCursorLimitClause(serviceSettingsTableName),
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
-	%s
-FROM %s
-WHERE %s.%s IS NULL
-	AND %s.%s = sqlc.arg(%s);`,
-					strings.Join(applyToEach(serviceSettingsColumns, func(i int, s string) string {
-						return fmt.Sprintf("%s.%s", serviceSettingsTableName, s)
-					}), ",\n\t"),
-					serviceSettingsTableName,
-					serviceSettingsTableName, archivedAtColumn,
-					serviceSettingsTableName, idColumn, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "SearchForServiceSettings",
-					Type: ManyType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "SearchForServiceSettings",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s
@@ -142,26 +96,27 @@ WHERE %s.%s IS NULL
 	AND %s.%s %s
 	%s
 %s;`,
-					strings.Join(applyToEach(serviceSettingsColumns, func(i int, s string) string {
-						return fmt.Sprintf("%s.%s", serviceSettingsTableName, s)
-					}), ",\n\t"),
-					buildFilterCountSelect(serviceSettingsTableName, true, true, []string{}),
-					buildTotalCountSelect(serviceSettingsTableName, true, []string{}),
-					serviceSettingsTableName,
-					serviceSettingsTableName,
-					archivedAtColumn,
-					serviceSettingsTableName,
-					nameColumn,
-					buildILIKEForArgument("name_query"),
-					buildFilterConditions(
+						strings.Join(applyToEach(serviceSettingsColumns, func(i int, s string) string {
+							return fmt.Sprintf("%s.%s", serviceSettingsTableName, s)
+						}), ",\n\t"),
+						buildFilterCountSelect(serviceSettingsTableName, true, true, []string{}),
+						buildTotalCountSelect(serviceSettingsTableName, true, []string{}),
 						serviceSettingsTableName,
-						true,
-						true,
-					),
-					buildCursorLimitClause(serviceSettingsTableName),
-				)),
+						serviceSettingsTableName,
+						archivedAtColumn,
+						serviceSettingsTableName,
+						nameColumn,
+						buildILIKEForArgument("name_query"),
+						buildFilterConditions(
+							serviceSettingsTableName,
+							true,
+							true,
+						),
+						buildCursorLimitClause(serviceSettingsTableName),
+					)),
+				},
 			},
-		}
+		)
 	default:
 		return nil
 	}

--- a/backend/cmd/tools/codegen/queries/uploadedmedia_uploaded_media.go
+++ b/backend/cmd/tools/codegen/queries/uploadedmedia_uploaded_media.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"fmt"
+	"slices"
 	"strings"
+
+	"github.com/primandproper/platform-go/v11/database/querygen"
 
 	"github.com/cristalhq/builq"
 )
@@ -30,120 +33,73 @@ var uploadedMediaColumns = []string{
 func buildUploadedMediaQueries(database string) []*Query {
 	switch database {
 	case postgres:
-		insertColumns := filterForInsert(uploadedMediaColumns)
 		fullSelectColumns := applyToEach(uploadedMediaColumns, func(_ int, s string) string {
 			return fullColumnName(uploadedMediaTableName, s)
 		})
 
-		return []*Query{
-			{
-				Annotation: QueryAnnotation{
-					Name: "CreateUploadedMedia",
-					Type: ExecType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`INSERT INTO %s (
-	%s
-) VALUES (
-	%s
-);`,
-					uploadedMediaTableName,
-					strings.Join(insertColumns, ",\n\t"),
-					strings.Join(applyToEach(insertColumns, func(_ int, s string) string {
-						return fmt.Sprintf("sqlc.arg(%s)", s)
-					}), ",\n\t"),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "UpdateUploadedMedia",
-					Type: ExecRowsType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
-	%s,
-	%s = %s
-WHERE %s IS NULL
-	AND %s = sqlc.arg(%s);`,
-					uploadedMediaTableName,
-					strings.Join(applyToEach(filterForUpdate(uploadedMediaColumns, createdByUserColumn), func(_ int, s string) string {
-						return fmt.Sprintf("%s = sqlc.arg(%s)", s, s)
-					}), ",\n\t"),
-					lastUpdatedAtColumn, currentTimeExpression,
-					archivedAtColumn,
-					idColumn, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "ArchiveUploadedMedia",
-					Type: ExecRowsType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
+		return slices.Concat(
+			querygen.StandardCRUD(uploadedMediaTableName, uploadedMediaColumns,
+				querygen.WithEntity("UploadedMedia", "UploadedMedias"),
+				querygen.WithImmutable(createdByUserColumn),
+				querygen.WithOmitted(querygen.ArchiveQuery, querygen.ExistsQuery, querygen.ListQuery),
+			),
+			[]*Query{
+				{
+					Annotation: QueryAnnotation{
+						Name: "ArchiveUploadedMedia",
+						Type: ExecRowsType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
 	%s = %s,
 	%s = %s
 WHERE %s IS NULL
 	AND %s = sqlc.arg(%s);`,
-					uploadedMediaTableName,
-					lastUpdatedAtColumn, currentTimeExpression,
-					archivedAtColumn, currentTimeExpression,
-					archivedAtColumn,
-					idColumn, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetUploadedMedia",
-					Type: OneType,
+						uploadedMediaTableName,
+						lastUpdatedAtColumn, currentTimeExpression,
+						archivedAtColumn, currentTimeExpression,
+						archivedAtColumn,
+						idColumn, idColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
-	%s
-FROM %s
-WHERE %s.%s IS NULL
-	AND %s.%s = sqlc.arg(%s);`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					uploadedMediaTableName,
-					uploadedMediaTableName, archivedAtColumn,
-					uploadedMediaTableName, idColumn, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CheckUploadedMediaExistence",
-					Type: OneType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT EXISTS(
+				{
+					Annotation: QueryAnnotation{
+						Name: "CheckUploadedMediaExistence",
+						Type: OneType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT EXISTS(
 	SELECT %s.%s
 	FROM %s
 	WHERE %s.%s IS NULL
 		AND %s.%s = sqlc.arg(%s)
 );`,
-					uploadedMediaTableName, idColumn,
-					uploadedMediaTableName,
-					uploadedMediaTableName, archivedAtColumn,
-					uploadedMediaTableName, idColumn, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetUploadedMediaWithIDs",
-					Type: ManyType,
+						uploadedMediaTableName, idColumn,
+						uploadedMediaTableName,
+						uploadedMediaTableName, archivedAtColumn,
+						uploadedMediaTableName, idColumn, idColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetUploadedMediaWithIDs",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s
 FROM %s
 WHERE %s.%s IS NULL
 	AND %s.%s = ANY(sqlc.arg(ids)::text[]);`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					uploadedMediaTableName,
-					uploadedMediaTableName, archivedAtColumn,
-					uploadedMediaTableName, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetUploadedMediaForUser",
-					Type: ManyType,
+						strings.Join(fullSelectColumns, ",\n\t"),
+						uploadedMediaTableName,
+						uploadedMediaTableName, archivedAtColumn,
+						uploadedMediaTableName, idColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetUploadedMediaForUser",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s
@@ -152,17 +108,18 @@ WHERE %s.%s IS NULL
 	AND %s.%s = sqlc.arg(%s)
 	%s
 %s;`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					buildFilterCountSelect(uploadedMediaTableName, true, true, nil, fmt.Sprintf("%s.%s = sqlc.arg(%s)", uploadedMediaTableName, createdByUserColumn, createdByUserColumn)),
-					buildTotalCountSelect(uploadedMediaTableName, true, nil, fmt.Sprintf("%s.%s = sqlc.arg(%s)", uploadedMediaTableName, createdByUserColumn, createdByUserColumn)),
-					uploadedMediaTableName,
-					uploadedMediaTableName, archivedAtColumn,
-					uploadedMediaTableName, createdByUserColumn, createdByUserColumn,
-					buildFilterConditions(uploadedMediaTableName, true, false, fmt.Sprintf("%s.%s = sqlc.arg(%s)", uploadedMediaTableName, createdByUserColumn, createdByUserColumn)),
-					buildCursorLimitClause(uploadedMediaTableName),
-				)),
+						strings.Join(fullSelectColumns, ",\n\t"),
+						buildFilterCountSelect(uploadedMediaTableName, true, true, nil, fmt.Sprintf("%s.%s = sqlc.arg(%s)", uploadedMediaTableName, createdByUserColumn, createdByUserColumn)),
+						buildTotalCountSelect(uploadedMediaTableName, true, nil, fmt.Sprintf("%s.%s = sqlc.arg(%s)", uploadedMediaTableName, createdByUserColumn, createdByUserColumn)),
+						uploadedMediaTableName,
+						uploadedMediaTableName, archivedAtColumn,
+						uploadedMediaTableName, createdByUserColumn, createdByUserColumn,
+						buildFilterConditions(uploadedMediaTableName, true, false, fmt.Sprintf("%s.%s = sqlc.arg(%s)", uploadedMediaTableName, createdByUserColumn, createdByUserColumn)),
+						buildCursorLimitClause(uploadedMediaTableName),
+					)),
+				},
 			},
-		}
+		)
 	default:
 		return nil
 	}

--- a/backend/cmd/tools/codegen/queries/waitlists_waitlist_signups.go
+++ b/backend/cmd/tools/codegen/queries/waitlists_waitlist_signups.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"fmt"
+	"slices"
 	"strings"
+
+	"github.com/primandproper/platform-go/v11/database/querygen"
 
 	"github.com/cristalhq/builq"
 )
@@ -31,124 +34,78 @@ var waitlistSignupColumns = []string{
 func buildWaitlistSignupsQueries(database string) []*Query {
 	switch database {
 	case postgres:
-		insertColumns := filterForInsert(waitlistSignupColumns)
 		fullSelectColumns := applyToEach(waitlistSignupColumns, func(_ int, s string) string {
 			return fullColumnName(waitlistSignupsTableName, s)
 		})
 
-		return []*Query{
-			{
-				Annotation: QueryAnnotation{
-					Name: "CreateWaitlistSignup",
-					Type: ExecType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`INSERT INTO %s (
-	%s
-) VALUES (
-	%s
-);`,
-					waitlistSignupsTableName,
-					strings.Join(insertColumns, ",\n\t"),
-					strings.Join(applyToEach(insertColumns, func(_ int, s string) string {
-						return fmt.Sprintf("sqlc.arg(%s)", s)
-					}), ",\n\t"),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "UpdateWaitlistSignup",
-					Type: ExecRowsType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
-	%s,
-	%s = %s
-WHERE %s IS NULL
-	AND %s = sqlc.arg(%s);`,
-					waitlistSignupsTableName,
-					strings.Join(applyToEach(filterForUpdate(waitlistSignupColumns, belongsToWaitlistColumn, belongsToUserColumn, belongsToAccountColumn), func(_ int, s string) string {
-						return fmt.Sprintf("%s = sqlc.arg(%s)", s, s)
-					}), ",\n\t"),
-					lastUpdatedAtColumn, currentTimeExpression,
-					archivedAtColumn,
-					idColumn, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "ArchiveWaitlistSignup",
-					Type: ExecRowsType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
+		return slices.Concat(
+			querygen.StandardCRUD(waitlistSignupsTableName, waitlistSignupColumns,
+				querygen.WithEntity("WaitlistSignup", "WaitlistSignups"),
+				querygen.WithImmutable(belongsToWaitlistColumn, belongsToUserColumn, belongsToAccountColumn),
+				querygen.WithQueryName(querygen.GetQuery, "GetWaitlistSignupByID"),
+				querygen.WithOmitted(querygen.ArchiveQuery, querygen.ExistsQuery, querygen.ListQuery),
+			),
+			[]*Query{
+				{
+					Annotation: QueryAnnotation{
+						Name: "ArchiveWaitlistSignup",
+						Type: ExecRowsType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
 	%s = %s,
 	%s = %s
 WHERE %s IS NULL
 	AND %s = sqlc.arg(%s);`,
-					waitlistSignupsTableName,
-					lastUpdatedAtColumn, currentTimeExpression,
-					archivedAtColumn, currentTimeExpression,
-					archivedAtColumn,
-					idColumn, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetWaitlistSignup",
-					Type: OneType,
+						waitlistSignupsTableName,
+						lastUpdatedAtColumn, currentTimeExpression,
+						archivedAtColumn, currentTimeExpression,
+						archivedAtColumn,
+						idColumn, idColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetWaitlistSignup",
+						Type: OneType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s
 FROM %s
 WHERE %s.%s IS NULL
 	AND %s.%s = sqlc.arg(%s)
 	AND %s.%s = sqlc.arg(%s);`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					waitlistSignupsTableName,
-					waitlistSignupsTableName, archivedAtColumn,
-					waitlistSignupsTableName, idColumn, idColumn,
-					waitlistSignupsTableName, belongsToWaitlistColumn, belongsToWaitlistColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetWaitlistSignupByID",
-					Type: OneType,
+						strings.Join(fullSelectColumns, ",\n\t"),
+						waitlistSignupsTableName,
+						waitlistSignupsTableName, archivedAtColumn,
+						waitlistSignupsTableName, idColumn, idColumn,
+						waitlistSignupsTableName, belongsToWaitlistColumn, belongsToWaitlistColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
-	%s
-FROM %s
-WHERE %s.%s IS NULL
-	AND %s.%s = sqlc.arg(%s);`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					waitlistSignupsTableName,
-					waitlistSignupsTableName, archivedAtColumn,
-					waitlistSignupsTableName, idColumn, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CheckWaitlistSignupExistence",
-					Type: OneType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT EXISTS(
+				{
+					Annotation: QueryAnnotation{
+						Name: "CheckWaitlistSignupExistence",
+						Type: OneType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT EXISTS(
 	SELECT %s.%s
 	FROM %s
 	WHERE %s.%s IS NULL
 		AND %s.%s = sqlc.arg(%s)
 		AND %s.%s = sqlc.arg(%s)
 );`,
-					waitlistSignupsTableName, idColumn,
-					waitlistSignupsTableName,
-					waitlistSignupsTableName, archivedAtColumn,
-					waitlistSignupsTableName, idColumn, idColumn,
-					waitlistSignupsTableName, belongsToWaitlistColumn, belongsToWaitlistColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetWaitlistSignupsForWaitlist",
-					Type: ManyType,
+						waitlistSignupsTableName, idColumn,
+						waitlistSignupsTableName,
+						waitlistSignupsTableName, archivedAtColumn,
+						waitlistSignupsTableName, idColumn, idColumn,
+						waitlistSignupsTableName, belongsToWaitlistColumn, belongsToWaitlistColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetWaitlistSignupsForWaitlist",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s
@@ -157,22 +114,22 @@ WHERE %s.%s IS NULL
 	AND %s.%s = sqlc.arg(%s)
 	%s
 %s;`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					buildFilterCountSelect(waitlistSignupsTableName, true, true, nil, fmt.Sprintf("%s.%s = sqlc.arg(%s)", waitlistSignupsTableName, belongsToWaitlistColumn, belongsToWaitlistColumn)),
-					buildTotalCountSelect(waitlistSignupsTableName, true, nil, fmt.Sprintf("%s.%s = sqlc.arg(%s)", waitlistSignupsTableName, belongsToWaitlistColumn, belongsToWaitlistColumn)),
-					waitlistSignupsTableName,
-					waitlistSignupsTableName, archivedAtColumn,
-					waitlistSignupsTableName, belongsToWaitlistColumn, belongsToWaitlistColumn,
-					buildFilterConditions(waitlistSignupsTableName, true, false, fmt.Sprintf("%s.%s = sqlc.arg(%s)", waitlistSignupsTableName, belongsToWaitlistColumn, belongsToWaitlistColumn)),
-					buildCursorLimitClause(waitlistSignupsTableName),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetWaitlistSignupsForUser",
-					Type: ManyType,
+						strings.Join(fullSelectColumns, ",\n\t"),
+						buildFilterCountSelect(waitlistSignupsTableName, true, true, nil, fmt.Sprintf("%s.%s = sqlc.arg(%s)", waitlistSignupsTableName, belongsToWaitlistColumn, belongsToWaitlistColumn)),
+						buildTotalCountSelect(waitlistSignupsTableName, true, nil, fmt.Sprintf("%s.%s = sqlc.arg(%s)", waitlistSignupsTableName, belongsToWaitlistColumn, belongsToWaitlistColumn)),
+						waitlistSignupsTableName,
+						waitlistSignupsTableName, archivedAtColumn,
+						waitlistSignupsTableName, belongsToWaitlistColumn, belongsToWaitlistColumn,
+						buildFilterConditions(waitlistSignupsTableName, true, false, fmt.Sprintf("%s.%s = sqlc.arg(%s)", waitlistSignupsTableName, belongsToWaitlistColumn, belongsToWaitlistColumn)),
+						buildCursorLimitClause(waitlistSignupsTableName),
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetWaitlistSignupsForUser",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s
@@ -181,17 +138,18 @@ WHERE %s.%s IS NULL
 	AND %s.%s = sqlc.arg(%s)
 	%s
 %s;`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					buildFilterCountSelect(waitlistSignupsTableName, true, true, nil, fmt.Sprintf("%s.%s = sqlc.arg(%s)", waitlistSignupsTableName, belongsToUserColumn, belongsToUserColumn)),
-					buildTotalCountSelect(waitlistSignupsTableName, true, nil, fmt.Sprintf("%s.%s = sqlc.arg(%s)", waitlistSignupsTableName, belongsToUserColumn, belongsToUserColumn)),
-					waitlistSignupsTableName,
-					waitlistSignupsTableName, archivedAtColumn,
-					waitlistSignupsTableName, belongsToUserColumn, belongsToUserColumn,
-					buildFilterConditions(waitlistSignupsTableName, true, false, fmt.Sprintf("%s.%s = sqlc.arg(%s)", waitlistSignupsTableName, belongsToUserColumn, belongsToUserColumn)),
-					buildCursorLimitClause(waitlistSignupsTableName),
-				)),
+						strings.Join(fullSelectColumns, ",\n\t"),
+						buildFilterCountSelect(waitlistSignupsTableName, true, true, nil, fmt.Sprintf("%s.%s = sqlc.arg(%s)", waitlistSignupsTableName, belongsToUserColumn, belongsToUserColumn)),
+						buildTotalCountSelect(waitlistSignupsTableName, true, nil, fmt.Sprintf("%s.%s = sqlc.arg(%s)", waitlistSignupsTableName, belongsToUserColumn, belongsToUserColumn)),
+						waitlistSignupsTableName,
+						waitlistSignupsTableName, archivedAtColumn,
+						waitlistSignupsTableName, belongsToUserColumn, belongsToUserColumn,
+						buildFilterConditions(waitlistSignupsTableName, true, false, fmt.Sprintf("%s.%s = sqlc.arg(%s)", waitlistSignupsTableName, belongsToUserColumn, belongsToUserColumn)),
+						buildCursorLimitClause(waitlistSignupsTableName),
+					)),
+				},
 			},
-		}
+		)
 	default:
 		return nil
 	}

--- a/backend/cmd/tools/codegen/queries/waitlists_waitlists.go
+++ b/backend/cmd/tools/codegen/queries/waitlists_waitlists.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"fmt"
+	"slices"
 	"strings"
+
+	"github.com/primandproper/platform-go/v11/database/querygen"
 
 	"github.com/cristalhq/builq"
 )
@@ -28,123 +31,75 @@ var waitlistsColumns = []string{
 func buildWaitlistsQueries(database string) []*Query {
 	switch database {
 	case postgres:
-		insertColumns := filterForInsert(waitlistsColumns)
 		fullSelectColumns := applyToEach(waitlistsColumns, func(_ int, s string) string {
 			return fullColumnName(waitlistsTableName, s)
 		})
 
-		return []*Query{
-			{
-				Annotation: QueryAnnotation{
-					Name: "CreateWaitlist",
-					Type: ExecType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`INSERT INTO %s (
-	%s
-) VALUES (
-	%s
-);`,
-					waitlistsTableName,
-					strings.Join(insertColumns, ",\n\t"),
-					strings.Join(applyToEach(insertColumns, func(_ int, s string) string {
-						return fmt.Sprintf("sqlc.arg(%s)", s)
-					}), ",\n\t"),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "UpdateWaitlist",
-					Type: ExecRowsType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
-	%s,
-	%s = %s
-WHERE %s IS NULL
-	AND %s = sqlc.arg(%s);`,
-					waitlistsTableName,
-					strings.Join(applyToEach(filterForUpdate(waitlistsColumns), func(_ int, s string) string {
-						return fmt.Sprintf("%s = sqlc.arg(%s)", s, s)
-					}), ",\n\t"),
-					lastUpdatedAtColumn, currentTimeExpression,
-					archivedAtColumn,
-					idColumn, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "ArchiveWaitlist",
-					Type: ExecRowsType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
+		return slices.Concat(
+			querygen.StandardCRUD(waitlistsTableName, waitlistsColumns,
+				querygen.WithEntity("Waitlist", "Waitlists"),
+				querygen.WithOmitted(querygen.ArchiveQuery, querygen.ExistsQuery, querygen.ListQuery),
+			),
+			[]*Query{
+				{
+					Annotation: QueryAnnotation{
+						Name: "ArchiveWaitlist",
+						Type: ExecRowsType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
 	%s = %s,
 	%s = %s
 WHERE %s IS NULL
 	AND %s = sqlc.arg(%s);`,
-					waitlistsTableName,
-					lastUpdatedAtColumn, currentTimeExpression,
-					archivedAtColumn, currentTimeExpression,
-					archivedAtColumn,
-					idColumn, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetWaitlist",
-					Type: OneType,
+						waitlistsTableName,
+						lastUpdatedAtColumn, currentTimeExpression,
+						archivedAtColumn, currentTimeExpression,
+						archivedAtColumn,
+						idColumn, idColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
-	%s
-FROM %s
-WHERE %s.%s IS NULL
-	AND %s.%s = sqlc.arg(%s);`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					waitlistsTableName,
-					waitlistsTableName, archivedAtColumn,
-					waitlistsTableName, idColumn, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CheckWaitlistExistence",
-					Type: OneType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT EXISTS(
+				{
+					Annotation: QueryAnnotation{
+						Name: "CheckWaitlistExistence",
+						Type: OneType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT EXISTS(
 	SELECT %s.%s
 	FROM %s
 	WHERE %s.%s IS NULL
 		AND %s.%s = sqlc.arg(%s)
 );`,
-					waitlistsTableName, idColumn,
-					waitlistsTableName,
-					waitlistsTableName, archivedAtColumn,
-					waitlistsTableName, idColumn, idColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "WaitlistIsNotExpired",
-					Type: OneType,
+						waitlistsTableName, idColumn,
+						waitlistsTableName,
+						waitlistsTableName, archivedAtColumn,
+						waitlistsTableName, idColumn, idColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT EXISTS(
+				{
+					Annotation: QueryAnnotation{
+						Name: "WaitlistIsNotExpired",
+						Type: OneType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT EXISTS(
 	SELECT %s.%s
 	FROM %s
 	WHERE %s.%s IS NULL
 		AND %s.%s = sqlc.arg(%s)
 		AND %s.valid_until >= %s
 );`,
-					waitlistsTableName, idColumn,
-					waitlistsTableName,
-					waitlistsTableName, archivedAtColumn,
-					waitlistsTableName, idColumn, idColumn,
-					waitlistsTableName, currentTimeExpression,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetWaitlists",
-					Type: ManyType,
+						waitlistsTableName, idColumn,
+						waitlistsTableName,
+						waitlistsTableName, archivedAtColumn,
+						waitlistsTableName, idColumn, idColumn,
+						waitlistsTableName, currentTimeExpression,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetWaitlists",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s
@@ -152,21 +107,21 @@ FROM %s
 WHERE %s.%s IS NULL
 	%s
 %s;`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					buildFilterCountSelect(waitlistsTableName, true, true, nil),
-					buildTotalCountSelect(waitlistsTableName, true, nil),
-					waitlistsTableName,
-					waitlistsTableName, archivedAtColumn,
-					buildFilterConditions(waitlistsTableName, true, false),
-					buildCursorLimitClause(waitlistsTableName),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetActiveWaitlists",
-					Type: ManyType,
+						strings.Join(fullSelectColumns, ",\n\t"),
+						buildFilterCountSelect(waitlistsTableName, true, true, nil),
+						buildTotalCountSelect(waitlistsTableName, true, nil),
+						waitlistsTableName,
+						waitlistsTableName, archivedAtColumn,
+						buildFilterConditions(waitlistsTableName, true, false),
+						buildCursorLimitClause(waitlistsTableName),
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetActiveWaitlists",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s
@@ -175,17 +130,18 @@ WHERE %s.%s IS NULL
 	AND %s.valid_until >= %s
 	%s
 %s;`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					buildFilterCountSelect(waitlistsTableName, true, true, nil, fmt.Sprintf("%s.valid_until >= %s", waitlistsTableName, currentTimeExpression)),
-					buildTotalCountSelect(waitlistsTableName, true, nil, fmt.Sprintf("%s.valid_until >= %s", waitlistsTableName, currentTimeExpression)),
-					waitlistsTableName,
-					waitlistsTableName, archivedAtColumn,
-					waitlistsTableName, currentTimeExpression,
-					buildFilterConditions(waitlistsTableName, true, false, fmt.Sprintf("%s.valid_until >= %s", waitlistsTableName, currentTimeExpression)),
-					buildCursorLimitClause(waitlistsTableName),
-				)),
+						strings.Join(fullSelectColumns, ",\n\t"),
+						buildFilterCountSelect(waitlistsTableName, true, true, nil, fmt.Sprintf("%s.valid_until >= %s", waitlistsTableName, currentTimeExpression)),
+						buildTotalCountSelect(waitlistsTableName, true, nil, fmt.Sprintf("%s.valid_until >= %s", waitlistsTableName, currentTimeExpression)),
+						waitlistsTableName,
+						waitlistsTableName, archivedAtColumn,
+						waitlistsTableName, currentTimeExpression,
+						buildFilterConditions(waitlistsTableName, true, false, fmt.Sprintf("%s.valid_until >= %s", waitlistsTableName, currentTimeExpression)),
+						buildCursorLimitClause(waitlistsTableName),
+					)),
+				},
 			},
-		}
+		)
 	default:
 		return nil
 	}

--- a/backend/cmd/tools/codegen/queries/webhooks_webhook_trigger_configs.go
+++ b/backend/cmd/tools/codegen/queries/webhooks_webhook_trigger_configs.go
@@ -1,8 +1,9 @@
 package main
 
 import (
-	"fmt"
-	"strings"
+	"slices"
+
+	"github.com/primandproper/platform-go/v11/database/querygen"
 
 	"github.com/cristalhq/builq"
 )
@@ -30,61 +31,49 @@ var (
 func buildWebhookTriggerConfigsQueries(database string) []*Query {
 	switch database {
 	case postgres:
-		insertColumns := filterForInsert(webhookTriggerConfigsColumns)
 
-		return []*Query{
-			{
-				Annotation: QueryAnnotation{
-					Name: "CreateWebhookTriggerConfig",
-					Type: ExecType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`INSERT INTO %s (
-	%s
-) VALUES (
-	%s
-);`,
-					webhookTriggerConfigsTableName,
-					strings.Join(insertColumns, ",\n\t"),
-					strings.Join(applyToEach(insertColumns, func(i int, s string) string {
-						return fmt.Sprintf("sqlc.arg(%s)", s)
-					}), ",\n\t"),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "ArchiveWebhookTriggerConfig",
-					Type: ExecRowsType,
-				},
-				// Scoped to the account through the owning webhook, not only to the
-				// webhook. The account is checked at the service layer too, but a query
-				// that will happily archive any account's trigger config given its two
-				// IDs is one call site away from being an IDOR, and the join costs an
-				// index lookup on a primary key.
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
+		return slices.Concat(
+			querygen.StandardCRUD(webhookTriggerConfigsTableName, webhookTriggerConfigsColumns,
+				querygen.WithEntity("WebhookTriggerConfig", "WebhookTriggerConfigs"),
+				querygen.WithOmitted(querygen.ArchiveQuery, querygen.ExistsQuery, querygen.GetQuery, querygen.ListQuery, querygen.UpdateQuery),
+			),
+			[]*Query{
+				{
+					Annotation: QueryAnnotation{
+						Name: "ArchiveWebhookTriggerConfig",
+						Type: ExecRowsType,
+					},
+					// Scoped to the account through the owning webhook, not only to the
+					// webhook. The account is checked at the service layer too, but a query
+					// that will happily archive any account's trigger config given its two
+					// IDs is one call site away from being an IDOR, and the join costs an
+					// index lookup on a primary key.
+					Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
 	%s = %s
 WHERE %s IS NULL
 	AND %s = sqlc.arg(%s)
 	AND %s IN (
 		SELECT %s FROM %s
 		WHERE %s = sqlc.arg(%s)
-			AND %s = sqlc.arg(%s)
-			AND %s IS NULL
+				AND %s = sqlc.arg(%s)
+				AND %s IS NULL
 	);`,
-					webhookTriggerConfigsTableName,
-					archivedAtColumn, currentTimeExpression,
-					fullColumnName(webhookTriggerConfigsTableName, archivedAtColumn),
-					fullColumnName(webhookTriggerConfigsTableName, idColumn), idColumn,
-					fullColumnName(webhookTriggerConfigsTableName, belongsToWebhookColumn),
-					// Fully qualified inside the subquery: the outer UPDATE and the inner
-					// SELECT both have an id and an archived_at, and an unqualified
-					// reference to either is ambiguous.
-					fullColumnName(webhooksTableName, idColumn), webhooksTableName,
-					fullColumnName(webhooksTableName, idColumn), belongsToWebhookColumn,
-					fullColumnName(webhooksTableName, belongsToAccountColumn), belongsToAccountColumn,
-					fullColumnName(webhooksTableName, archivedAtColumn),
-				)),
+						webhookTriggerConfigsTableName,
+						archivedAtColumn, currentTimeExpression,
+						fullColumnName(webhookTriggerConfigsTableName, archivedAtColumn),
+						fullColumnName(webhookTriggerConfigsTableName, idColumn), idColumn,
+						fullColumnName(webhookTriggerConfigsTableName, belongsToWebhookColumn),
+						// Fully qualified inside the subquery: the outer UPDATE and the inner
+						// SELECT both have an id and an archived_at, and an unqualified
+						// reference to either is ambiguous.
+						fullColumnName(webhooksTableName, idColumn), webhooksTableName,
+						fullColumnName(webhooksTableName, idColumn), belongsToWebhookColumn,
+						fullColumnName(webhooksTableName, belongsToAccountColumn), belongsToAccountColumn,
+						fullColumnName(webhooksTableName, archivedAtColumn),
+					)),
+				},
 			},
-		}
+		)
 	default:
 		return nil
 	}

--- a/backend/cmd/tools/codegen/queries/webhooks_webhooks.go
+++ b/backend/cmd/tools/codegen/queries/webhooks_webhooks.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"fmt"
+	"slices"
 	"strings"
+
+	"github.com/primandproper/platform-go/v11/database/querygen"
 
 	"github.com/cristalhq/builq"
 )
@@ -34,7 +37,6 @@ func buildWebhooksQueries(database string) []*Query {
 	switch database {
 	case postgres:
 
-		insertColumns := filterForInsert(webhooksColumns)
 		fullSelectColumns := mergeColumns(
 			applyToEach(webhooksColumns, func(_ int, s string) string {
 				return fullColumnName(webhooksTableName, s)
@@ -45,66 +47,38 @@ func buildWebhooksQueries(database string) []*Query {
 			5,
 		)
 
-		return []*Query{
-			{
-				Annotation: QueryAnnotation{
-					Name: "ArchiveWebhook",
-					Type: ExecRowsType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET
-	%s = %s
-WHERE %s IS NULL
-	AND %s = sqlc.arg(%s)
-	AND %s = sqlc.arg(%s);`,
-					webhooksTableName,
-					archivedAtColumn, currentTimeExpression,
-					archivedAtColumn,
-					idColumn, idColumn,
-					belongsToAccountColumn, belongsToAccountColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CreateWebhook",
-					Type: ExecType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`INSERT INTO %s (
-	%s
-) VALUES (
-	%s
-);`,
-					webhooksTableName,
-					strings.Join(insertColumns, ",\n\t"),
-					strings.Join(applyToEach(insertColumns, func(_ int, s string) string {
-						return fmt.Sprintf("sqlc.arg(%s)", s)
-					}), ",\n\t"),
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "CheckWebhookExistence",
-					Type: OneType,
-				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT EXISTS(
+		return slices.Concat(
+			querygen.StandardCRUD(webhooksTableName, webhooksColumns,
+				querygen.WithEntity("Webhook", "Webhooks"),
+				querygen.WithOwnership(belongsToAccountColumn),
+				querygen.WithOmitted(querygen.ExistsQuery, querygen.GetQuery, querygen.ListQuery, querygen.UpdateQuery),
+			),
+			[]*Query{
+				{
+					Annotation: QueryAnnotation{
+						Name: "CheckWebhookExistence",
+						Type: OneType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT EXISTS(
 	SELECT %s.%s
 	FROM %s
 	WHERE %s.%s IS NULL
 	AND %s.%s = sqlc.arg(%s)
 	AND %s.%s = sqlc.arg(%s)
 );`,
-					webhooksTableName, idColumn,
-					webhooksTableName,
-					webhooksTableName, archivedAtColumn,
-					webhooksTableName, idColumn, idColumn,
-					webhooksTableName, belongsToAccountColumn, belongsToAccountColumn,
-				)),
-			},
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetWebhooksForAccount",
-					Type: ManyType,
+						webhooksTableName, idColumn,
+						webhooksTableName,
+						webhooksTableName, archivedAtColumn,
+						webhooksTableName, idColumn, idColumn,
+						webhooksTableName, belongsToAccountColumn, belongsToAccountColumn,
+					)),
 				},
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetWebhooksForAccount",
+						Type: ManyType,
+					},
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s,
 	%s,
 	%s
@@ -113,58 +87,55 @@ FROM %s
 WHERE %s.%s IS NULL
 	%s
 %s;`,
-					strings.Join(fullSelectColumns, ",\n\t"),
-					buildFilterCountSelect(webhooksTableName, true, true, []string{}, "webhooks.belongs_to_account = sqlc.arg(belongs_to_account)"),
-					buildTotalCountSelect(
+						strings.Join(fullSelectColumns, ",\n\t"),
+						buildFilterCountSelect(webhooksTableName, true, true, []string{}, "webhooks.belongs_to_account = sqlc.arg(belongs_to_account)"),
+						buildTotalCountSelect(
+							webhooksTableName,
+							true,
+							nil,
+							fmt.Sprintf("%s.%s = sqlc.arg(%s)", webhooksTableName, belongsToAccountColumn, belongsToAccountColumn),
+						),
 						webhooksTableName,
-						true,
-						nil,
-						fmt.Sprintf("%s.%s = sqlc.arg(%s)", webhooksTableName, belongsToAccountColumn, belongsToAccountColumn),
-					),
-					webhooksTableName,
-					webhookTriggerConfigsTableName, webhooksTableName, idColumn, webhookTriggerConfigsTableName, belongsToWebhookColumn,
-					webhooksTableName, archivedAtColumn,
-					buildFilterConditions(webhooksTableName, true, true, fmt.Sprintf("%s.%s = sqlc.arg(%s)", webhooksTableName, belongsToAccountColumn, belongsToAccountColumn), fmt.Sprintf("%s.%s IS NULL", webhookTriggerConfigsTableName, archivedAtColumn)),
-					buildCursorLimitClause(webhooksTableName),
-				)),
-			},
-			// There is deliberately no "webhooks for this account and event" query here any
-			// more. Fan-out reads the platform's webhooks_subscriptions table, whose event
-			// types carry the account, so that table is the single answer to "who wants this
-			// event" — two tables that could answer it would eventually answer differently.
-			{
-				Annotation: QueryAnnotation{
-					Name: "GetWebhook",
-					Type: ManyType,
+						webhookTriggerConfigsTableName, webhooksTableName, idColumn, webhookTriggerConfigsTableName, belongsToWebhookColumn,
+						webhooksTableName, archivedAtColumn,
+						buildFilterConditions(webhooksTableName, true, true, fmt.Sprintf("%s.%s = sqlc.arg(%s)", webhooksTableName, belongsToAccountColumn, belongsToAccountColumn), fmt.Sprintf("%s.%s IS NULL", webhookTriggerConfigsTableName, archivedAtColumn)),
+						buildCursorLimitClause(webhooksTableName),
+					)),
 				},
-				// The archived-config filter belongs in the JOIN, not the WHERE.
-				//
-				// In the WHERE it silently turns the LEFT JOIN into an inner one: a webhook
-				// whose every trigger config is archived matches no rows and disappears
-				// from its owner's view entirely, which is what unsubscribing from your
-				// last event used to do to a webhook.
-				Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
+				{
+					Annotation: QueryAnnotation{
+						Name: "GetWebhook",
+						Type: ManyType,
+					},
+					// The archived-config filter belongs in the JOIN, not the WHERE.
+					//
+					// In the WHERE it silently turns the LEFT JOIN into an inner one: a webhook
+					// whose every trigger config is archived matches no rows and disappears
+					// from its owner's view entirely, which is what unsubscribing from your
+					// last event used to do to a webhook.
+					Content: buildRawQuery((&builq.Builder{}).Addf(`SELECT
 	%s
 FROM %s
 	LEFT JOIN %s ON %s.%s = %s.%s AND %s.%s IS NULL
 WHERE %s.%s IS NULL
 	AND %s.%s = sqlc.arg(%s)
 	AND %s.%s = sqlc.arg(%s);`,
-					strings.Join(applyToEach(fullSelectColumns, func(_ int, s string) string {
-						parts := strings.Split(s, ".")
-						return fmt.Sprintf("%s as %s_%s",
-							s, strings.TrimSuffix(parts[0], "s"), parts[1],
-						)
-					}), ",\n\t"),
-					webhooksTableName,
-					webhookTriggerConfigsTableName, webhooksTableName, idColumn, webhookTriggerConfigsTableName, belongsToWebhookColumn,
-					webhookTriggerConfigsTableName, archivedAtColumn,
-					webhooksTableName, archivedAtColumn,
-					webhooksTableName, belongsToAccountColumn, belongsToAccountColumn,
-					webhooksTableName, idColumn, idColumn,
-				)),
+						strings.Join(applyToEach(fullSelectColumns, func(_ int, s string) string {
+							parts := strings.Split(s, ".")
+							return fmt.Sprintf("%s as %s_%s",
+								s, strings.TrimSuffix(parts[0], "s"), parts[1],
+							)
+						}), ",\n\t"),
+						webhooksTableName,
+						webhookTriggerConfigsTableName, webhooksTableName, idColumn, webhookTriggerConfigsTableName, belongsToWebhookColumn,
+						webhookTriggerConfigsTableName, archivedAtColumn,
+						webhooksTableName, archivedAtColumn,
+						webhooksTableName, belongsToAccountColumn, belongsToAccountColumn,
+						webhooksTableName, idColumn, idColumn,
+					)),
+				},
 			},
-		}
+		)
 	default:
 		return nil
 	}

--- a/backend/internal/repositories/postgres/auth/generated/user_sessions.generated.sql_generated.go
+++ b/backend/internal/repositories/postgres/auth/generated/user_sessions.generated.sql_generated.go
@@ -95,17 +95,17 @@ SELECT
 		SELECT COUNT(user_sessions.id)
 		FROM user_sessions
 		WHERE user_sessions.belongs_to_user = $1
-			AND user_sessions.revoked_at IS NULL
-			AND user_sessions.expires_at > NOW()
-			AND user_sessions.created_at > COALESCE($2, (SELECT NOW() - '999 years'::INTERVAL))
-			AND user_sessions.created_at < COALESCE($3, (SELECT NOW() + '999 years'::INTERVAL))
+				AND user_sessions.revoked_at IS NULL
+				AND user_sessions.expires_at > NOW()
+				AND user_sessions.created_at > COALESCE($2, (SELECT NOW() - '999 years'::INTERVAL))
+				AND user_sessions.created_at < COALESCE($3, (SELECT NOW() + '999 years'::INTERVAL))
 	) AS filtered_count,
 	(
 		SELECT COUNT(user_sessions.id)
 		FROM user_sessions
 		WHERE user_sessions.belongs_to_user = $1
-			AND user_sessions.revoked_at IS NULL
-			AND user_sessions.expires_at > NOW()
+				AND user_sessions.revoked_at IS NULL
+				AND user_sessions.expires_at > NOW()
 	) AS total_count
 FROM user_sessions
 WHERE user_sessions.belongs_to_user = $1

--- a/backend/internal/repositories/postgres/auth/sqlc_queries/user_sessions.generated.sql
+++ b/backend/internal/repositories/postgres/auth/sqlc_queries/user_sessions.generated.sql
@@ -76,17 +76,17 @@ SELECT
 		SELECT COUNT(user_sessions.id)
 		FROM user_sessions
 		WHERE user_sessions.belongs_to_user = sqlc.arg(belongs_to_user)
-			AND user_sessions.revoked_at IS NULL
-			AND user_sessions.expires_at > NOW()
-			AND user_sessions.created_at > COALESCE(sqlc.narg(created_after), (SELECT NOW() - '999 years'::INTERVAL))
-			AND user_sessions.created_at < COALESCE(sqlc.narg(created_before), (SELECT NOW() + '999 years'::INTERVAL))
+				AND user_sessions.revoked_at IS NULL
+				AND user_sessions.expires_at > NOW()
+				AND user_sessions.created_at > COALESCE(sqlc.narg(created_after), (SELECT NOW() - '999 years'::INTERVAL))
+				AND user_sessions.created_at < COALESCE(sqlc.narg(created_before), (SELECT NOW() + '999 years'::INTERVAL))
 	) AS filtered_count,
 	(
 		SELECT COUNT(user_sessions.id)
 		FROM user_sessions
 		WHERE user_sessions.belongs_to_user = sqlc.arg(belongs_to_user)
-			AND user_sessions.revoked_at IS NULL
-			AND user_sessions.expires_at > NOW()
+				AND user_sessions.revoked_at IS NULL
+				AND user_sessions.expires_at > NOW()
 	) AS total_count
 FROM user_sessions
 WHERE user_sessions.belongs_to_user = sqlc.arg(belongs_to_user)

--- a/backend/internal/repositories/postgres/comments/generated/comments.generated.sql_generated.go
+++ b/backend/internal/repositories/postgres/comments/generated/comments.generated.sql_generated.go
@@ -12,7 +12,10 @@ import (
 )
 
 const archiveComment = `-- name: ArchiveComment :execrows
-UPDATE comments SET archived_at = NOW() WHERE archived_at IS NULL AND id = $1
+UPDATE comments SET
+	archived_at = NOW()
+WHERE archived_at IS NULL
+	AND id = $1
 `
 
 func (q *Queries) ArchiveComment(ctx context.Context, db DBTX, id string) (int64, error) {

--- a/backend/internal/repositories/postgres/comments/sqlc_queries/comments.generated.sql
+++ b/backend/internal/repositories/postgres/comments/sqlc_queries/comments.generated.sql
@@ -1,11 +1,3 @@
--- name: ArchiveComment :execrows
-UPDATE comments SET archived_at = NOW() WHERE archived_at IS NULL AND id = sqlc.arg(id);
-
--- name: ArchiveCommentsForReference :execrows
-UPDATE comments SET archived_at = NOW() WHERE archived_at IS NULL
-	AND target_type = sqlc.arg(target_type)
-	AND referenced_id = sqlc.arg(referenced_id);
-
 -- name: CreateComment :exec
 INSERT INTO comments (
 	id,
@@ -37,6 +29,17 @@ SELECT
 FROM comments
 WHERE comments.archived_at IS NULL
 	AND comments.id = sqlc.arg(id);
+
+-- name: ArchiveComment :execrows
+UPDATE comments SET
+	archived_at = NOW()
+WHERE archived_at IS NULL
+	AND id = sqlc.arg(id);
+
+-- name: ArchiveCommentsForReference :execrows
+UPDATE comments SET archived_at = NOW() WHERE archived_at IS NULL
+	AND target_type = sqlc.arg(target_type)
+	AND referenced_id = sqlc.arg(referenced_id);
 
 -- name: GetCommentsForReference :many
 SELECT

--- a/backend/internal/repositories/postgres/identity/generated/account_invitations.generated.sql_generated.go
+++ b/backend/internal/repositories/postgres/identity/generated/account_invitations.generated.sql_generated.go
@@ -58,7 +58,7 @@ SELECT EXISTS (
 	SELECT account_invitations.id
 	FROM account_invitations
 	WHERE account_invitations.archived_at IS NULL
-	AND account_invitations.id = $1
+		AND account_invitations.id = $1
 )
 `
 

--- a/backend/internal/repositories/postgres/identity/generated/accounts.generated.sql_generated.go
+++ b/backend/internal/repositories/postgres/identity/generated/accounts.generated.sql_generated.go
@@ -507,8 +507,8 @@ UPDATE accounts SET
 	longitude = $10,
 	last_updated_at = NOW()
 WHERE archived_at IS NULL
-	AND belongs_to_user = $11
-	AND id = $12
+	AND id = $11
+	AND belongs_to_user = $12
 `
 
 type UpdateAccountParams struct {
@@ -522,8 +522,8 @@ type UpdateAccountParams struct {
 	Country       string
 	Latitude      sql.NullString
 	Longitude     sql.NullString
-	BelongsToUser string
 	ID            string
+	BelongsToUser string
 }
 
 func (q *Queries) UpdateAccount(ctx context.Context, db DBTX, arg *UpdateAccountParams) (int64, error) {
@@ -538,8 +538,8 @@ func (q *Queries) UpdateAccount(ctx context.Context, db DBTX, arg *UpdateAccount
 		arg.Country,
 		arg.Latitude,
 		arg.Longitude,
-		arg.BelongsToUser,
 		arg.ID,
+		arg.BelongsToUser,
 	)
 	if err != nil {
 		return 0, err

--- a/backend/internal/repositories/postgres/identity/generated/permissions.generated.sql_generated.go
+++ b/backend/internal/repositories/postgres/identity/generated/permissions.generated.sql_generated.go
@@ -12,7 +12,10 @@ import (
 )
 
 const archivePermission = `-- name: ArchivePermission :execrows
-UPDATE permissions SET archived_at = NOW() WHERE archived_at IS NULL AND id = $1
+UPDATE permissions SET
+	archived_at = NOW()
+WHERE archived_at IS NULL
+	AND id = $1
 `
 
 func (q *Queries) ArchivePermission(ctx context.Context, db DBTX, id string) (int64, error) {

--- a/backend/internal/repositories/postgres/identity/generated/user_roles.generated.sql_generated.go
+++ b/backend/internal/repositories/postgres/identity/generated/user_roles.generated.sql_generated.go
@@ -12,7 +12,10 @@ import (
 )
 
 const archiveUserRole = `-- name: ArchiveUserRole :execrows
-UPDATE user_roles SET archived_at = NOW() WHERE archived_at IS NULL AND id = $1
+UPDATE user_roles SET
+	archived_at = NOW()
+WHERE archived_at IS NULL
+	AND id = $1
 `
 
 func (q *Queries) ArchiveUserRole(ctx context.Context, db DBTX, id string) (int64, error) {

--- a/backend/internal/repositories/postgres/identity/generated/users.generated.sql_generated.go
+++ b/backend/internal/repositories/postgres/identity/generated/users.generated.sql_generated.go
@@ -38,7 +38,10 @@ func (q *Queries) AcceptTermsOfServiceForUser(ctx context.Context, db DBTX, id s
 }
 
 const archiveUser = `-- name: ArchiveUser :execrows
-UPDATE users SET archived_at = NOW() WHERE archived_at IS NULL AND id = $1
+UPDATE users SET
+	archived_at = NOW()
+WHERE archived_at IS NULL
+	AND id = $1
 `
 
 func (q *Queries) ArchiveUser(ctx context.Context, db DBTX, id string) (int64, error) {
@@ -50,8 +53,7 @@ func (q *Queries) ArchiveUser(ctx context.Context, db DBTX, id string) (int64, e
 }
 
 const createUser = `-- name: CreateUser :exec
-INSERT INTO users
-(
+INSERT INTO users (
 	id,
 	username,
 	email_address,

--- a/backend/internal/repositories/postgres/identity/sqlc_queries/account_invitations.generated.sql
+++ b/backend/internal/repositories/postgres/identity/sqlc_queries/account_invitations.generated.sql
@@ -1,10 +1,3 @@
--- name: AttachAccountInvitationsToUserID :execrows
-UPDATE account_invitations SET
-	to_user = sqlc.arg(to_user),
-	last_updated_at = NOW()
-WHERE archived_at IS NULL
-	AND to_email = LOWER(sqlc.arg(to_email));
-
 -- name: CreateAccountInvitation :exec
 INSERT INTO account_invitations (
 	id,
@@ -28,20 +21,27 @@ INSERT INTO account_invitations (
 	sqlc.arg(expires_at)
 );
 
+-- name: CheckAccountInvitationExistence :one
+SELECT EXISTS (
+	SELECT account_invitations.id
+	FROM account_invitations
+	WHERE account_invitations.archived_at IS NULL
+		AND account_invitations.id = sqlc.arg(id)
+);
+
+-- name: AttachAccountInvitationsToUserID :execrows
+UPDATE account_invitations SET
+	to_user = sqlc.arg(to_user),
+	last_updated_at = NOW()
+WHERE archived_at IS NULL
+	AND to_email = LOWER(sqlc.arg(to_email));
+
 -- name: AssignInvitationsToUserByEmail :execrows
 UPDATE account_invitations SET
 	to_user = sqlc.arg(to_user),
 	last_updated_at = NOW()
 WHERE archived_at IS NULL
 	AND to_email = LOWER(sqlc.arg(email_address));
-
--- name: CheckAccountInvitationExistence :one
-SELECT EXISTS (
-	SELECT account_invitations.id
-	FROM account_invitations
-	WHERE account_invitations.archived_at IS NULL
-	AND account_invitations.id = sqlc.arg(id)
-);
 
 -- name: GetAccountInvitationByEmailAndToken :one
 SELECT

--- a/backend/internal/repositories/postgres/identity/sqlc_queries/accounts.generated.sql
+++ b/backend/internal/repositories/postgres/identity/sqlc_queries/accounts.generated.sql
@@ -1,22 +1,3 @@
--- name: AddToAccountDuringCreation :exec
-INSERT INTO account_user_memberships (
-	id,
-	belongs_to_account,
-	belongs_to_user
-) VALUES (
-	sqlc.arg(id),
-	sqlc.arg(belongs_to_account),
-	sqlc.arg(belongs_to_user)
-);
-
--- name: ArchiveAccount :execrows
-UPDATE accounts SET
-	last_updated_at = NOW(),
-	archived_at = NOW()
-WHERE archived_at IS NULL
-	AND belongs_to_user = sqlc.arg(belongs_to_user)
-	AND id = sqlc.arg(id);
-
 -- name: CreateAccount :exec
 INSERT INTO accounts (
 	id,
@@ -49,6 +30,42 @@ INSERT INTO accounts (
 	sqlc.arg(longitude),
 	sqlc.arg(webhook_hmac_secret)
 );
+
+-- name: UpdateAccount :execrows
+UPDATE accounts SET
+	name = sqlc.arg(name),
+	contact_phone = sqlc.arg(contact_phone),
+	address_line_1 = sqlc.arg(address_line_1),
+	address_line_2 = sqlc.arg(address_line_2),
+	city = sqlc.arg(city),
+	state = sqlc.arg(state),
+	zip_code = sqlc.arg(zip_code),
+	country = sqlc.arg(country),
+	latitude = sqlc.arg(latitude),
+	longitude = sqlc.arg(longitude),
+	last_updated_at = NOW()
+WHERE archived_at IS NULL
+	AND id = sqlc.arg(id)
+	AND belongs_to_user = sqlc.arg(belongs_to_user);
+
+-- name: AddToAccountDuringCreation :exec
+INSERT INTO account_user_memberships (
+	id,
+	belongs_to_account,
+	belongs_to_user
+) VALUES (
+	sqlc.arg(id),
+	sqlc.arg(belongs_to_account),
+	sqlc.arg(belongs_to_user)
+);
+
+-- name: ArchiveAccount :execrows
+UPDATE accounts SET
+	last_updated_at = NOW(),
+	archived_at = NOW()
+WHERE archived_at IS NULL
+	AND belongs_to_user = sqlc.arg(belongs_to_user)
+	AND id = sqlc.arg(id);
 
 -- name: GetAccountByIDWithMemberships :many
 SELECT
@@ -181,23 +198,6 @@ WHERE accounts.archived_at IS NULL
 	AND accounts.id > COALESCE(sqlc.narg(cursor), '')
 ORDER BY accounts.id ASC
 LIMIT COALESCE(sqlc.narg(result_limit), 50);
-
--- name: UpdateAccount :execrows
-UPDATE accounts SET
-	name = sqlc.arg(name),
-	contact_phone = sqlc.arg(contact_phone),
-	address_line_1 = sqlc.arg(address_line_1),
-	address_line_2 = sqlc.arg(address_line_2),
-	city = sqlc.arg(city),
-	state = sqlc.arg(state),
-	zip_code = sqlc.arg(zip_code),
-	country = sqlc.arg(country),
-	latitude = sqlc.arg(latitude),
-	longitude = sqlc.arg(longitude),
-	last_updated_at = NOW()
-WHERE archived_at IS NULL
-	AND belongs_to_user = sqlc.arg(belongs_to_user)
-	AND id = sqlc.arg(id);
 
 -- name: UpdateAccountBillingFields :execrows
 UPDATE accounts SET

--- a/backend/internal/repositories/postgres/identity/sqlc_queries/permissions.generated.sql
+++ b/backend/internal/repositories/postgres/identity/sqlc_queries/permissions.generated.sql
@@ -21,6 +21,12 @@ FROM permissions
 WHERE permissions.archived_at IS NULL
 	AND permissions.id = sqlc.arg(id);
 
+-- name: ArchivePermission :execrows
+UPDATE permissions SET
+	archived_at = NOW()
+WHERE archived_at IS NULL
+	AND id = sqlc.arg(id);
+
 -- name: GetPermissionByName :one
 SELECT
 	permissions.id,
@@ -79,6 +85,3 @@ WHERE permissions.archived_at IS NULL
 	AND permissions.id > COALESCE(sqlc.narg(cursor), '')
 ORDER BY permissions.id ASC
 LIMIT COALESCE(sqlc.narg(result_limit), 50);
-
--- name: ArchivePermission :execrows
-UPDATE permissions SET archived_at = NOW() WHERE archived_at IS NULL AND id = sqlc.arg(id);

--- a/backend/internal/repositories/postgres/identity/sqlc_queries/user_roles.generated.sql
+++ b/backend/internal/repositories/postgres/identity/sqlc_queries/user_roles.generated.sql
@@ -24,6 +24,12 @@ FROM user_roles
 WHERE user_roles.archived_at IS NULL
 	AND user_roles.id = sqlc.arg(id);
 
+-- name: ArchiveUserRole :execrows
+UPDATE user_roles SET
+	archived_at = NOW()
+WHERE archived_at IS NULL
+	AND id = sqlc.arg(id);
+
 -- name: GetUserRoleByName :one
 SELECT
 	user_roles.id,
@@ -84,6 +90,3 @@ WHERE user_roles.archived_at IS NULL
 	AND user_roles.id > COALESCE(sqlc.narg(cursor), '')
 ORDER BY user_roles.id ASC
 LIMIT COALESCE(sqlc.narg(result_limit), 50);
-
--- name: ArchiveUserRole :execrows
-UPDATE user_roles SET archived_at = NOW() WHERE archived_at IS NULL AND id = sqlc.arg(id);

--- a/backend/internal/repositories/postgres/identity/sqlc_queries/users.generated.sql
+++ b/backend/internal/repositories/postgres/identity/sqlc_queries/users.generated.sql
@@ -1,24 +1,5 @@
--- name: AcceptPrivacyPolicyForUser :exec
-UPDATE users SET
-	last_accepted_privacy_policy = NOW()
-WHERE archived_at IS NULL
-	AND id = sqlc.arg(id);
-
--- name: AcceptTermsOfServiceForUser :exec
-UPDATE users SET
-	last_accepted_terms_of_service = NOW()
-WHERE archived_at IS NULL
-	AND id = sqlc.arg(id);
-
--- name: ArchiveUser :execrows
-UPDATE users SET archived_at = NOW() WHERE archived_at IS NULL AND id = sqlc.arg(id);
-
--- name: DeleteUser :execrows
-DELETE FROM users WHERE id = sqlc.arg(id);
-
 -- name: CreateUser :exec
-INSERT INTO users
-(
+INSERT INTO users (
 	id,
 	username,
 	email_address,
@@ -47,6 +28,40 @@ INSERT INTO users
 	sqlc.arg(first_name),
 	sqlc.arg(last_name)
 );
+
+-- name: ArchiveUser :execrows
+UPDATE users SET
+	archived_at = NOW()
+WHERE archived_at IS NULL
+	AND id = sqlc.arg(id);
+
+-- name: ScanUserIDsForReindex :many
+SELECT users.id
+FROM users
+WHERE users.archived_at IS NULL
+	AND users.id COLLATE "C" > sqlc.arg(cursor)
+ORDER BY users.id COLLATE "C"
+LIMIT COALESCE(sqlc.narg(result_limit), 50);
+
+-- name: MarkUsersAsIndexed :execrows
+UPDATE users SET
+	last_indexed_at = NOW()
+WHERE id = ANY(sqlc.arg(ids)::text[]);
+
+-- name: AcceptPrivacyPolicyForUser :exec
+UPDATE users SET
+	last_accepted_privacy_policy = NOW()
+WHERE archived_at IS NULL
+	AND id = sqlc.arg(id);
+
+-- name: AcceptTermsOfServiceForUser :exec
+UPDATE users SET
+	last_accepted_terms_of_service = NOW()
+WHERE archived_at IS NULL
+	AND id = sqlc.arg(id);
+
+-- name: DeleteUser :execrows
+DELETE FROM users WHERE id = sqlc.arg(id);
 
 -- name: GetAdminUserByUsername :one
 SELECT
@@ -428,14 +443,6 @@ FROM users
 WHERE users.archived_at IS NULL
 	AND users.id = sqlc.arg(id);
 
--- name: ScanUserIDsForReindex :many
-SELECT users.id
-FROM users
-WHERE users.archived_at IS NULL
-	AND users.id COLLATE "C" > sqlc.arg(cursor)
-ORDER BY users.id COLLATE "C"
-LIMIT COALESCE(sqlc.narg(result_limit), 50);
-
 -- name: GetUserIDsNeedingIndexing :many
 SELECT users.id
 FROM users
@@ -637,11 +644,6 @@ UPDATE users SET
 	last_updated_at = NOW()
 WHERE archived_at IS NULL
 	AND id = sqlc.arg(id);
-
--- name: MarkUsersAsIndexed :execrows
-UPDATE users SET
-	last_indexed_at = NOW()
-WHERE id = ANY(sqlc.arg(ids)::text[]);
 
 -- name: UpdateUserPassword :execrows
 UPDATE users SET

--- a/backend/internal/repositories/postgres/issuereports/sqlc_queries/issue_reports.generated.sql
+++ b/backend/internal/repositories/postgres/issuereports/sqlc_queries/issue_reports.generated.sql
@@ -17,6 +17,22 @@ INSERT INTO issue_reports (
 	sqlc.arg(belongs_to_account)
 );
 
+-- name: GetIssueReport :one
+SELECT
+	issue_reports.id,
+	issue_reports.issue_type,
+	issue_reports.details,
+	issue_reports.relevant_table,
+	issue_reports.relevant_record_id,
+	issue_reports.created_at,
+	issue_reports.last_updated_at,
+	issue_reports.archived_at,
+	issue_reports.created_by_user,
+	issue_reports.belongs_to_account
+FROM issue_reports
+WHERE issue_reports.archived_at IS NULL
+	AND issue_reports.id = sqlc.arg(id);
+
 -- name: UpdateIssueReport :execrows
 UPDATE issue_reports SET
 	issue_type = sqlc.arg(issue_type),
@@ -33,22 +49,6 @@ UPDATE issue_reports SET
 	archived_at = NOW()
 WHERE archived_at IS NULL
 	AND id = sqlc.arg(id);
-
--- name: GetIssueReport :one
-SELECT
-	issue_reports.id,
-	issue_reports.issue_type,
-	issue_reports.details,
-	issue_reports.relevant_table,
-	issue_reports.relevant_record_id,
-	issue_reports.created_at,
-	issue_reports.last_updated_at,
-	issue_reports.archived_at,
-	issue_reports.created_by_user,
-	issue_reports.belongs_to_account
-FROM issue_reports
-WHERE issue_reports.archived_at IS NULL
-	AND issue_reports.id = sqlc.arg(id);
 
 -- name: CheckIssueReportExistence :one
 SELECT EXISTS(

--- a/backend/internal/repositories/postgres/mealplanning/generated/account_instrument_ownerships.generated.sql_generated.go
+++ b/backend/internal/repositories/postgres/mealplanning/generated/account_instrument_ownerships.generated.sql_generated.go
@@ -343,7 +343,7 @@ UPDATE account_instrument_ownerships SET
 	last_updated_at = NOW()
 WHERE archived_at IS NULL
 	AND id = $4
-	AND account_instrument_ownerships.belongs_to_account = $5
+	AND belongs_to_account = $5
 `
 
 type UpdateAccountInstrumentOwnershipParams struct {

--- a/backend/internal/repositories/postgres/mealplanning/generated/meal_list_items.generated.sql_generated.go
+++ b/backend/internal/repositories/postgres/mealplanning/generated/meal_list_items.generated.sql_generated.go
@@ -12,16 +12,20 @@ import (
 )
 
 const archiveMealListItem = `-- name: ArchiveMealListItem :execrows
-UPDATE meal_list_items SET archived_at = NOW() WHERE archived_at IS NULL AND belongs_to_meal_list = $1 AND id = $2
+UPDATE meal_list_items SET
+	archived_at = NOW()
+WHERE archived_at IS NULL
+	AND id = $1
+	AND belongs_to_meal_list = $2
 `
 
 type ArchiveMealListItemParams struct {
-	BelongsToMealList string
 	ID                string
+	BelongsToMealList string
 }
 
 func (q *Queries) ArchiveMealListItem(ctx context.Context, db DBTX, arg *ArchiveMealListItemParams) (int64, error) {
-	result, err := db.ExecContext(ctx, archiveMealListItem, arg.BelongsToMealList, arg.ID)
+	result, err := db.ExecContext(ctx, archiveMealListItem, arg.ID, arg.BelongsToMealList)
 	if err != nil {
 		return 0, err
 	}
@@ -207,23 +211,23 @@ UPDATE meal_list_items SET
 	notes = $2,
 	last_updated_at = NOW()
 WHERE archived_at IS NULL
-	AND belongs_to_meal_list = $3
-	AND id = $4
+	AND id = $3
+	AND belongs_to_meal_list = $4
 `
 
 type UpdateMealListItemParams struct {
 	MealID            string
 	Notes             string
-	BelongsToMealList string
 	ID                string
+	BelongsToMealList string
 }
 
 func (q *Queries) UpdateMealListItem(ctx context.Context, db DBTX, arg *UpdateMealListItemParams) (int64, error) {
 	result, err := db.ExecContext(ctx, updateMealListItem,
 		arg.MealID,
 		arg.Notes,
-		arg.BelongsToMealList,
 		arg.ID,
+		arg.BelongsToMealList,
 	)
 	if err != nil {
 		return 0, err

--- a/backend/internal/repositories/postgres/mealplanning/generated/meal_lists.generated.sql_generated.go
+++ b/backend/internal/repositories/postgres/mealplanning/generated/meal_lists.generated.sql_generated.go
@@ -12,16 +12,20 @@ import (
 )
 
 const archiveMealList = `-- name: ArchiveMealList :execrows
-UPDATE meal_lists SET archived_at = NOW() WHERE archived_at IS NULL AND belongs_to_user = $1 AND id = $2
+UPDATE meal_lists SET
+	archived_at = NOW()
+WHERE archived_at IS NULL
+	AND id = $1
+	AND belongs_to_user = $2
 `
 
 type ArchiveMealListParams struct {
-	BelongsToUser string
 	ID            string
+	BelongsToUser string
 }
 
 func (q *Queries) ArchiveMealList(ctx context.Context, db DBTX, arg *ArchiveMealListParams) (int64, error) {
-	result, err := db.ExecContext(ctx, archiveMealList, arg.BelongsToUser, arg.ID)
+	result, err := db.ExecContext(ctx, archiveMealList, arg.ID, arg.BelongsToUser)
 	if err != nil {
 		return 0, err
 	}
@@ -203,23 +207,23 @@ UPDATE meal_lists SET
 	description = $2,
 	last_updated_at = NOW()
 WHERE archived_at IS NULL
-	AND belongs_to_user = $3
-	AND id = $4
+	AND id = $3
+	AND belongs_to_user = $4
 `
 
 type UpdateMealListParams struct {
 	Name          string
 	Description   string
-	BelongsToUser string
 	ID            string
+	BelongsToUser string
 }
 
 func (q *Queries) UpdateMealList(ctx context.Context, db DBTX, arg *UpdateMealListParams) (int64, error) {
 	result, err := db.ExecContext(ctx, updateMealList,
 		arg.Name,
 		arg.Description,
-		arg.BelongsToUser,
 		arg.ID,
+		arg.BelongsToUser,
 	)
 	if err != nil {
 		return 0, err

--- a/backend/internal/repositories/postgres/mealplanning/generated/meal_plan_events.generated.sql_generated.go
+++ b/backend/internal/repositories/postgres/mealplanning/generated/meal_plan_events.generated.sql_generated.go
@@ -12,7 +12,11 @@ import (
 )
 
 const archiveMealPlanEvent = `-- name: ArchiveMealPlanEvent :execrows
-UPDATE meal_plan_events SET archived_at = NOW() WHERE archived_at IS NULL AND id = $1 AND belongs_to_meal_plan = $2
+UPDATE meal_plan_events SET
+	archived_at = NOW()
+WHERE archived_at IS NULL
+	AND id = $1
+	AND belongs_to_meal_plan = $2
 `
 
 type ArchiveMealPlanEventParams struct {

--- a/backend/internal/repositories/postgres/mealplanning/generated/meal_plan_grocery_list_items.generated.sql_generated.go
+++ b/backend/internal/repositories/postgres/mealplanning/generated/meal_plan_grocery_list_items.generated.sql_generated.go
@@ -14,7 +14,10 @@ import (
 )
 
 const archiveMealPlanGroceryListItem = `-- name: ArchiveMealPlanGroceryListItem :execrows
-UPDATE meal_plan_grocery_list_items SET archived_at = NOW() WHERE archived_at IS NULL AND id = $1
+UPDATE meal_plan_grocery_list_items SET
+	archived_at = NOW()
+WHERE archived_at IS NULL
+	AND id = $1
 `
 
 func (q *Queries) ArchiveMealPlanGroceryListItem(ctx context.Context, db DBTX, id string) (int64, error) {

--- a/backend/internal/repositories/postgres/mealplanning/generated/meal_plan_option_votes.generated.sql_generated.go
+++ b/backend/internal/repositories/postgres/mealplanning/generated/meal_plan_option_votes.generated.sql_generated.go
@@ -12,16 +12,20 @@ import (
 )
 
 const archiveMealPlanOptionVote = `-- name: ArchiveMealPlanOptionVote :execrows
-UPDATE meal_plan_option_votes SET archived_at = NOW() WHERE archived_at IS NULL AND belongs_to_meal_plan_option = $1 AND id = $2
+UPDATE meal_plan_option_votes SET
+	archived_at = NOW()
+WHERE archived_at IS NULL
+	AND id = $1
+	AND belongs_to_meal_plan_option = $2
 `
 
 type ArchiveMealPlanOptionVoteParams struct {
-	BelongsToMealPlanOption string
 	ID                      string
+	BelongsToMealPlanOption string
 }
 
 func (q *Queries) ArchiveMealPlanOptionVote(ctx context.Context, db DBTX, arg *ArchiveMealPlanOptionVoteParams) (int64, error) {
-	result, err := db.ExecContext(ctx, archiveMealPlanOptionVote, arg.BelongsToMealPlanOption, arg.ID)
+	result, err := db.ExecContext(ctx, archiveMealPlanOptionVote, arg.ID, arg.BelongsToMealPlanOption)
 	if err != nil {
 		return 0, err
 	}
@@ -377,8 +381,8 @@ UPDATE meal_plan_option_votes SET
 	by_user = $4,
 	last_updated_at = NOW()
 WHERE archived_at IS NULL
-	AND belongs_to_meal_plan_option = $5
-	AND id = $6
+	AND id = $5
+	AND belongs_to_meal_plan_option = $6
 `
 
 type UpdateMealPlanOptionVoteParams struct {
@@ -386,8 +390,8 @@ type UpdateMealPlanOptionVoteParams struct {
 	Abstain                 bool
 	Notes                   string
 	ByUser                  string
-	BelongsToMealPlanOption string
 	ID                      string
+	BelongsToMealPlanOption string
 }
 
 func (q *Queries) UpdateMealPlanOptionVote(ctx context.Context, db DBTX, arg *UpdateMealPlanOptionVoteParams) (int64, error) {
@@ -396,8 +400,8 @@ func (q *Queries) UpdateMealPlanOptionVote(ctx context.Context, db DBTX, arg *Up
 		arg.Abstain,
 		arg.Notes,
 		arg.ByUser,
-		arg.BelongsToMealPlanOption,
 		arg.ID,
+		arg.BelongsToMealPlanOption,
 	)
 	if err != nil {
 		return 0, err

--- a/backend/internal/repositories/postgres/mealplanning/generated/meal_plan_options.generated.sql_generated.go
+++ b/backend/internal/repositories/postgres/mealplanning/generated/meal_plan_options.generated.sql_generated.go
@@ -15,17 +15,17 @@ const archiveMealPlanOption = `-- name: ArchiveMealPlanOption :execrows
 UPDATE meal_plan_options SET
 	archived_at = NOW()
 WHERE archived_at IS NULL
-	AND belongs_to_meal_plan_event = $1
-	AND id = $2
+	AND id = $1
+	AND belongs_to_meal_plan_event = $2
 `
 
 type ArchiveMealPlanOptionParams struct {
-	BelongsToMealPlanEvent sql.NullString
 	ID                     string
+	BelongsToMealPlanEvent sql.NullString
 }
 
 func (q *Queries) ArchiveMealPlanOption(ctx context.Context, db DBTX, arg *ArchiveMealPlanOptionParams) (int64, error) {
-	result, err := db.ExecContext(ctx, archiveMealPlanOption, arg.BelongsToMealPlanEvent, arg.ID)
+	result, err := db.ExecContext(ctx, archiveMealPlanOption, arg.ID, arg.BelongsToMealPlanEvent)
 	if err != nil {
 		return 0, err
 	}

--- a/backend/internal/repositories/postgres/mealplanning/generated/meal_plans.generated.sql_generated.go
+++ b/backend/internal/repositories/postgres/mealplanning/generated/meal_plans.generated.sql_generated.go
@@ -12,16 +12,20 @@ import (
 )
 
 const archiveMealPlan = `-- name: ArchiveMealPlan :execrows
-UPDATE meal_plans SET archived_at = NOW() WHERE archived_at IS NULL AND belongs_to_account = $1 AND id = $2
+UPDATE meal_plans SET
+	archived_at = NOW()
+WHERE archived_at IS NULL
+	AND id = $1
+	AND belongs_to_account = $2
 `
 
 type ArchiveMealPlanParams struct {
-	BelongsToAccount string
 	ID               string
+	BelongsToAccount string
 }
 
 func (q *Queries) ArchiveMealPlan(ctx context.Context, db DBTX, arg *ArchiveMealPlanParams) (int64, error) {
-	result, err := db.ExecContext(ctx, archiveMealPlan, arg.BelongsToAccount, arg.ID)
+	result, err := db.ExecContext(ctx, archiveMealPlan, arg.ID, arg.BelongsToAccount)
 	if err != nil {
 		return 0, err
 	}
@@ -291,8 +295,8 @@ SELECT
 	meal_plans.created_by_user
 FROM meal_plans
 WHERE meal_plans.archived_at IS NULL
-  AND meal_plans.id = $1
-  AND meal_plans.belongs_to_account = $2
+	AND meal_plans.id = $1
+	AND meal_plans.belongs_to_account = $2
 `
 
 type GetMealPlanParams struct {
@@ -631,16 +635,16 @@ UPDATE meal_plans SET
 	voting_deadline = $3,
 	last_updated_at = NOW()
 WHERE archived_at IS NULL
-	AND belongs_to_account = $4
-	AND id = $5
+	AND id = $4
+	AND belongs_to_account = $5
 `
 
 type UpdateMealPlanParams struct {
 	Notes            string
 	Status           MealPlanStatus
 	VotingDeadline   time.Time
-	BelongsToAccount string
 	ID               string
+	BelongsToAccount string
 }
 
 func (q *Queries) UpdateMealPlan(ctx context.Context, db DBTX, arg *UpdateMealPlanParams) (int64, error) {
@@ -648,8 +652,8 @@ func (q *Queries) UpdateMealPlan(ctx context.Context, db DBTX, arg *UpdateMealPl
 		arg.Notes,
 		arg.Status,
 		arg.VotingDeadline,
-		arg.BelongsToAccount,
 		arg.ID,
+		arg.BelongsToAccount,
 	)
 	if err != nil {
 		return 0, err

--- a/backend/internal/repositories/postgres/mealplanning/generated/recipe_list_items.generated.sql_generated.go
+++ b/backend/internal/repositories/postgres/mealplanning/generated/recipe_list_items.generated.sql_generated.go
@@ -12,16 +12,20 @@ import (
 )
 
 const archiveRecipeListItem = `-- name: ArchiveRecipeListItem :execrows
-UPDATE recipe_list_items SET archived_at = NOW() WHERE archived_at IS NULL AND belongs_to_recipe_list = $1 AND id = $2
+UPDATE recipe_list_items SET
+	archived_at = NOW()
+WHERE archived_at IS NULL
+	AND id = $1
+	AND belongs_to_recipe_list = $2
 `
 
 type ArchiveRecipeListItemParams struct {
-	BelongsToRecipeList string
 	ID                  string
+	BelongsToRecipeList string
 }
 
 func (q *Queries) ArchiveRecipeListItem(ctx context.Context, db DBTX, arg *ArchiveRecipeListItemParams) (int64, error) {
-	result, err := db.ExecContext(ctx, archiveRecipeListItem, arg.BelongsToRecipeList, arg.ID)
+	result, err := db.ExecContext(ctx, archiveRecipeListItem, arg.ID, arg.BelongsToRecipeList)
 	if err != nil {
 		return 0, err
 	}
@@ -181,23 +185,23 @@ UPDATE recipe_list_items SET
 	notes = $2,
 	last_updated_at = NOW()
 WHERE archived_at IS NULL
-	AND belongs_to_recipe_list = $3
-	AND id = $4
+	AND id = $3
+	AND belongs_to_recipe_list = $4
 `
 
 type UpdateRecipeListItemParams struct {
 	RecipeID            string
 	Notes               string
-	BelongsToRecipeList string
 	ID                  string
+	BelongsToRecipeList string
 }
 
 func (q *Queries) UpdateRecipeListItem(ctx context.Context, db DBTX, arg *UpdateRecipeListItemParams) (int64, error) {
 	result, err := db.ExecContext(ctx, updateRecipeListItem,
 		arg.RecipeID,
 		arg.Notes,
-		arg.BelongsToRecipeList,
 		arg.ID,
+		arg.BelongsToRecipeList,
 	)
 	if err != nil {
 		return 0, err

--- a/backend/internal/repositories/postgres/mealplanning/generated/recipe_lists.generated.sql_generated.go
+++ b/backend/internal/repositories/postgres/mealplanning/generated/recipe_lists.generated.sql_generated.go
@@ -12,16 +12,20 @@ import (
 )
 
 const archiveRecipeList = `-- name: ArchiveRecipeList :execrows
-UPDATE recipe_lists SET archived_at = NOW() WHERE archived_at IS NULL AND belongs_to_user = $1 AND id = $2
+UPDATE recipe_lists SET
+	archived_at = NOW()
+WHERE archived_at IS NULL
+	AND id = $1
+	AND belongs_to_user = $2
 `
 
 type ArchiveRecipeListParams struct {
-	BelongsToUser string
 	ID            string
+	BelongsToUser string
 }
 
 func (q *Queries) ArchiveRecipeList(ctx context.Context, db DBTX, arg *ArchiveRecipeListParams) (int64, error) {
-	result, err := db.ExecContext(ctx, archiveRecipeList, arg.BelongsToUser, arg.ID)
+	result, err := db.ExecContext(ctx, archiveRecipeList, arg.ID, arg.BelongsToUser)
 	if err != nil {
 		return 0, err
 	}
@@ -198,23 +202,23 @@ UPDATE recipe_lists SET
 	description = $2,
 	last_updated_at = NOW()
 WHERE archived_at IS NULL
-	AND belongs_to_user = $3
-	AND id = $4
+	AND id = $3
+	AND belongs_to_user = $4
 `
 
 type UpdateRecipeListParams struct {
 	Name          string
 	Description   string
-	BelongsToUser string
 	ID            string
+	BelongsToUser string
 }
 
 func (q *Queries) UpdateRecipeList(ctx context.Context, db DBTX, arg *UpdateRecipeListParams) (int64, error) {
 	result, err := db.ExecContext(ctx, updateRecipeList,
 		arg.Name,
 		arg.Description,
-		arg.BelongsToUser,
 		arg.ID,
+		arg.BelongsToUser,
 	)
 	if err != nil {
 		return 0, err

--- a/backend/internal/repositories/postgres/mealplanning/generated/recipe_media.generated.sql_generated.go
+++ b/backend/internal/repositories/postgres/mealplanning/generated/recipe_media.generated.sql_generated.go
@@ -12,7 +12,10 @@ import (
 )
 
 const archiveRecipeMedia = `-- name: ArchiveRecipeMedia :execrows
-UPDATE recipe_media SET archived_at = NOW() WHERE archived_at IS NULL AND id = $1
+UPDATE recipe_media SET
+	archived_at = NOW()
+WHERE archived_at IS NULL
+	AND id = $1
 `
 
 func (q *Queries) ArchiveRecipeMedia(ctx context.Context, db DBTX, id string) (int64, error) {

--- a/backend/internal/repositories/postgres/mealplanning/generated/recipe_prep_tasks.generated.sql_generated.go
+++ b/backend/internal/repositories/postgres/mealplanning/generated/recipe_prep_tasks.generated.sql_generated.go
@@ -12,7 +12,10 @@ import (
 )
 
 const archiveRecipePrepTask = `-- name: ArchiveRecipePrepTask :execrows
-UPDATE recipe_prep_tasks SET archived_at = NOW() WHERE archived_at IS NULL AND id = $1
+UPDATE recipe_prep_tasks SET
+	archived_at = NOW()
+WHERE archived_at IS NULL
+	AND id = $1
 `
 
 func (q *Queries) ArchiveRecipePrepTask(ctx context.Context, db DBTX, id string) (int64, error) {

--- a/backend/internal/repositories/postgres/mealplanning/generated/recipe_ratings.generated.sql_generated.go
+++ b/backend/internal/repositories/postgres/mealplanning/generated/recipe_ratings.generated.sql_generated.go
@@ -12,7 +12,10 @@ import (
 )
 
 const archiveRecipeRating = `-- name: ArchiveRecipeRating :execrows
-UPDATE recipe_ratings SET archived_at = NOW() WHERE archived_at IS NULL AND id = $1
+UPDATE recipe_ratings SET
+	archived_at = NOW()
+WHERE archived_at IS NULL
+	AND id = $1
 `
 
 func (q *Queries) ArchiveRecipeRating(ctx context.Context, db DBTX, id string) (int64, error) {

--- a/backend/internal/repositories/postgres/mealplanning/generated/recipe_step_ingredients.generated.sql_generated.go
+++ b/backend/internal/repositories/postgres/mealplanning/generated/recipe_step_ingredients.generated.sql_generated.go
@@ -12,16 +12,20 @@ import (
 )
 
 const archiveRecipeStepIngredient = `-- name: ArchiveRecipeStepIngredient :execrows
-UPDATE recipe_step_ingredients SET archived_at = NOW() WHERE archived_at IS NULL AND belongs_to_recipe_step = $1 AND id = $2
+UPDATE recipe_step_ingredients SET
+	archived_at = NOW()
+WHERE archived_at IS NULL
+	AND id = $1
+	AND belongs_to_recipe_step = $2
 `
 
 type ArchiveRecipeStepIngredientParams struct {
-	BelongsToRecipeStep string
 	ID                  string
+	BelongsToRecipeStep string
 }
 
 func (q *Queries) ArchiveRecipeStepIngredient(ctx context.Context, db DBTX, arg *ArchiveRecipeStepIngredientParams) (int64, error) {
-	result, err := db.ExecContext(ctx, archiveRecipeStepIngredient, arg.BelongsToRecipeStep, arg.ID)
+	result, err := db.ExecContext(ctx, archiveRecipeStepIngredient, arg.ID, arg.BelongsToRecipeStep)
 	if err != nil {
 		return 0, err
 	}
@@ -1002,8 +1006,8 @@ UPDATE recipe_step_ingredients SET
 	recipe_step_product_recipe_id = $16,
 	last_updated_at = NOW()
 WHERE archived_at IS NULL
-	AND belongs_to_recipe_step = $17
-	AND id = $18
+	AND id = $17
+	AND belongs_to_recipe_step = $18
 `
 
 type UpdateRecipeStepIngredientParams struct {
@@ -1023,8 +1027,8 @@ type UpdateRecipeStepIngredientParams struct {
 	VesselIndex               sql.NullInt32
 	ScaleFactor               string
 	RecipeStepProductRecipeID sql.NullString
-	BelongsToRecipeStep       string
 	ID                        string
+	BelongsToRecipeStep       string
 }
 
 func (q *Queries) UpdateRecipeStepIngredient(ctx context.Context, db DBTX, arg *UpdateRecipeStepIngredientParams) (int64, error) {
@@ -1045,8 +1049,8 @@ func (q *Queries) UpdateRecipeStepIngredient(ctx context.Context, db DBTX, arg *
 		arg.VesselIndex,
 		arg.ScaleFactor,
 		arg.RecipeStepProductRecipeID,
-		arg.BelongsToRecipeStep,
 		arg.ID,
+		arg.BelongsToRecipeStep,
 	)
 	if err != nil {
 		return 0, err

--- a/backend/internal/repositories/postgres/mealplanning/generated/recipe_step_instruments.generated.sql_generated.go
+++ b/backend/internal/repositories/postgres/mealplanning/generated/recipe_step_instruments.generated.sql_generated.go
@@ -12,16 +12,20 @@ import (
 )
 
 const archiveRecipeStepInstrument = `-- name: ArchiveRecipeStepInstrument :execrows
-UPDATE recipe_step_instruments SET archived_at = NOW() WHERE archived_at IS NULL AND belongs_to_recipe_step = $1 AND id = $2
+UPDATE recipe_step_instruments SET
+	archived_at = NOW()
+WHERE archived_at IS NULL
+	AND id = $1
+	AND belongs_to_recipe_step = $2
 `
 
 type ArchiveRecipeStepInstrumentParams struct {
-	BelongsToRecipeStep string
 	ID                  string
+	BelongsToRecipeStep string
 }
 
 func (q *Queries) ArchiveRecipeStepInstrument(ctx context.Context, db DBTX, arg *ArchiveRecipeStepInstrumentParams) (int64, error) {
-	result, err := db.ExecContext(ctx, archiveRecipeStepInstrument, arg.BelongsToRecipeStep, arg.ID)
+	result, err := db.ExecContext(ctx, archiveRecipeStepInstrument, arg.ID, arg.BelongsToRecipeStep)
 	if err != nil {
 		return 0, err
 	}
@@ -569,8 +573,8 @@ UPDATE recipe_step_instruments SET
 	scale_factor = $11,
 	last_updated_at = NOW()
 WHERE archived_at IS NULL
-	AND belongs_to_recipe_step = $12
-	AND id = $13
+	AND id = $12
+	AND belongs_to_recipe_step = $13
 `
 
 type UpdateRecipeStepInstrumentParams struct {
@@ -585,8 +589,8 @@ type UpdateRecipeStepInstrumentParams struct {
 	Index               int32
 	OptionIndex         int32
 	ScaleFactor         string
-	BelongsToRecipeStep string
 	ID                  string
+	BelongsToRecipeStep string
 }
 
 func (q *Queries) UpdateRecipeStepInstrument(ctx context.Context, db DBTX, arg *UpdateRecipeStepInstrumentParams) (int64, error) {
@@ -602,8 +606,8 @@ func (q *Queries) UpdateRecipeStepInstrument(ctx context.Context, db DBTX, arg *
 		arg.Index,
 		arg.OptionIndex,
 		arg.ScaleFactor,
-		arg.BelongsToRecipeStep,
 		arg.ID,
+		arg.BelongsToRecipeStep,
 	)
 	if err != nil {
 		return 0, err

--- a/backend/internal/repositories/postgres/mealplanning/generated/recipe_step_products.generated.sql_generated.go
+++ b/backend/internal/repositories/postgres/mealplanning/generated/recipe_step_products.generated.sql_generated.go
@@ -12,16 +12,20 @@ import (
 )
 
 const archiveRecipeStepProduct = `-- name: ArchiveRecipeStepProduct :execrows
-UPDATE recipe_step_products SET archived_at = NOW() WHERE archived_at IS NULL AND belongs_to_recipe_step = $1 AND id = $2
+UPDATE recipe_step_products SET
+	archived_at = NOW()
+WHERE archived_at IS NULL
+	AND id = $1
+	AND belongs_to_recipe_step = $2
 `
 
 type ArchiveRecipeStepProductParams struct {
-	BelongsToRecipeStep string
 	ID                  string
+	BelongsToRecipeStep string
 }
 
 func (q *Queries) ArchiveRecipeStepProduct(ctx context.Context, db DBTX, arg *ArchiveRecipeStepProductParams) (int64, error) {
-	result, err := db.ExecContext(ctx, archiveRecipeStepProduct, arg.BelongsToRecipeStep, arg.ID)
+	result, err := db.ExecContext(ctx, archiveRecipeStepProduct, arg.ID, arg.BelongsToRecipeStep)
 	if err != nil {
 		return 0, err
 	}
@@ -345,7 +349,7 @@ SELECT
 		SELECT COUNT(recipe_step_products.id)
 		FROM recipe_step_products
 		WHERE recipe_step_products.archived_at IS NULL
-			AND recipe_step_products.belongs_to_recipe_step = $6
+				AND recipe_step_products.belongs_to_recipe_step = $6
 	) AS total_count
 FROM recipe_step_products
 	JOIN recipe_steps ON recipe_step_products.belongs_to_recipe_step=recipe_steps.id
@@ -663,8 +667,8 @@ UPDATE recipe_step_products SET
 	contained_in_vessel_index = $17,
 	last_updated_at = NOW()
 WHERE archived_at IS NULL
-	AND belongs_to_recipe_step = $18
-	AND id = $19
+	AND id = $18
+	AND belongs_to_recipe_step = $19
 `
 
 type UpdateRecipeStepProductParams struct {
@@ -685,8 +689,8 @@ type UpdateRecipeStepProductParams struct {
 	IsWaste                            bool
 	Index                              int32
 	ContainedInVesselIndex             sql.NullInt32
-	BelongsToRecipeStep                string
 	ID                                 string
+	BelongsToRecipeStep                string
 }
 
 func (q *Queries) UpdateRecipeStepProduct(ctx context.Context, db DBTX, arg *UpdateRecipeStepProductParams) (int64, error) {
@@ -708,8 +712,8 @@ func (q *Queries) UpdateRecipeStepProduct(ctx context.Context, db DBTX, arg *Upd
 		arg.IsWaste,
 		arg.Index,
 		arg.ContainedInVesselIndex,
-		arg.BelongsToRecipeStep,
 		arg.ID,
+		arg.BelongsToRecipeStep,
 	)
 	if err != nil {
 		return 0, err

--- a/backend/internal/repositories/postgres/mealplanning/generated/recipe_step_vessels.generated.sql_generated.go
+++ b/backend/internal/repositories/postgres/mealplanning/generated/recipe_step_vessels.generated.sql_generated.go
@@ -12,16 +12,20 @@ import (
 )
 
 const archiveRecipeStepVessel = `-- name: ArchiveRecipeStepVessel :execrows
-UPDATE recipe_step_vessels SET archived_at = NOW() WHERE archived_at IS NULL AND belongs_to_recipe_step = $1 AND id = $2
+UPDATE recipe_step_vessels SET
+	archived_at = NOW()
+WHERE archived_at IS NULL
+	AND id = $1
+	AND belongs_to_recipe_step = $2
 `
 
 type ArchiveRecipeStepVesselParams struct {
-	BelongsToRecipeStep string
 	ID                  string
+	BelongsToRecipeStep string
 }
 
 func (q *Queries) ArchiveRecipeStepVessel(ctx context.Context, db DBTX, arg *ArchiveRecipeStepVesselParams) (int64, error) {
-	result, err := db.ExecContext(ctx, archiveRecipeStepVessel, arg.BelongsToRecipeStep, arg.ID)
+	result, err := db.ExecContext(ctx, archiveRecipeStepVessel, arg.ID, arg.BelongsToRecipeStep)
 	if err != nil {
 		return 0, err
 	}

--- a/backend/internal/repositories/postgres/mealplanning/generated/recipe_steps.generated.sql_generated.go
+++ b/backend/internal/repositories/postgres/mealplanning/generated/recipe_steps.generated.sql_generated.go
@@ -12,16 +12,20 @@ import (
 )
 
 const archiveRecipeStep = `-- name: ArchiveRecipeStep :execrows
-UPDATE recipe_steps SET archived_at = NOW() WHERE archived_at IS NULL AND belongs_to_recipe = $1 AND id = $2
+UPDATE recipe_steps SET
+	archived_at = NOW()
+WHERE archived_at IS NULL
+	AND id = $1
+	AND belongs_to_recipe = $2
 `
 
 type ArchiveRecipeStepParams struct {
-	BelongsToRecipe string
 	ID              string
+	BelongsToRecipe string
 }
 
 func (q *Queries) ArchiveRecipeStep(ctx context.Context, db DBTX, arg *ArchiveRecipeStepParams) (int64, error) {
-	result, err := db.ExecContext(ctx, archiveRecipeStep, arg.BelongsToRecipe, arg.ID)
+	result, err := db.ExecContext(ctx, archiveRecipeStep, arg.ID, arg.BelongsToRecipe)
 	if err != nil {
 		return 0, err
 	}
@@ -621,8 +625,8 @@ UPDATE recipe_steps SET
 	start_timer_automatically = $11,
 	last_updated_at = NOW()
 WHERE archived_at IS NULL
-	AND belongs_to_recipe = $12
-	AND id = $13
+	AND id = $12
+	AND belongs_to_recipe = $13
 `
 
 type UpdateRecipeStepParams struct {
@@ -637,8 +641,8 @@ type UpdateRecipeStepParams struct {
 	ConditionExpression           string
 	Optional                      bool
 	StartTimerAutomatically       bool
-	BelongsToRecipe               string
 	ID                            string
+	BelongsToRecipe               string
 }
 
 func (q *Queries) UpdateRecipeStep(ctx context.Context, db DBTX, arg *UpdateRecipeStepParams) (int64, error) {
@@ -654,8 +658,8 @@ func (q *Queries) UpdateRecipeStep(ctx context.Context, db DBTX, arg *UpdateReci
 		arg.ConditionExpression,
 		arg.Optional,
 		arg.StartTimerAutomatically,
-		arg.BelongsToRecipe,
 		arg.ID,
+		arg.BelongsToRecipe,
 	)
 	if err != nil {
 		return 0, err

--- a/backend/internal/repositories/postgres/mealplanning/generated/recipes.generated.sql_generated.go
+++ b/backend/internal/repositories/postgres/mealplanning/generated/recipes.generated.sql_generated.go
@@ -1558,14 +1558,14 @@ WHERE recipes.archived_at IS NULL
 		SELECT 1 FROM recipe_step_instruments rsi
 		JOIN recipe_steps rs ON rsi.belongs_to_recipe_step = rs.id
 		WHERE rs.belongs_to_recipe = recipes.id
-			AND rsi.archived_at IS NULL
-			AND rs.archived_at IS NULL
-			AND rsi.optional = false
-			AND rsi.instrument_id IS NOT NULL
-			AND rsi.instrument_id NOT IN (
-				SELECT valid_instrument_id FROM account_instrument_ownerships
-				WHERE belongs_to_account = $8 AND archived_at IS NULL
-			)
+				AND rsi.archived_at IS NULL
+				AND rs.archived_at IS NULL
+				AND rsi.optional = false
+				AND rsi.instrument_id IS NOT NULL
+				AND rsi.instrument_id NOT IN (
+					SELECT valid_instrument_id FROM account_instrument_ownerships
+					WHERE belongs_to_account = $8 AND archived_at IS NULL
+				)
 	)
 ORDER BY recipes.id ASC
 LIMIT COALESCE($9, 50)

--- a/backend/internal/repositories/postgres/mealplanning/generated/user_ingredient_preferences.generated.sql_generated.go
+++ b/backend/internal/repositories/postgres/mealplanning/generated/user_ingredient_preferences.generated.sql_generated.go
@@ -12,16 +12,20 @@ import (
 )
 
 const archiveUserIngredientPreference = `-- name: ArchiveUserIngredientPreference :execrows
-UPDATE user_ingredient_preferences SET archived_at = NOW() WHERE archived_at IS NULL AND belongs_to_user = $1 AND id = $2
+UPDATE user_ingredient_preferences SET
+	archived_at = NOW()
+WHERE archived_at IS NULL
+	AND id = $1
+	AND belongs_to_user = $2
 `
 
 type ArchiveUserIngredientPreferenceParams struct {
-	BelongsToUser string
 	ID            string
+	BelongsToUser string
 }
 
 func (q *Queries) ArchiveUserIngredientPreference(ctx context.Context, db DBTX, arg *ArchiveUserIngredientPreferenceParams) (int64, error) {
-	result, err := db.ExecContext(ctx, archiveUserIngredientPreference, arg.BelongsToUser, arg.ID)
+	result, err := db.ExecContext(ctx, archiveUserIngredientPreference, arg.ID, arg.BelongsToUser)
 	if err != nil {
 		return 0, err
 	}
@@ -500,8 +504,8 @@ UPDATE user_ingredient_preferences SET
 	allergy = $4,
 	last_updated_at = NOW()
 WHERE archived_at IS NULL
-	AND belongs_to_user = $5
-	AND id = $6
+	AND id = $5
+	AND belongs_to_user = $6
 `
 
 type UpdateUserIngredientPreferenceParams struct {
@@ -509,8 +513,8 @@ type UpdateUserIngredientPreferenceParams struct {
 	Rating        int16
 	Notes         string
 	Allergy       bool
-	BelongsToUser string
 	ID            string
+	BelongsToUser string
 }
 
 func (q *Queries) UpdateUserIngredientPreference(ctx context.Context, db DBTX, arg *UpdateUserIngredientPreferenceParams) (int64, error) {
@@ -519,8 +523,8 @@ func (q *Queries) UpdateUserIngredientPreference(ctx context.Context, db DBTX, a
 		arg.Rating,
 		arg.Notes,
 		arg.Allergy,
-		arg.BelongsToUser,
 		arg.ID,
+		arg.BelongsToUser,
 	)
 	if err != nil {
 		return 0, err

--- a/backend/internal/repositories/postgres/mealplanning/generated/valid_ingredient_measurement_units.generated.sql_generated.go
+++ b/backend/internal/repositories/postgres/mealplanning/generated/valid_ingredient_measurement_units.generated.sql_generated.go
@@ -14,7 +14,10 @@ import (
 )
 
 const archiveValidIngredientMeasurementUnit = `-- name: ArchiveValidIngredientMeasurementUnit :execrows
-UPDATE valid_ingredient_measurement_units SET archived_at = NOW() WHERE archived_at IS NULL AND id = $1
+UPDATE valid_ingredient_measurement_units SET
+	archived_at = NOW()
+WHERE archived_at IS NULL
+	AND id = $1
 `
 
 func (q *Queries) ArchiveValidIngredientMeasurementUnit(ctx context.Context, db DBTX, id string) (int64, error) {

--- a/backend/internal/repositories/postgres/mealplanning/generated/valid_ingredient_preparations.generated.sql_generated.go
+++ b/backend/internal/repositories/postgres/mealplanning/generated/valid_ingredient_preparations.generated.sql_generated.go
@@ -14,7 +14,10 @@ import (
 )
 
 const archiveValidIngredientPreparation = `-- name: ArchiveValidIngredientPreparation :execrows
-UPDATE valid_ingredient_preparations SET archived_at = NOW() WHERE archived_at IS NULL AND id = $1
+UPDATE valid_ingredient_preparations SET
+	archived_at = NOW()
+WHERE archived_at IS NULL
+	AND id = $1
 `
 
 func (q *Queries) ArchiveValidIngredientPreparation(ctx context.Context, db DBTX, id string) (int64, error) {

--- a/backend/internal/repositories/postgres/mealplanning/generated/valid_ingredient_state_ingredients.generated.sql_generated.go
+++ b/backend/internal/repositories/postgres/mealplanning/generated/valid_ingredient_state_ingredients.generated.sql_generated.go
@@ -14,7 +14,10 @@ import (
 )
 
 const archiveValidIngredientStateIngredient = `-- name: ArchiveValidIngredientStateIngredient :execrows
-UPDATE valid_ingredient_state_ingredients SET archived_at = NOW() WHERE archived_at IS NULL AND id = $1
+UPDATE valid_ingredient_state_ingredients SET
+	archived_at = NOW()
+WHERE archived_at IS NULL
+	AND id = $1
 `
 
 func (q *Queries) ArchiveValidIngredientStateIngredient(ctx context.Context, db DBTX, id string) (int64, error) {

--- a/backend/internal/repositories/postgres/mealplanning/generated/valid_measurement_unit_conversions.generated.sql_generated.go
+++ b/backend/internal/repositories/postgres/mealplanning/generated/valid_measurement_unit_conversions.generated.sql_generated.go
@@ -14,7 +14,10 @@ import (
 )
 
 const archiveValidMeasurementUnitConversion = `-- name: ArchiveValidMeasurementUnitConversion :execrows
-UPDATE valid_measurement_unit_conversions SET archived_at = NOW() WHERE archived_at IS NULL AND id = $1
+UPDATE valid_measurement_unit_conversions SET
+	archived_at = NOW()
+WHERE archived_at IS NULL
+	AND id = $1
 `
 
 func (q *Queries) ArchiveValidMeasurementUnitConversion(ctx context.Context, db DBTX, id string) (int64, error) {

--- a/backend/internal/repositories/postgres/mealplanning/generated/valid_prep_task_configs.generated.sql_generated.go
+++ b/backend/internal/repositories/postgres/mealplanning/generated/valid_prep_task_configs.generated.sql_generated.go
@@ -12,7 +12,10 @@ import (
 )
 
 const archiveValidPrepTaskConfig = `-- name: ArchiveValidPrepTaskConfig :execrows
-UPDATE valid_prep_task_configs SET archived_at = NOW() WHERE archived_at IS NULL AND id = $1
+UPDATE valid_prep_task_configs SET
+	archived_at = NOW()
+WHERE archived_at IS NULL
+	AND id = $1
 `
 
 func (q *Queries) ArchiveValidPrepTaskConfig(ctx context.Context, db DBTX, id string) (int64, error) {

--- a/backend/internal/repositories/postgres/mealplanning/generated/valid_preparation_instruments.generated.sql_generated.go
+++ b/backend/internal/repositories/postgres/mealplanning/generated/valid_preparation_instruments.generated.sql_generated.go
@@ -14,7 +14,10 @@ import (
 )
 
 const archiveValidPreparationInstrument = `-- name: ArchiveValidPreparationInstrument :execrows
-UPDATE valid_preparation_instruments SET archived_at = NOW() WHERE archived_at IS NULL AND id = $1
+UPDATE valid_preparation_instruments SET
+	archived_at = NOW()
+WHERE archived_at IS NULL
+	AND id = $1
 `
 
 func (q *Queries) ArchiveValidPreparationInstrument(ctx context.Context, db DBTX, id string) (int64, error) {

--- a/backend/internal/repositories/postgres/mealplanning/generated/valid_preparation_vessels.generated.sql_generated.go
+++ b/backend/internal/repositories/postgres/mealplanning/generated/valid_preparation_vessels.generated.sql_generated.go
@@ -14,7 +14,10 @@ import (
 )
 
 const archiveValidPreparationVessel = `-- name: ArchiveValidPreparationVessel :execrows
-UPDATE valid_preparation_vessels SET archived_at = NOW() WHERE archived_at IS NULL AND id = $1
+UPDATE valid_preparation_vessels SET
+	archived_at = NOW()
+WHERE archived_at IS NULL
+	AND id = $1
 `
 
 func (q *Queries) ArchiveValidPreparationVessel(ctx context.Context, db DBTX, id string) (int64, error) {

--- a/backend/internal/repositories/postgres/mealplanning/sqlc_queries/account_instrument_ownerships.generated.sql
+++ b/backend/internal/repositories/postgres/mealplanning/sqlc_queries/account_instrument_ownerships.generated.sql
@@ -1,10 +1,3 @@
--- name: ArchiveAccountInstrumentOwnership :execrows
-UPDATE account_instrument_ownerships SET
-	archived_at = NOW()
-WHERE archived_at IS NULL
-	AND id = sqlc.arg(id)
-	AND belongs_to_account = sqlc.arg(belongs_to_account);
-
 -- name: CreateAccountInstrumentOwnership :exec
 INSERT INTO account_instrument_ownerships (
 	id,
@@ -28,6 +21,23 @@ SELECT EXISTS (
 		AND account_instrument_ownerships.id = sqlc.arg(id)
 		AND account_instrument_ownerships.belongs_to_account = sqlc.arg(belongs_to_account)
 );
+
+-- name: UpdateAccountInstrumentOwnership :execrows
+UPDATE account_instrument_ownerships SET
+	notes = sqlc.arg(notes),
+	quantity = sqlc.arg(quantity),
+	valid_instrument_id = sqlc.arg(valid_instrument_id),
+	last_updated_at = NOW()
+WHERE archived_at IS NULL
+	AND id = sqlc.arg(id)
+	AND belongs_to_account = sqlc.arg(belongs_to_account);
+
+-- name: ArchiveAccountInstrumentOwnership :execrows
+UPDATE account_instrument_ownerships SET
+	archived_at = NOW()
+WHERE archived_at IS NULL
+	AND id = sqlc.arg(id)
+	AND belongs_to_account = sqlc.arg(belongs_to_account);
 
 -- name: GetAccountInstrumentOwnerships :many
 SELECT
@@ -124,14 +134,4 @@ FROM account_instrument_ownerships
 INNER JOIN valid_instruments ON account_instrument_ownerships.valid_instrument_id = valid_instruments.id
 WHERE account_instrument_ownerships.archived_at IS NULL
 	AND account_instrument_ownerships.id = sqlc.arg(id)
-	AND account_instrument_ownerships.belongs_to_account = sqlc.arg(belongs_to_account);
-
--- name: UpdateAccountInstrumentOwnership :execrows
-UPDATE account_instrument_ownerships SET
-	notes = sqlc.arg(notes),
-	quantity = sqlc.arg(quantity),
-	valid_instrument_id = sqlc.arg(valid_instrument_id),
-	last_updated_at = NOW()
-WHERE archived_at IS NULL
-	AND id = sqlc.arg(id)
 	AND account_instrument_ownerships.belongs_to_account = sqlc.arg(belongs_to_account);

--- a/backend/internal/repositories/postgres/mealplanning/sqlc_queries/meal_list_items.generated.sql
+++ b/backend/internal/repositories/postgres/mealplanning/sqlc_queries/meal_list_items.generated.sql
@@ -1,15 +1,3 @@
--- name: CheckMealInMealList :one
-SELECT EXISTS (
-	SELECT meal_list_items.id
-	FROM meal_list_items
-	WHERE meal_list_items.archived_at IS NULL
-		AND meal_list_items.belongs_to_meal_list = sqlc.arg(belongs_to_meal_list)
-		AND meal_list_items.meal_id = sqlc.arg(meal_id)
-);
-
--- name: ArchiveMealListItem :execrows
-UPDATE meal_list_items SET archived_at = NOW() WHERE archived_at IS NULL AND belongs_to_meal_list = sqlc.arg(belongs_to_meal_list) AND id = sqlc.arg(id);
-
 -- name: CreateMealListItem :exec
 INSERT INTO meal_list_items (
 	id,
@@ -21,6 +9,31 @@ INSERT INTO meal_list_items (
 	sqlc.arg(meal_id),
 	sqlc.arg(notes),
 	sqlc.arg(belongs_to_meal_list)
+);
+
+-- name: UpdateMealListItem :execrows
+UPDATE meal_list_items SET
+	meal_id = sqlc.arg(meal_id),
+	notes = sqlc.arg(notes),
+	last_updated_at = NOW()
+WHERE archived_at IS NULL
+	AND id = sqlc.arg(id)
+	AND belongs_to_meal_list = sqlc.arg(belongs_to_meal_list);
+
+-- name: ArchiveMealListItem :execrows
+UPDATE meal_list_items SET
+	archived_at = NOW()
+WHERE archived_at IS NULL
+	AND id = sqlc.arg(id)
+	AND belongs_to_meal_list = sqlc.arg(belongs_to_meal_list);
+
+-- name: CheckMealInMealList :one
+SELECT EXISTS (
+	SELECT meal_list_items.id
+	FROM meal_list_items
+	WHERE meal_list_items.archived_at IS NULL
+		AND meal_list_items.belongs_to_meal_list = sqlc.arg(belongs_to_meal_list)
+		AND meal_list_items.meal_id = sqlc.arg(meal_id)
 );
 
 -- name: GetMealListItems :many
@@ -74,12 +87,3 @@ WHERE meal_list_items.archived_at IS NULL
 	AND meal_list_items.belongs_to_meal_list = sqlc.arg(meal_list_id)
 ORDER BY meal_list_items.id ASC
 LIMIT COALESCE(sqlc.narg(result_limit), 50);
-
--- name: UpdateMealListItem :execrows
-UPDATE meal_list_items SET
-	meal_id = sqlc.arg(meal_id),
-	notes = sqlc.arg(notes),
-	last_updated_at = NOW()
-WHERE archived_at IS NULL
-	AND belongs_to_meal_list = sqlc.arg(belongs_to_meal_list)
-	AND id = sqlc.arg(id);

--- a/backend/internal/repositories/postgres/mealplanning/sqlc_queries/meal_lists.generated.sql
+++ b/backend/internal/repositories/postgres/mealplanning/sqlc_queries/meal_lists.generated.sql
@@ -1,6 +1,3 @@
--- name: ArchiveMealList :execrows
-UPDATE meal_lists SET archived_at = NOW() WHERE archived_at IS NULL AND belongs_to_user = sqlc.arg(belongs_to_user) AND id = sqlc.arg(id);
-
 -- name: CreateMealList :exec
 INSERT INTO meal_lists (
 	id,
@@ -13,6 +10,22 @@ INSERT INTO meal_lists (
 	sqlc.arg(description),
 	sqlc.arg(belongs_to_user)
 );
+
+-- name: UpdateMealList :execrows
+UPDATE meal_lists SET
+	name = sqlc.arg(name),
+	description = sqlc.arg(description),
+	last_updated_at = NOW()
+WHERE archived_at IS NULL
+	AND id = sqlc.arg(id)
+	AND belongs_to_user = sqlc.arg(belongs_to_user);
+
+-- name: ArchiveMealList :execrows
+UPDATE meal_lists SET
+	archived_at = NOW()
+WHERE archived_at IS NULL
+	AND id = sqlc.arg(id)
+	AND belongs_to_user = sqlc.arg(belongs_to_user);
 
 -- name: GetMealLists :many
 SELECT
@@ -71,12 +84,3 @@ FROM meal_lists
 	AND meal_lists.id > COALESCE(sqlc.narg(cursor), '')
 ORDER BY meal_lists.id ASC
 LIMIT COALESCE(sqlc.narg(result_limit), 50);
-
--- name: UpdateMealList :execrows
-UPDATE meal_lists SET
-	name = sqlc.arg(name),
-	description = sqlc.arg(description),
-	last_updated_at = NOW()
-WHERE archived_at IS NULL
-	AND belongs_to_user = sqlc.arg(belongs_to_user)
-	AND id = sqlc.arg(id);

--- a/backend/internal/repositories/postgres/mealplanning/sqlc_queries/meal_plan_events.generated.sql
+++ b/backend/internal/repositories/postgres/mealplanning/sqlc_queries/meal_plan_events.generated.sql
@@ -1,6 +1,3 @@
--- name: ArchiveMealPlanEvent :execrows
-UPDATE meal_plan_events SET archived_at = NOW() WHERE archived_at IS NULL AND id = sqlc.arg(id) AND belongs_to_meal_plan = sqlc.arg(belongs_to_meal_plan);
-
 -- name: CreateMealPlanEvent :exec
 INSERT INTO meal_plan_events (
 	id,
@@ -17,6 +14,29 @@ INSERT INTO meal_plan_events (
 	sqlc.arg(meal_name),
 	sqlc.arg(belongs_to_meal_plan)
 );
+
+-- name: GetMealPlanEvent :one
+SELECT
+	meal_plan_events.id,
+	meal_plan_events.notes,
+	meal_plan_events.starts_at,
+	meal_plan_events.ends_at,
+	meal_plan_events.meal_name,
+	meal_plan_events.belongs_to_meal_plan,
+	meal_plan_events.created_at,
+	meal_plan_events.last_updated_at,
+	meal_plan_events.archived_at
+FROM meal_plan_events
+WHERE meal_plan_events.archived_at IS NULL
+	AND meal_plan_events.id = sqlc.arg(id)
+	AND meal_plan_events.belongs_to_meal_plan = sqlc.arg(belongs_to_meal_plan);
+
+-- name: ArchiveMealPlanEvent :execrows
+UPDATE meal_plan_events SET
+	archived_at = NOW()
+WHERE archived_at IS NULL
+	AND id = sqlc.arg(id)
+	AND belongs_to_meal_plan = sqlc.arg(belongs_to_meal_plan);
 
 -- name: MealPlanEventIsEligibleForVoting :one
 SELECT EXISTS (
@@ -111,22 +131,6 @@ FROM meal_plan_events
 WHERE
 	meal_plan_events.archived_at IS NULL
 	AND meal_plan_events.belongs_to_meal_plan = sqlc.arg(meal_plan_id);
-
--- name: GetMealPlanEvent :one
-SELECT
-	meal_plan_events.id,
-	meal_plan_events.notes,
-	meal_plan_events.starts_at,
-	meal_plan_events.ends_at,
-	meal_plan_events.meal_name,
-	meal_plan_events.belongs_to_meal_plan,
-	meal_plan_events.created_at,
-	meal_plan_events.last_updated_at,
-	meal_plan_events.archived_at
-FROM meal_plan_events
-WHERE meal_plan_events.archived_at IS NULL
-	AND meal_plan_events.id = sqlc.arg(id)
-	AND meal_plan_events.belongs_to_meal_plan = sqlc.arg(belongs_to_meal_plan);
 
 -- name: UpdateMealPlanEvent :execrows
 UPDATE meal_plan_events SET

--- a/backend/internal/repositories/postgres/mealplanning/sqlc_queries/meal_plan_grocery_list_items.generated.sql
+++ b/backend/internal/repositories/postgres/mealplanning/sqlc_queries/meal_plan_grocery_list_items.generated.sql
@@ -1,9 +1,3 @@
--- name: DeleteMealPlanGroceryListItems :exec
-DELETE FROM meal_plan_grocery_list_items WHERE id = ANY(sqlc.arg(ids)::text[]);
-
--- name: ArchiveMealPlanGroceryListItem :execrows
-UPDATE meal_plan_grocery_list_items SET archived_at = NOW() WHERE archived_at IS NULL AND id = sqlc.arg(id);
-
 -- name: CreateMealPlanGroceryListItem :exec
 INSERT INTO meal_plan_grocery_list_items (
 	id,
@@ -42,6 +36,37 @@ INSERT INTO meal_plan_grocery_list_items (
 	sqlc.arg(ingredient_index),
 	sqlc.arg(option_index)
 );
+
+-- name: UpdateMealPlanGroceryListItem :execrows
+UPDATE meal_plan_grocery_list_items SET
+	belongs_to_meal_plan = sqlc.arg(belongs_to_meal_plan),
+	valid_ingredient = sqlc.arg(valid_ingredient),
+	valid_measurement_unit = sqlc.arg(valid_measurement_unit),
+	minimum_quantity_needed = sqlc.arg(minimum_quantity_needed),
+	maximum_quantity_needed = sqlc.arg(maximum_quantity_needed),
+	quantity_purchased = sqlc.arg(quantity_purchased),
+	purchased_measurement_unit = sqlc.arg(purchased_measurement_unit),
+	purchased_upc = sqlc.arg(purchased_upc),
+	purchase_price = sqlc.arg(purchase_price),
+	status_explanation = sqlc.arg(status_explanation),
+	status = sqlc.arg(status),
+	belongs_to_meal_plan_option = sqlc.arg(belongs_to_meal_plan_option),
+	recipe_id = sqlc.arg(recipe_id),
+	recipe_step_id = sqlc.arg(recipe_step_id),
+	ingredient_index = sqlc.arg(ingredient_index),
+	option_index = sqlc.arg(option_index),
+	last_updated_at = NOW()
+WHERE archived_at IS NULL
+	AND id = sqlc.arg(id);
+
+-- name: ArchiveMealPlanGroceryListItem :execrows
+UPDATE meal_plan_grocery_list_items SET
+	archived_at = NOW()
+WHERE archived_at IS NULL
+	AND id = sqlc.arg(id);
+
+-- name: DeleteMealPlanGroceryListItems :exec
+DELETE FROM meal_plan_grocery_list_items WHERE id = ANY(sqlc.arg(ids)::text[]);
 
 -- name: CheckMealPlanGroceryListItemExistence :one
 SELECT EXISTS (
@@ -274,25 +299,3 @@ WHERE meal_plan_grocery_list_items.archived_at IS NULL
 	AND valid_ingredients.archived_at IS NULL
 	AND meal_plan_grocery_list_items.id = sqlc.arg(meal_plan_grocery_list_item_id)
 	AND meal_plan_grocery_list_items.belongs_to_meal_plan = sqlc.arg(meal_plan_id);
-
--- name: UpdateMealPlanGroceryListItem :execrows
-UPDATE meal_plan_grocery_list_items SET
-	belongs_to_meal_plan = sqlc.arg(belongs_to_meal_plan),
-	valid_ingredient = sqlc.arg(valid_ingredient),
-	valid_measurement_unit = sqlc.arg(valid_measurement_unit),
-	minimum_quantity_needed = sqlc.arg(minimum_quantity_needed),
-	maximum_quantity_needed = sqlc.arg(maximum_quantity_needed),
-	quantity_purchased = sqlc.arg(quantity_purchased),
-	purchased_measurement_unit = sqlc.arg(purchased_measurement_unit),
-	purchased_upc = sqlc.arg(purchased_upc),
-	purchase_price = sqlc.arg(purchase_price),
-	status_explanation = sqlc.arg(status_explanation),
-	status = sqlc.arg(status),
-	belongs_to_meal_plan_option = sqlc.arg(belongs_to_meal_plan_option),
-	recipe_id = sqlc.arg(recipe_id),
-	recipe_step_id = sqlc.arg(recipe_step_id),
-	ingredient_index = sqlc.arg(ingredient_index),
-	option_index = sqlc.arg(option_index),
-	last_updated_at = NOW()
-WHERE archived_at IS NULL
-	AND id = sqlc.arg(id);

--- a/backend/internal/repositories/postgres/mealplanning/sqlc_queries/meal_plan_option_votes.generated.sql
+++ b/backend/internal/repositories/postgres/mealplanning/sqlc_queries/meal_plan_option_votes.generated.sql
@@ -1,6 +1,3 @@
--- name: ArchiveMealPlanOptionVote :execrows
-UPDATE meal_plan_option_votes SET archived_at = NOW() WHERE archived_at IS NULL AND belongs_to_meal_plan_option = sqlc.arg(belongs_to_meal_plan_option) AND id = sqlc.arg(id);
-
 -- name: CreateMealPlanOptionVote :exec
 INSERT INTO meal_plan_option_votes (
 	id,
@@ -17,6 +14,24 @@ INSERT INTO meal_plan_option_votes (
 	sqlc.arg(by_user),
 	sqlc.arg(belongs_to_meal_plan_option)
 );
+
+-- name: UpdateMealPlanOptionVote :execrows
+UPDATE meal_plan_option_votes SET
+	rank = sqlc.arg(rank),
+	abstain = sqlc.arg(abstain),
+	notes = sqlc.arg(notes),
+	by_user = sqlc.arg(by_user),
+	last_updated_at = NOW()
+WHERE archived_at IS NULL
+	AND id = sqlc.arg(id)
+	AND belongs_to_meal_plan_option = sqlc.arg(belongs_to_meal_plan_option);
+
+-- name: ArchiveMealPlanOptionVote :execrows
+UPDATE meal_plan_option_votes SET
+	archived_at = NOW()
+WHERE archived_at IS NULL
+	AND id = sqlc.arg(id)
+	AND belongs_to_meal_plan_option = sqlc.arg(belongs_to_meal_plan_option);
 
 -- name: CheckMealPlanOptionVoteExistence :one
 SELECT EXISTS (
@@ -155,14 +170,3 @@ WHERE meal_plan_option_votes.archived_at IS NULL
 	AND meal_plan_options.id = sqlc.arg(meal_plan_option_id)
 	AND meal_plans.archived_at IS NULL
 	AND meal_plans.id = sqlc.arg(meal_plan_id);
-
--- name: UpdateMealPlanOptionVote :execrows
-UPDATE meal_plan_option_votes SET
-	rank = sqlc.arg(rank),
-	abstain = sqlc.arg(abstain),
-	notes = sqlc.arg(notes),
-	by_user = sqlc.arg(by_user),
-	last_updated_at = NOW()
-WHERE archived_at IS NULL
-	AND belongs_to_meal_plan_option = sqlc.arg(belongs_to_meal_plan_option)
-	AND id = sqlc.arg(id);

--- a/backend/internal/repositories/postgres/mealplanning/sqlc_queries/meal_plan_options.generated.sql
+++ b/backend/internal/repositories/postgres/mealplanning/sqlc_queries/meal_plan_options.generated.sql
@@ -1,19 +1,3 @@
--- name: CheckMealInMealPlanEvent :one
-SELECT EXISTS (
-	SELECT meal_plan_options.id
-	FROM meal_plan_options
-	WHERE meal_plan_options.archived_at IS NULL
-		AND meal_plan_options.belongs_to_meal_plan_event = sqlc.arg(belongs_to_meal_plan_event)
-		AND meal_plan_options.meal_id = sqlc.arg(meal_id)
-);
-
--- name: ArchiveMealPlanOption :execrows
-UPDATE meal_plan_options SET
-	archived_at = NOW()
-WHERE archived_at IS NULL
-	AND belongs_to_meal_plan_event = sqlc.arg(belongs_to_meal_plan_event)
-	AND id = sqlc.arg(id);
-
 -- name: CreateMealPlanOption :exec
 INSERT INTO meal_plan_options (
 	id,
@@ -33,6 +17,22 @@ INSERT INTO meal_plan_options (
 	sqlc.arg(meal_id),
 	sqlc.arg(notes),
 	sqlc.arg(belongs_to_meal_plan_event)
+);
+
+-- name: ArchiveMealPlanOption :execrows
+UPDATE meal_plan_options SET
+	archived_at = NOW()
+WHERE archived_at IS NULL
+	AND id = sqlc.arg(id)
+	AND belongs_to_meal_plan_event = sqlc.arg(belongs_to_meal_plan_event);
+
+-- name: CheckMealInMealPlanEvent :one
+SELECT EXISTS (
+	SELECT meal_plan_options.id
+	FROM meal_plan_options
+	WHERE meal_plan_options.archived_at IS NULL
+		AND meal_plan_options.belongs_to_meal_plan_event = sqlc.arg(belongs_to_meal_plan_event)
+		AND meal_plan_options.meal_id = sqlc.arg(meal_id)
 );
 
 -- name: CheckMealPlanOptionExistence :one

--- a/backend/internal/repositories/postgres/mealplanning/sqlc_queries/meal_plan_tasks.generated.sql
+++ b/backend/internal/repositories/postgres/mealplanning/sqlc_queries/meal_plan_tasks.generated.sql
@@ -1,13 +1,3 @@
--- name: DeleteMealPlanTasks :exec
-DELETE FROM meal_plan_tasks WHERE id = ANY(sqlc.arg(ids)::text[]);
-
--- name: ChangeMealPlanTaskStatus :exec
-UPDATE meal_plan_tasks SET
-	completed_at = sqlc.arg(completed_at),
-	status_explanation = sqlc.arg(status_explanation),
-	status = sqlc.arg(status)
-WHERE id = sqlc.arg(id);
-
 -- name: CreateMealPlanTask :exec
 INSERT INTO meal_plan_tasks (
 	id,
@@ -26,6 +16,16 @@ INSERT INTO meal_plan_tasks (
 	sqlc.arg(belongs_to_recipe_prep_task),
 	sqlc.arg(assigned_to_user)
 );
+
+-- name: DeleteMealPlanTasks :exec
+DELETE FROM meal_plan_tasks WHERE id = ANY(sqlc.arg(ids)::text[]);
+
+-- name: ChangeMealPlanTaskStatus :exec
+UPDATE meal_plan_tasks SET
+	completed_at = sqlc.arg(completed_at),
+	status_explanation = sqlc.arg(status_explanation),
+	status = sqlc.arg(status)
+WHERE id = sqlc.arg(id);
 
 -- name: CheckMealPlanTaskExistence :one
 SELECT EXISTS (

--- a/backend/internal/repositories/postgres/mealplanning/sqlc_queries/meal_plans.generated.sql
+++ b/backend/internal/repositories/postgres/mealplanning/sqlc_queries/meal_plans.generated.sql
@@ -1,6 +1,3 @@
--- name: ArchiveMealPlan :execrows
-UPDATE meal_plans SET archived_at = NOW() WHERE archived_at IS NULL AND belongs_to_account = sqlc.arg(belongs_to_account) AND id = sqlc.arg(id);
-
 -- name: CreateMealPlan :exec
 INSERT INTO meal_plans (
 	id,
@@ -17,6 +14,42 @@ INSERT INTO meal_plans (
 	sqlc.arg(belongs_to_account),
 	sqlc.arg(created_by_user)
 );
+
+-- name: GetMealPlan :one
+SELECT
+	meal_plans.id,
+	meal_plans.notes,
+	meal_plans.status,
+	meal_plans.voting_deadline,
+	meal_plans.grocery_list_initialized,
+	meal_plans.tasks_created,
+	meal_plans.election_method,
+	meal_plans.created_at,
+	meal_plans.last_updated_at,
+	meal_plans.archived_at,
+	meal_plans.belongs_to_account,
+	meal_plans.created_by_user
+FROM meal_plans
+WHERE meal_plans.archived_at IS NULL
+	AND meal_plans.id = sqlc.arg(id)
+	AND meal_plans.belongs_to_account = sqlc.arg(belongs_to_account);
+
+-- name: UpdateMealPlan :execrows
+UPDATE meal_plans SET
+	notes = sqlc.arg(notes),
+	status = sqlc.arg(status),
+	voting_deadline = sqlc.arg(voting_deadline),
+	last_updated_at = NOW()
+WHERE archived_at IS NULL
+	AND id = sqlc.arg(id)
+	AND belongs_to_account = sqlc.arg(belongs_to_account);
+
+-- name: ArchiveMealPlan :execrows
+UPDATE meal_plans SET
+	archived_at = NOW()
+WHERE archived_at IS NULL
+	AND id = sqlc.arg(id)
+	AND belongs_to_account = sqlc.arg(belongs_to_account);
 
 -- name: CheckMealPlanExistence :one
 SELECT EXISTS (
@@ -96,25 +129,6 @@ UPDATE meal_plans SET
 	last_updated_at = NOW()
 WHERE archived_at IS NULL
 	AND id = sqlc.arg(id);
-
--- name: GetMealPlan :one
-SELECT
-	meal_plans.id,
-	meal_plans.notes,
-	meal_plans.status,
-	meal_plans.voting_deadline,
-	meal_plans.grocery_list_initialized,
-	meal_plans.tasks_created,
-	meal_plans.election_method,
-	meal_plans.created_at,
-	meal_plans.last_updated_at,
-	meal_plans.archived_at,
-	meal_plans.belongs_to_account,
-	meal_plans.created_by_user
-FROM meal_plans
-WHERE meal_plans.archived_at IS NULL
-  AND meal_plans.id = sqlc.arg(id)
-  AND meal_plans.belongs_to_account = sqlc.arg(belongs_to_account);
 
 -- name: GetMealPlansForAccount :many
 SELECT
@@ -228,14 +242,4 @@ UPDATE meal_plans SET
 	tasks_created = TRUE,
 	last_updated_at = NOW()
 WHERE archived_at IS NULL
-	AND id = sqlc.arg(id);
-
--- name: UpdateMealPlan :execrows
-UPDATE meal_plans SET
-	notes = sqlc.arg(notes),
-	status = sqlc.arg(status),
-	voting_deadline = sqlc.arg(voting_deadline),
-	last_updated_at = NOW()
-WHERE archived_at IS NULL
-	AND belongs_to_account = sqlc.arg(belongs_to_account)
 	AND id = sqlc.arg(id);

--- a/backend/internal/repositories/postgres/mealplanning/sqlc_queries/meals.generated.sql
+++ b/backend/internal/repositories/postgres/mealplanning/sqlc_queries/meals.generated.sql
@@ -1,6 +1,3 @@
--- name: ArchiveMeal :execrows
-UPDATE meals SET archived_at = NOW() WHERE archived_at IS NULL AND created_by_user = sqlc.arg(created_by_user) AND id = sqlc.arg(id);
-
 -- name: CreateMeal :exec
 INSERT INTO meals (
 	id,
@@ -27,6 +24,17 @@ SELECT EXISTS (
 	WHERE meals.archived_at IS NULL
 		AND meals.id = sqlc.arg(id)
 );
+
+-- name: ScanMealIDsForReindex :many
+SELECT meals.id
+FROM meals
+WHERE meals.archived_at IS NULL
+	AND meals.id COLLATE "C" > sqlc.arg(cursor)
+ORDER BY meals.id COLLATE "C"
+LIMIT COALESCE(sqlc.narg(result_limit), 50);
+
+-- name: ArchiveMeal :execrows
+UPDATE meals SET archived_at = NOW() WHERE archived_at IS NULL AND created_by_user = sqlc.arg(created_by_user) AND id = sqlc.arg(id);
 
 -- name: GetMealsByCreatorAndName :many
 SELECT
@@ -57,14 +65,6 @@ WHERE meals.archived_at IS NULL
 	AND meals.created_by_user = sqlc.arg(created_by_user)
 	AND meals.name = sqlc.arg(name)
 ORDER BY meals.id ASC, meal_components.id ASC;
-
--- name: ScanMealIDsForReindex :many
-SELECT meals.id
-FROM meals
-WHERE meals.archived_at IS NULL
-	AND meals.id COLLATE "C" > sqlc.arg(cursor)
-ORDER BY meals.id COLLATE "C"
-LIMIT COALESCE(sqlc.narg(result_limit), 50);
 
 -- name: GetMealsNeedingIndexing :many
 SELECT meals.id

--- a/backend/internal/repositories/postgres/mealplanning/sqlc_queries/recipe_list_items.generated.sql
+++ b/backend/internal/repositories/postgres/mealplanning/sqlc_queries/recipe_list_items.generated.sql
@@ -1,6 +1,3 @@
--- name: ArchiveRecipeListItem :execrows
-UPDATE recipe_list_items SET archived_at = NOW() WHERE archived_at IS NULL AND belongs_to_recipe_list = sqlc.arg(belongs_to_recipe_list) AND id = sqlc.arg(id);
-
 -- name: CreateRecipeListItem :exec
 INSERT INTO recipe_list_items (
 	id,
@@ -13,6 +10,22 @@ INSERT INTO recipe_list_items (
 	sqlc.arg(notes),
 	sqlc.arg(belongs_to_recipe_list)
 );
+
+-- name: UpdateRecipeListItem :execrows
+UPDATE recipe_list_items SET
+	recipe_id = sqlc.arg(recipe_id),
+	notes = sqlc.arg(notes),
+	last_updated_at = NOW()
+WHERE archived_at IS NULL
+	AND id = sqlc.arg(id)
+	AND belongs_to_recipe_list = sqlc.arg(belongs_to_recipe_list);
+
+-- name: ArchiveRecipeListItem :execrows
+UPDATE recipe_list_items SET
+	archived_at = NOW()
+WHERE archived_at IS NULL
+	AND id = sqlc.arg(id)
+	AND belongs_to_recipe_list = sqlc.arg(belongs_to_recipe_list);
 
 -- name: GetRecipeListItems :many
 SELECT
@@ -63,12 +76,3 @@ WHERE recipe_list_items.archived_at IS NULL
 	AND recipe_list_items.belongs_to_recipe_list = sqlc.arg(recipe_list_id)
 ORDER BY recipe_list_items.id ASC
 LIMIT COALESCE(sqlc.narg(result_limit), 50);
-
--- name: UpdateRecipeListItem :execrows
-UPDATE recipe_list_items SET
-	recipe_id = sqlc.arg(recipe_id),
-	notes = sqlc.arg(notes),
-	last_updated_at = NOW()
-WHERE archived_at IS NULL
-	AND belongs_to_recipe_list = sqlc.arg(belongs_to_recipe_list)
-	AND id = sqlc.arg(id);

--- a/backend/internal/repositories/postgres/mealplanning/sqlc_queries/recipe_lists.generated.sql
+++ b/backend/internal/repositories/postgres/mealplanning/sqlc_queries/recipe_lists.generated.sql
@@ -1,6 +1,3 @@
--- name: ArchiveRecipeList :execrows
-UPDATE recipe_lists SET archived_at = NOW() WHERE archived_at IS NULL AND belongs_to_user = sqlc.arg(belongs_to_user) AND id = sqlc.arg(id);
-
 -- name: CreateRecipeList :exec
 INSERT INTO recipe_lists (
 	id,
@@ -13,6 +10,22 @@ INSERT INTO recipe_lists (
 	sqlc.arg(description),
 	sqlc.arg(belongs_to_user)
 );
+
+-- name: UpdateRecipeList :execrows
+UPDATE recipe_lists SET
+	name = sqlc.arg(name),
+	description = sqlc.arg(description),
+	last_updated_at = NOW()
+WHERE archived_at IS NULL
+	AND id = sqlc.arg(id)
+	AND belongs_to_user = sqlc.arg(belongs_to_user);
+
+-- name: ArchiveRecipeList :execrows
+UPDATE recipe_lists SET
+	archived_at = NOW()
+WHERE archived_at IS NULL
+	AND id = sqlc.arg(id)
+	AND belongs_to_user = sqlc.arg(belongs_to_user);
 
 -- name: GetRecipeLists :many
 SELECT
@@ -68,12 +81,3 @@ FROM recipe_lists
 	AND recipe_lists.id > COALESCE(sqlc.narg(cursor), '')
 ORDER BY recipe_lists.id ASC
 LIMIT COALESCE(sqlc.narg(result_limit), 50);
-
--- name: UpdateRecipeList :execrows
-UPDATE recipe_lists SET
-	name = sqlc.arg(name),
-	description = sqlc.arg(description),
-	last_updated_at = NOW()
-WHERE archived_at IS NULL
-	AND belongs_to_user = sqlc.arg(belongs_to_user)
-	AND id = sqlc.arg(id);

--- a/backend/internal/repositories/postgres/mealplanning/sqlc_queries/recipe_media.generated.sql
+++ b/backend/internal/repositories/postgres/mealplanning/sqlc_queries/recipe_media.generated.sql
@@ -1,6 +1,3 @@
--- name: ArchiveRecipeMedia :execrows
-UPDATE recipe_media SET archived_at = NOW() WHERE archived_at IS NULL AND id = sqlc.arg(id);
-
 -- name: CreateRecipeMedia :exec
 INSERT INTO recipe_media (
 	id,
@@ -20,6 +17,22 @@ INSERT INTO recipe_media (
 	sqlc.arg(index)
 );
 
+-- name: GetRecipeMedia :one
+SELECT
+	recipe_media.id,
+	recipe_media.belongs_to_recipe,
+	recipe_media.belongs_to_recipe_step,
+	recipe_media.mime_type,
+	recipe_media.internal_path,
+	recipe_media.external_path,
+	recipe_media.index,
+	recipe_media.created_at,
+	recipe_media.last_updated_at,
+	recipe_media.archived_at
+FROM recipe_media
+WHERE recipe_media.archived_at IS NULL
+	AND recipe_media.id = sqlc.arg(id);
+
 -- name: CheckRecipeMediaExistence :one
 SELECT EXISTS (
 	SELECT recipe_media.id
@@ -27,6 +40,24 @@ SELECT EXISTS (
 	WHERE recipe_media.archived_at IS NULL
 		AND recipe_media.id = sqlc.arg(id)
 );
+
+-- name: UpdateRecipeMedia :execrows
+UPDATE recipe_media SET
+	belongs_to_recipe = sqlc.arg(belongs_to_recipe),
+	belongs_to_recipe_step = sqlc.arg(belongs_to_recipe_step),
+	mime_type = sqlc.arg(mime_type),
+	internal_path = sqlc.arg(internal_path),
+	external_path = sqlc.arg(external_path),
+	index = sqlc.arg(index),
+	last_updated_at = NOW()
+WHERE archived_at IS NULL
+	AND id = sqlc.arg(id);
+
+-- name: ArchiveRecipeMedia :execrows
+UPDATE recipe_media SET
+	archived_at = NOW()
+WHERE archived_at IS NULL
+	AND id = sqlc.arg(id);
 
 -- name: GetRecipeMediaForRecipe :many
 SELECT
@@ -65,31 +96,3 @@ WHERE recipe_media.belongs_to_recipe = sqlc.arg(recipe_id)
 	AND recipe_media.archived_at IS NULL
 GROUP BY recipe_media.id
 ORDER BY recipe_media.id;
-
--- name: GetRecipeMedia :one
-SELECT
-	recipe_media.id,
-	recipe_media.belongs_to_recipe,
-	recipe_media.belongs_to_recipe_step,
-	recipe_media.mime_type,
-	recipe_media.internal_path,
-	recipe_media.external_path,
-	recipe_media.index,
-	recipe_media.created_at,
-	recipe_media.last_updated_at,
-	recipe_media.archived_at
-FROM recipe_media
-WHERE recipe_media.archived_at IS NULL
-	AND recipe_media.id = sqlc.arg(id);
-
--- name: UpdateRecipeMedia :execrows
-UPDATE recipe_media SET
-	belongs_to_recipe = sqlc.arg(belongs_to_recipe),
-	belongs_to_recipe_step = sqlc.arg(belongs_to_recipe_step),
-	mime_type = sqlc.arg(mime_type),
-	internal_path = sqlc.arg(internal_path),
-	external_path = sqlc.arg(external_path),
-	index = sqlc.arg(index),
-	last_updated_at = NOW()
-WHERE archived_at IS NULL
-	AND id = sqlc.arg(id);

--- a/backend/internal/repositories/postgres/mealplanning/sqlc_queries/recipe_prep_tasks.generated.sql
+++ b/backend/internal/repositories/postgres/mealplanning/sqlc_queries/recipe_prep_tasks.generated.sql
@@ -1,6 +1,3 @@
--- name: ArchiveRecipePrepTask :execrows
-UPDATE recipe_prep_tasks SET archived_at = NOW() WHERE archived_at IS NULL AND id = sqlc.arg(id);
-
 -- name: CreateRecipePrepTask :exec
 INSERT INTO recipe_prep_tasks (
 	id,
@@ -29,6 +26,29 @@ INSERT INTO recipe_prep_tasks (
 	sqlc.arg(maximum_storage_temperature_in_celsius),
 	sqlc.arg(belongs_to_recipe)
 );
+
+-- name: UpdateRecipePrepTask :execrows
+UPDATE recipe_prep_tasks SET
+	name = sqlc.arg(name),
+	description = sqlc.arg(description),
+	notes = sqlc.arg(notes),
+	optional = sqlc.arg(optional),
+	explicit_storage_instructions = sqlc.arg(explicit_storage_instructions),
+	minimum_time_buffer_before_recipe_in_seconds = sqlc.arg(minimum_time_buffer_before_recipe_in_seconds),
+	maximum_time_buffer_before_recipe_in_seconds = sqlc.arg(maximum_time_buffer_before_recipe_in_seconds),
+	storage_type = sqlc.arg(storage_type),
+	minimum_storage_temperature_in_celsius = sqlc.arg(minimum_storage_temperature_in_celsius),
+	maximum_storage_temperature_in_celsius = sqlc.arg(maximum_storage_temperature_in_celsius),
+	belongs_to_recipe = sqlc.arg(belongs_to_recipe),
+	last_updated_at = NOW()
+WHERE archived_at IS NULL
+	AND id = sqlc.arg(id);
+
+-- name: ArchiveRecipePrepTask :execrows
+UPDATE recipe_prep_tasks SET
+	archived_at = NOW()
+WHERE archived_at IS NULL
+	AND id = sqlc.arg(id);
 
 -- name: CheckRecipePrepTaskExistence :one
 SELECT EXISTS (
@@ -97,20 +117,3 @@ WHERE recipe_prep_tasks.archived_at IS NULL
 	AND recipe_steps.archived_at IS NULL
 	AND recipes.archived_at IS NULL
 	AND recipes.id = sqlc.arg(recipe_id);
-
--- name: UpdateRecipePrepTask :execrows
-UPDATE recipe_prep_tasks SET
-	name = sqlc.arg(name),
-	description = sqlc.arg(description),
-	notes = sqlc.arg(notes),
-	optional = sqlc.arg(optional),
-	explicit_storage_instructions = sqlc.arg(explicit_storage_instructions),
-	minimum_time_buffer_before_recipe_in_seconds = sqlc.arg(minimum_time_buffer_before_recipe_in_seconds),
-	maximum_time_buffer_before_recipe_in_seconds = sqlc.arg(maximum_time_buffer_before_recipe_in_seconds),
-	storage_type = sqlc.arg(storage_type),
-	minimum_storage_temperature_in_celsius = sqlc.arg(minimum_storage_temperature_in_celsius),
-	maximum_storage_temperature_in_celsius = sqlc.arg(maximum_storage_temperature_in_celsius),
-	belongs_to_recipe = sqlc.arg(belongs_to_recipe),
-	last_updated_at = NOW()
-WHERE archived_at IS NULL
-	AND id = sqlc.arg(id);

--- a/backend/internal/repositories/postgres/mealplanning/sqlc_queries/recipe_ratings.generated.sql
+++ b/backend/internal/repositories/postgres/mealplanning/sqlc_queries/recipe_ratings.generated.sql
@@ -1,6 +1,3 @@
--- name: ArchiveRecipeRating :execrows
-UPDATE recipe_ratings SET archived_at = NOW() WHERE archived_at IS NULL AND id = sqlc.arg(id);
-
 -- name: CreateRecipeRating :exec
 INSERT INTO recipe_ratings (
 	id,
@@ -24,6 +21,24 @@ INSERT INTO recipe_ratings (
 	sqlc.arg(created_by_user)
 );
 
+-- name: GetRecipeRating :one
+SELECT
+	recipe_ratings.id,
+	recipe_ratings.belongs_to_recipe,
+	recipe_ratings.taste,
+	recipe_ratings.difficulty,
+	recipe_ratings.cleanup,
+	recipe_ratings.instructions,
+	recipe_ratings.overall,
+	recipe_ratings.notes,
+	recipe_ratings.created_by_user,
+	recipe_ratings.created_at,
+	recipe_ratings.last_updated_at,
+	recipe_ratings.archived_at
+FROM recipe_ratings
+WHERE recipe_ratings.archived_at IS NULL
+	AND recipe_ratings.id = sqlc.arg(id);
+
 -- name: CheckRecipeRatingExistence :one
 SELECT EXISTS (
 	SELECT recipe_ratings.id
@@ -31,6 +46,25 @@ SELECT EXISTS (
 	WHERE recipe_ratings.archived_at IS NULL
 		AND recipe_ratings.id = sqlc.arg(id)
 );
+
+-- name: UpdateRecipeRating :execrows
+UPDATE recipe_ratings SET
+	belongs_to_recipe = sqlc.arg(belongs_to_recipe),
+	taste = sqlc.arg(taste),
+	difficulty = sqlc.arg(difficulty),
+	cleanup = sqlc.arg(cleanup),
+	instructions = sqlc.arg(instructions),
+	overall = sqlc.arg(overall),
+	notes = sqlc.arg(notes),
+	last_updated_at = NOW()
+WHERE archived_at IS NULL
+	AND id = sqlc.arg(id);
+
+-- name: ArchiveRecipeRating :execrows
+UPDATE recipe_ratings SET
+	archived_at = NOW()
+WHERE archived_at IS NULL
+	AND id = sqlc.arg(id);
 
 -- name: GetRecipeRatingsForRecipe :many
 SELECT
@@ -149,34 +183,3 @@ WHERE
 GROUP BY recipe_ratings.id
 ORDER BY recipe_ratings.id ASC
 LIMIT COALESCE(sqlc.narg(result_limit), 50);
-
--- name: GetRecipeRating :one
-SELECT
-	recipe_ratings.id,
-	recipe_ratings.belongs_to_recipe,
-	recipe_ratings.taste,
-	recipe_ratings.difficulty,
-	recipe_ratings.cleanup,
-	recipe_ratings.instructions,
-	recipe_ratings.overall,
-	recipe_ratings.notes,
-	recipe_ratings.created_by_user,
-	recipe_ratings.created_at,
-	recipe_ratings.last_updated_at,
-	recipe_ratings.archived_at
-FROM recipe_ratings
-WHERE recipe_ratings.archived_at IS NULL
-	AND recipe_ratings.id = sqlc.arg(id);
-
--- name: UpdateRecipeRating :execrows
-UPDATE recipe_ratings SET
-	belongs_to_recipe = sqlc.arg(belongs_to_recipe),
-	taste = sqlc.arg(taste),
-	difficulty = sqlc.arg(difficulty),
-	cleanup = sqlc.arg(cleanup),
-	instructions = sqlc.arg(instructions),
-	overall = sqlc.arg(overall),
-	notes = sqlc.arg(notes),
-	last_updated_at = NOW()
-WHERE archived_at IS NULL
-	AND id = sqlc.arg(id);

--- a/backend/internal/repositories/postgres/mealplanning/sqlc_queries/recipe_step_completion_conditions.generated.sql
+++ b/backend/internal/repositories/postgres/mealplanning/sqlc_queries/recipe_step_completion_conditions.generated.sql
@@ -1,6 +1,3 @@
--- name: ArchiveRecipeStepCompletionCondition :execrows
-UPDATE recipe_step_completion_conditions SET archived_at = NOW() WHERE archived_at IS NULL AND belongs_to_recipe_step = sqlc.arg(belongs_to_recipe_step) AND id = sqlc.arg(id);
-
 -- name: CreateRecipeStepCompletionCondition :exec
 INSERT INTO recipe_step_completion_conditions (
 	id,
@@ -15,6 +12,19 @@ INSERT INTO recipe_step_completion_conditions (
 	sqlc.arg(belongs_to_recipe_step),
 	sqlc.arg(ingredient_state)
 );
+
+-- name: UpdateRecipeStepCompletionCondition :execrows
+UPDATE recipe_step_completion_conditions SET
+	optional = sqlc.arg(optional),
+	notes = sqlc.arg(notes),
+	belongs_to_recipe_step = sqlc.arg(belongs_to_recipe_step),
+	ingredient_state = sqlc.arg(ingredient_state),
+	last_updated_at = NOW()
+WHERE archived_at IS NULL
+	AND id = sqlc.arg(id);
+
+-- name: ArchiveRecipeStepCompletionCondition :execrows
+UPDATE recipe_step_completion_conditions SET archived_at = NOW() WHERE archived_at IS NULL AND belongs_to_recipe_step = sqlc.arg(belongs_to_recipe_step) AND id = sqlc.arg(id);
 
 -- name: CheckRecipeStepCompletionConditionExistence :one
 SELECT EXISTS (
@@ -186,13 +196,3 @@ WHERE recipe_step_completion_conditions.archived_at IS NULL
 	AND recipe_steps.id = sqlc.arg(recipe_step_id)
 	AND recipes.archived_at IS NULL
 	AND recipes.id = sqlc.arg(recipe_id);
-
--- name: UpdateRecipeStepCompletionCondition :execrows
-UPDATE recipe_step_completion_conditions SET
-	optional = sqlc.arg(optional),
-	notes = sqlc.arg(notes),
-	belongs_to_recipe_step = sqlc.arg(belongs_to_recipe_step),
-	ingredient_state = sqlc.arg(ingredient_state),
-	last_updated_at = NOW()
-WHERE archived_at IS NULL
-	AND id = sqlc.arg(id);

--- a/backend/internal/repositories/postgres/mealplanning/sqlc_queries/recipe_step_ingredients.generated.sql
+++ b/backend/internal/repositories/postgres/mealplanning/sqlc_queries/recipe_step_ingredients.generated.sql
@@ -1,6 +1,3 @@
--- name: ArchiveRecipeStepIngredient :execrows
-UPDATE recipe_step_ingredients SET archived_at = NOW() WHERE archived_at IS NULL AND belongs_to_recipe_step = sqlc.arg(belongs_to_recipe_step) AND id = sqlc.arg(id);
-
 -- name: CreateRecipeStepIngredient :exec
 INSERT INTO recipe_step_ingredients (
 	id,
@@ -41,6 +38,36 @@ INSERT INTO recipe_step_ingredients (
 	sqlc.arg(recipe_step_product_recipe_id),
 	sqlc.arg(belongs_to_recipe_step)
 );
+
+-- name: UpdateRecipeStepIngredient :execrows
+UPDATE recipe_step_ingredients SET
+	name = sqlc.arg(name),
+	optional = sqlc.arg(optional),
+	ingredient_id = sqlc.arg(ingredient_id),
+	measurement_unit = sqlc.arg(measurement_unit),
+	minimum_quantity_value = sqlc.arg(minimum_quantity_value),
+	maximum_quantity_value = sqlc.arg(maximum_quantity_value),
+	quantity_notes = sqlc.arg(quantity_notes),
+	recipe_step_product_id = sqlc.arg(recipe_step_product_id),
+	ingredient_notes = sqlc.arg(ingredient_notes),
+	index = sqlc.arg(index),
+	option_index = sqlc.arg(option_index),
+	to_taste = sqlc.arg(to_taste),
+	product_percentage_to_use = sqlc.arg(product_percentage_to_use),
+	vessel_index = sqlc.arg(vessel_index),
+	scale_factor = sqlc.arg(scale_factor),
+	recipe_step_product_recipe_id = sqlc.arg(recipe_step_product_recipe_id),
+	last_updated_at = NOW()
+WHERE archived_at IS NULL
+	AND id = sqlc.arg(id)
+	AND belongs_to_recipe_step = sqlc.arg(belongs_to_recipe_step);
+
+-- name: ArchiveRecipeStepIngredient :execrows
+UPDATE recipe_step_ingredients SET
+	archived_at = NOW()
+WHERE archived_at IS NULL
+	AND id = sqlc.arg(id)
+	AND belongs_to_recipe_step = sqlc.arg(belongs_to_recipe_step);
 
 -- name: CheckRecipeStepIngredientExistence :one
 SELECT EXISTS (
@@ -362,26 +389,3 @@ WHERE recipe_step_ingredients.archived_at IS NULL
 	AND recipe_steps.id = sqlc.arg(recipe_step_id)
 	AND recipes.archived_at IS NULL
 	AND recipes.id = sqlc.arg(recipe_id);
-
--- name: UpdateRecipeStepIngredient :execrows
-UPDATE recipe_step_ingredients SET
-	name = sqlc.arg(name),
-	optional = sqlc.arg(optional),
-	ingredient_id = sqlc.arg(ingredient_id),
-	measurement_unit = sqlc.arg(measurement_unit),
-	minimum_quantity_value = sqlc.arg(minimum_quantity_value),
-	maximum_quantity_value = sqlc.arg(maximum_quantity_value),
-	quantity_notes = sqlc.arg(quantity_notes),
-	recipe_step_product_id = sqlc.arg(recipe_step_product_id),
-	ingredient_notes = sqlc.arg(ingredient_notes),
-	index = sqlc.arg(index),
-	option_index = sqlc.arg(option_index),
-	to_taste = sqlc.arg(to_taste),
-	product_percentage_to_use = sqlc.arg(product_percentage_to_use),
-	vessel_index = sqlc.arg(vessel_index),
-	scale_factor = sqlc.arg(scale_factor),
-	recipe_step_product_recipe_id = sqlc.arg(recipe_step_product_recipe_id),
-	last_updated_at = NOW()
-WHERE archived_at IS NULL
-	AND belongs_to_recipe_step = sqlc.arg(belongs_to_recipe_step)
-	AND id = sqlc.arg(id);

--- a/backend/internal/repositories/postgres/mealplanning/sqlc_queries/recipe_step_instruments.generated.sql
+++ b/backend/internal/repositories/postgres/mealplanning/sqlc_queries/recipe_step_instruments.generated.sql
@@ -1,6 +1,3 @@
--- name: ArchiveRecipeStepInstrument :execrows
-UPDATE recipe_step_instruments SET archived_at = NOW() WHERE archived_at IS NULL AND belongs_to_recipe_step = sqlc.arg(belongs_to_recipe_step) AND id = sqlc.arg(id);
-
 -- name: CreateRecipeStepInstrument :exec
 INSERT INTO recipe_step_instruments (
 	id,
@@ -31,6 +28,31 @@ INSERT INTO recipe_step_instruments (
 	sqlc.arg(scale_factor),
 	sqlc.arg(belongs_to_recipe_step)
 );
+
+-- name: UpdateRecipeStepInstrument :execrows
+UPDATE recipe_step_instruments SET
+	instrument_id = sqlc.arg(instrument_id),
+	recipe_step_product_id = sqlc.arg(recipe_step_product_id),
+	name = sqlc.arg(name),
+	notes = sqlc.arg(notes),
+	preference_rank = sqlc.arg(preference_rank),
+	optional = sqlc.arg(optional),
+	minimum_quantity = sqlc.arg(minimum_quantity),
+	maximum_quantity = sqlc.arg(maximum_quantity),
+	index = sqlc.arg(index),
+	option_index = sqlc.arg(option_index),
+	scale_factor = sqlc.arg(scale_factor),
+	last_updated_at = NOW()
+WHERE archived_at IS NULL
+	AND id = sqlc.arg(id)
+	AND belongs_to_recipe_step = sqlc.arg(belongs_to_recipe_step);
+
+-- name: ArchiveRecipeStepInstrument :execrows
+UPDATE recipe_step_instruments SET
+	archived_at = NOW()
+WHERE archived_at IS NULL
+	AND id = sqlc.arg(id)
+	AND belongs_to_recipe_step = sqlc.arg(belongs_to_recipe_step);
 
 -- name: CheckRecipeStepInstrumentExistence :one
 SELECT EXISTS (
@@ -208,21 +230,3 @@ WHERE
 	AND recipe_step_instruments.id > COALESCE(sqlc.narg(cursor), '')
 ORDER BY recipe_step_instruments.id ASC
 LIMIT COALESCE(sqlc.narg(result_limit), 50);
-
--- name: UpdateRecipeStepInstrument :execrows
-UPDATE recipe_step_instruments SET
-	instrument_id = sqlc.arg(instrument_id),
-	recipe_step_product_id = sqlc.arg(recipe_step_product_id),
-	name = sqlc.arg(name),
-	notes = sqlc.arg(notes),
-	preference_rank = sqlc.arg(preference_rank),
-	optional = sqlc.arg(optional),
-	minimum_quantity = sqlc.arg(minimum_quantity),
-	maximum_quantity = sqlc.arg(maximum_quantity),
-	index = sqlc.arg(index),
-	option_index = sqlc.arg(option_index),
-	scale_factor = sqlc.arg(scale_factor),
-	last_updated_at = NOW()
-WHERE archived_at IS NULL
-	AND belongs_to_recipe_step = sqlc.arg(belongs_to_recipe_step)
-	AND id = sqlc.arg(id);

--- a/backend/internal/repositories/postgres/mealplanning/sqlc_queries/recipe_step_products.generated.sql
+++ b/backend/internal/repositories/postgres/mealplanning/sqlc_queries/recipe_step_products.generated.sql
@@ -1,6 +1,3 @@
--- name: ArchiveRecipeStepProduct :execrows
-UPDATE recipe_step_products SET archived_at = NOW() WHERE archived_at IS NULL AND belongs_to_recipe_step = sqlc.arg(belongs_to_recipe_step) AND id = sqlc.arg(id);
-
 -- name: CreateRecipeStepProduct :exec
 INSERT INTO recipe_step_products (
 	id,
@@ -43,6 +40,37 @@ INSERT INTO recipe_step_products (
 	sqlc.arg(contained_in_vessel_index),
 	sqlc.arg(belongs_to_recipe_step)
 );
+
+-- name: UpdateRecipeStepProduct :execrows
+UPDATE recipe_step_products SET
+	name = sqlc.arg(name),
+	type = sqlc.arg(type),
+	measurement_unit = sqlc.arg(measurement_unit),
+	minimum_measurement_quantity_value = sqlc.arg(minimum_measurement_quantity_value),
+	maximum_measurement_quantity_value = sqlc.arg(maximum_measurement_quantity_value),
+	minimum_item_quantity_value = sqlc.arg(minimum_item_quantity_value),
+	maximum_item_quantity_value = sqlc.arg(maximum_item_quantity_value),
+	quantity_notes = sqlc.arg(quantity_notes),
+	compostable = sqlc.arg(compostable),
+	maximum_storage_duration_in_seconds = sqlc.arg(maximum_storage_duration_in_seconds),
+	minimum_storage_temperature_in_celsius = sqlc.arg(minimum_storage_temperature_in_celsius),
+	maximum_storage_temperature_in_celsius = sqlc.arg(maximum_storage_temperature_in_celsius),
+	storage_instructions = sqlc.arg(storage_instructions),
+	is_liquid = sqlc.arg(is_liquid),
+	is_waste = sqlc.arg(is_waste),
+	index = sqlc.arg(index),
+	contained_in_vessel_index = sqlc.arg(contained_in_vessel_index),
+	last_updated_at = NOW()
+WHERE archived_at IS NULL
+	AND id = sqlc.arg(id)
+	AND belongs_to_recipe_step = sqlc.arg(belongs_to_recipe_step);
+
+-- name: ArchiveRecipeStepProduct :execrows
+UPDATE recipe_step_products SET
+	archived_at = NOW()
+WHERE archived_at IS NULL
+	AND id = sqlc.arg(id)
+	AND belongs_to_recipe_step = sqlc.arg(belongs_to_recipe_step);
 
 -- name: CheckRecipeStepProductExistence :one
 SELECT EXISTS (
@@ -165,7 +193,7 @@ SELECT
 		SELECT COUNT(recipe_step_products.id)
 		FROM recipe_step_products
 		WHERE recipe_step_products.archived_at IS NULL
-			AND recipe_step_products.belongs_to_recipe_step = sqlc.arg(recipe_step_id)
+				AND recipe_step_products.belongs_to_recipe_step = sqlc.arg(recipe_step_id)
 	) AS total_count
 FROM recipe_step_products
 	JOIN recipe_steps ON recipe_step_products.belongs_to_recipe_step=recipe_steps.id
@@ -242,27 +270,3 @@ WHERE recipe_step_products.archived_at IS NULL
 	AND recipe_steps.id = sqlc.arg(recipe_step_id)
 	AND recipes.archived_at IS NULL
 	AND recipes.id = sqlc.arg(recipe_id);
-
--- name: UpdateRecipeStepProduct :execrows
-UPDATE recipe_step_products SET
-	name = sqlc.arg(name),
-	type = sqlc.arg(type),
-	measurement_unit = sqlc.arg(measurement_unit),
-	minimum_measurement_quantity_value = sqlc.arg(minimum_measurement_quantity_value),
-	maximum_measurement_quantity_value = sqlc.arg(maximum_measurement_quantity_value),
-	minimum_item_quantity_value = sqlc.arg(minimum_item_quantity_value),
-	maximum_item_quantity_value = sqlc.arg(maximum_item_quantity_value),
-	quantity_notes = sqlc.arg(quantity_notes),
-	compostable = sqlc.arg(compostable),
-	maximum_storage_duration_in_seconds = sqlc.arg(maximum_storage_duration_in_seconds),
-	minimum_storage_temperature_in_celsius = sqlc.arg(minimum_storage_temperature_in_celsius),
-	maximum_storage_temperature_in_celsius = sqlc.arg(maximum_storage_temperature_in_celsius),
-	storage_instructions = sqlc.arg(storage_instructions),
-	is_liquid = sqlc.arg(is_liquid),
-	is_waste = sqlc.arg(is_waste),
-	index = sqlc.arg(index),
-	contained_in_vessel_index = sqlc.arg(contained_in_vessel_index),
-	last_updated_at = NOW()
-WHERE archived_at IS NULL
-	AND belongs_to_recipe_step = sqlc.arg(belongs_to_recipe_step)
-	AND id = sqlc.arg(id);

--- a/backend/internal/repositories/postgres/mealplanning/sqlc_queries/recipe_step_vessels.generated.sql
+++ b/backend/internal/repositories/postgres/mealplanning/sqlc_queries/recipe_step_vessels.generated.sql
@@ -1,6 +1,3 @@
--- name: ArchiveRecipeStepVessel :execrows
-UPDATE recipe_step_vessels SET archived_at = NOW() WHERE archived_at IS NULL AND belongs_to_recipe_step = sqlc.arg(belongs_to_recipe_step) AND id = sqlc.arg(id);
-
 -- name: CreateRecipeStepVessel :exec
 INSERT INTO recipe_step_vessels (
 	id,
@@ -31,6 +28,13 @@ INSERT INTO recipe_step_vessels (
 	sqlc.arg(option_index),
 	sqlc.arg(scale_factor)
 );
+
+-- name: ArchiveRecipeStepVessel :execrows
+UPDATE recipe_step_vessels SET
+	archived_at = NOW()
+WHERE archived_at IS NULL
+	AND id = sqlc.arg(id)
+	AND belongs_to_recipe_step = sqlc.arg(belongs_to_recipe_step);
 
 -- name: CheckRecipeStepVesselExistence :one
 SELECT EXISTS (

--- a/backend/internal/repositories/postgres/mealplanning/sqlc_queries/recipe_steps.generated.sql
+++ b/backend/internal/repositories/postgres/mealplanning/sqlc_queries/recipe_steps.generated.sql
@@ -1,6 +1,3 @@
--- name: ArchiveRecipeStep :execrows
-UPDATE recipe_steps SET archived_at = NOW() WHERE archived_at IS NULL AND belongs_to_recipe = sqlc.arg(belongs_to_recipe) AND id = sqlc.arg(id);
-
 -- name: CreateRecipeStep :exec
 INSERT INTO recipe_steps (
 	id,
@@ -31,6 +28,31 @@ INSERT INTO recipe_steps (
 	sqlc.arg(start_timer_automatically),
 	sqlc.arg(belongs_to_recipe)
 );
+
+-- name: UpdateRecipeStep :execrows
+UPDATE recipe_steps SET
+	index = sqlc.arg(index),
+	preparation_id = sqlc.arg(preparation_id),
+	minimum_estimated_time_in_seconds = sqlc.arg(minimum_estimated_time_in_seconds),
+	maximum_estimated_time_in_seconds = sqlc.arg(maximum_estimated_time_in_seconds),
+	minimum_temperature_in_celsius = sqlc.arg(minimum_temperature_in_celsius),
+	maximum_temperature_in_celsius = sqlc.arg(maximum_temperature_in_celsius),
+	notes = sqlc.arg(notes),
+	explicit_instructions = sqlc.arg(explicit_instructions),
+	condition_expression = sqlc.arg(condition_expression),
+	optional = sqlc.arg(optional),
+	start_timer_automatically = sqlc.arg(start_timer_automatically),
+	last_updated_at = NOW()
+WHERE archived_at IS NULL
+	AND id = sqlc.arg(id)
+	AND belongs_to_recipe = sqlc.arg(belongs_to_recipe);
+
+-- name: ArchiveRecipeStep :execrows
+UPDATE recipe_steps SET
+	archived_at = NOW()
+WHERE archived_at IS NULL
+	AND id = sqlc.arg(id)
+	AND belongs_to_recipe = sqlc.arg(belongs_to_recipe);
 
 -- name: CheckRecipeStepExistence :one
 SELECT EXISTS (
@@ -220,21 +242,3 @@ FROM recipe_steps
 	JOIN valid_preparations ON recipe_steps.preparation_id=valid_preparations.id
 WHERE recipe_steps.archived_at IS NULL
 	AND recipe_steps.id = sqlc.arg(id);
-
--- name: UpdateRecipeStep :execrows
-UPDATE recipe_steps SET
-	index = sqlc.arg(index),
-	preparation_id = sqlc.arg(preparation_id),
-	minimum_estimated_time_in_seconds = sqlc.arg(minimum_estimated_time_in_seconds),
-	maximum_estimated_time_in_seconds = sqlc.arg(maximum_estimated_time_in_seconds),
-	minimum_temperature_in_celsius = sqlc.arg(minimum_temperature_in_celsius),
-	maximum_temperature_in_celsius = sqlc.arg(maximum_temperature_in_celsius),
-	notes = sqlc.arg(notes),
-	explicit_instructions = sqlc.arg(explicit_instructions),
-	condition_expression = sqlc.arg(condition_expression),
-	optional = sqlc.arg(optional),
-	start_timer_automatically = sqlc.arg(start_timer_automatically),
-	last_updated_at = NOW()
-WHERE archived_at IS NULL
-	AND belongs_to_recipe = sqlc.arg(belongs_to_recipe)
-	AND id = sqlc.arg(id);

--- a/backend/internal/repositories/postgres/mealplanning/sqlc_queries/recipes.generated.sql
+++ b/backend/internal/repositories/postgres/mealplanning/sqlc_queries/recipes.generated.sql
@@ -1,6 +1,3 @@
--- name: ArchiveRecipe :execrows
-UPDATE recipes SET archived_at = NOW() WHERE archived_at IS NULL AND created_by_user = sqlc.arg(created_by_user) AND id = sqlc.arg(id);
-
 -- name: CreateRecipe :exec
 INSERT INTO recipes (
 	id,
@@ -43,6 +40,24 @@ SELECT EXISTS (
 	WHERE recipes.archived_at IS NULL
 		AND recipes.id = sqlc.arg(id)
 );
+
+-- name: UpdateRecipeStatus :execrows
+UPDATE recipes SET
+	status = sqlc.arg(status),
+	last_updated_at = NOW()
+WHERE archived_at IS NULL
+	AND id = sqlc.arg(id);
+
+-- name: ScanRecipeIDsForReindex :many
+SELECT recipes.id
+FROM recipes
+WHERE recipes.archived_at IS NULL
+	AND recipes.id COLLATE "C" > sqlc.arg(cursor)
+ORDER BY recipes.id COLLATE "C"
+LIMIT COALESCE(sqlc.narg(result_limit), 50);
+
+-- name: ArchiveRecipe :execrows
+UPDATE recipes SET archived_at = NOW() WHERE archived_at IS NULL AND created_by_user = sqlc.arg(created_by_user) AND id = sqlc.arg(id);
 
 -- name: GetRecipeByID :many
 SELECT
@@ -557,24 +572,16 @@ WHERE recipes.archived_at IS NULL
 		SELECT 1 FROM recipe_step_instruments rsi
 		JOIN recipe_steps rs ON rsi.belongs_to_recipe_step = rs.id
 		WHERE rs.belongs_to_recipe = recipes.id
-			AND rsi.archived_at IS NULL
-			AND rs.archived_at IS NULL
-			AND rsi.optional = false
-			AND rsi.instrument_id IS NOT NULL
-			AND rsi.instrument_id NOT IN (
-				SELECT valid_instrument_id FROM account_instrument_ownerships
-				WHERE belongs_to_account = sqlc.arg(account_id) AND archived_at IS NULL
-			)
+				AND rsi.archived_at IS NULL
+				AND rs.archived_at IS NULL
+				AND rsi.optional = false
+				AND rsi.instrument_id IS NOT NULL
+				AND rsi.instrument_id NOT IN (
+					SELECT valid_instrument_id FROM account_instrument_ownerships
+					WHERE belongs_to_account = sqlc.arg(account_id) AND archived_at IS NULL
+				)
 	)
 ORDER BY recipes.id ASC
-LIMIT COALESCE(sqlc.narg(result_limit), 50);
-
--- name: ScanRecipeIDsForReindex :many
-SELECT recipes.id
-FROM recipes
-WHERE recipes.archived_at IS NULL
-	AND recipes.id COLLATE "C" > sqlc.arg(cursor)
-ORDER BY recipes.id COLLATE "C"
 LIMIT COALESCE(sqlc.narg(result_limit), 50);
 
 -- name: GetRecipesNeedingIndexing :many
@@ -614,13 +621,6 @@ UPDATE recipes SET
 	last_updated_at = NOW()
 WHERE archived_at IS NULL
 	AND created_by_user = sqlc.arg(created_by_user)
-	AND id = sqlc.arg(id);
-
--- name: UpdateRecipeStatus :execrows
-UPDATE recipes SET
-	status = sqlc.arg(status),
-	last_updated_at = NOW()
-WHERE archived_at IS NULL
 	AND id = sqlc.arg(id);
 
 -- name: MarkRecipesAsIndexed :execrows

--- a/backend/internal/repositories/postgres/mealplanning/sqlc_queries/user_ingredient_preferences.generated.sql
+++ b/backend/internal/repositories/postgres/mealplanning/sqlc_queries/user_ingredient_preferences.generated.sql
@@ -1,6 +1,3 @@
--- name: ArchiveUserIngredientPreference :execrows
-UPDATE user_ingredient_preferences SET archived_at = NOW() WHERE archived_at IS NULL AND belongs_to_user = sqlc.arg(belongs_to_user) AND id = sqlc.arg(id);
-
 -- name: CreateUserIngredientPreference :exec
 INSERT INTO user_ingredient_preferences (
 	id,
@@ -26,6 +23,24 @@ SELECT EXISTS (
 		AND user_ingredient_preferences.id = sqlc.arg(id)
 		AND user_ingredient_preferences.belongs_to_user = sqlc.arg(belongs_to_user)
 );
+
+-- name: UpdateUserIngredientPreference :execrows
+UPDATE user_ingredient_preferences SET
+	ingredient = sqlc.arg(ingredient),
+	rating = sqlc.arg(rating),
+	notes = sqlc.arg(notes),
+	allergy = sqlc.arg(allergy),
+	last_updated_at = NOW()
+WHERE archived_at IS NULL
+	AND id = sqlc.arg(id)
+	AND belongs_to_user = sqlc.arg(belongs_to_user);
+
+-- name: ArchiveUserIngredientPreference :execrows
+UPDATE user_ingredient_preferences SET
+	archived_at = NOW()
+WHERE archived_at IS NULL
+	AND id = sqlc.arg(id)
+	AND belongs_to_user = sqlc.arg(belongs_to_user);
 
 -- name: GetUserIngredientPreferencesForUser :many
 SELECT
@@ -172,14 +187,3 @@ WHERE user_ingredient_preferences.archived_at IS NULL
 	AND valid_ingredients.archived_at IS NULL
 	AND user_ingredient_preferences.id = sqlc.arg(id)
 	AND user_ingredient_preferences.belongs_to_user = sqlc.arg(belongs_to_user);
-
--- name: UpdateUserIngredientPreference :execrows
-UPDATE user_ingredient_preferences SET
-	ingredient = sqlc.arg(ingredient),
-	rating = sqlc.arg(rating),
-	notes = sqlc.arg(notes),
-	allergy = sqlc.arg(allergy),
-	last_updated_at = NOW()
-WHERE archived_at IS NULL
-	AND belongs_to_user = sqlc.arg(belongs_to_user)
-	AND id = sqlc.arg(id);

--- a/backend/internal/repositories/postgres/mealplanning/sqlc_queries/valid_ingredient_groups.generated.sql
+++ b/backend/internal/repositories/postgres/mealplanning/sqlc_queries/valid_ingredient_groups.generated.sql
@@ -47,13 +47,6 @@ UPDATE valid_ingredient_groups SET
 WHERE archived_at IS NULL
 	AND id = sqlc.arg(id);
 
--- name: ArchiveValidIngredientGroupMember :execrows
-UPDATE valid_ingredient_group_members SET
-	archived_at = NOW()
-WHERE archived_at IS NULL
-	AND id = sqlc.arg(id)
-	AND belongs_to_group = sqlc.arg(belongs_to_group);
-
 -- name: CreateValidIngredientGroupMember :exec
 INSERT INTO valid_ingredient_group_members (
 	id,
@@ -64,6 +57,13 @@ INSERT INTO valid_ingredient_group_members (
 	sqlc.arg(belongs_to_group),
 	sqlc.arg(valid_ingredient)
 );
+
+-- name: ArchiveValidIngredientGroupMember :execrows
+UPDATE valid_ingredient_group_members SET
+	archived_at = NOW()
+WHERE archived_at IS NULL
+	AND id = sqlc.arg(id)
+	AND belongs_to_group = sqlc.arg(belongs_to_group);
 
 -- name: GetValidIngredientGroups :many
 SELECT

--- a/backend/internal/repositories/postgres/mealplanning/sqlc_queries/valid_ingredient_measurement_units.generated.sql
+++ b/backend/internal/repositories/postgres/mealplanning/sqlc_queries/valid_ingredient_measurement_units.generated.sql
@@ -1,6 +1,3 @@
--- name: ArchiveValidIngredientMeasurementUnit :execrows
-UPDATE valid_ingredient_measurement_units SET archived_at = NOW() WHERE archived_at IS NULL AND id = sqlc.arg(id);
-
 -- name: CreateValidIngredientMeasurementUnit :exec
 INSERT INTO valid_ingredient_measurement_units (
 	id,
@@ -25,6 +22,23 @@ SELECT EXISTS (
 	WHERE valid_ingredient_measurement_units.archived_at IS NULL
 		AND valid_ingredient_measurement_units.id = sqlc.arg(id)
 );
+
+-- name: UpdateValidIngredientMeasurementUnit :execrows
+UPDATE valid_ingredient_measurement_units SET
+	notes = sqlc.arg(notes),
+	valid_measurement_unit_id = sqlc.arg(valid_measurement_unit_id),
+	valid_ingredient_id = sqlc.arg(valid_ingredient_id),
+	minimum_allowable_quantity = sqlc.arg(minimum_allowable_quantity),
+	maximum_allowable_quantity = sqlc.arg(maximum_allowable_quantity),
+	last_updated_at = NOW()
+WHERE archived_at IS NULL
+	AND id = sqlc.arg(id);
+
+-- name: ArchiveValidIngredientMeasurementUnit :execrows
+UPDATE valid_ingredient_measurement_units SET
+	archived_at = NOW()
+WHERE archived_at IS NULL
+	AND id = sqlc.arg(id);
 
 -- name: GetValidIngredientMeasurementUnitsForIngredient :many
 SELECT
@@ -493,14 +507,3 @@ SELECT EXISTS(
 	AND valid_ingredient_id = sqlc.arg(valid_ingredient_id)
 	AND archived_at IS NULL
 );
-
--- name: UpdateValidIngredientMeasurementUnit :execrows
-UPDATE valid_ingredient_measurement_units SET
-	notes = sqlc.arg(notes),
-	valid_measurement_unit_id = sqlc.arg(valid_measurement_unit_id),
-	valid_ingredient_id = sqlc.arg(valid_ingredient_id),
-	minimum_allowable_quantity = sqlc.arg(minimum_allowable_quantity),
-	maximum_allowable_quantity = sqlc.arg(maximum_allowable_quantity),
-	last_updated_at = NOW()
-WHERE archived_at IS NULL
-	AND id = sqlc.arg(id);

--- a/backend/internal/repositories/postgres/mealplanning/sqlc_queries/valid_ingredient_preparations.generated.sql
+++ b/backend/internal/repositories/postgres/mealplanning/sqlc_queries/valid_ingredient_preparations.generated.sql
@@ -1,6 +1,3 @@
--- name: ArchiveValidIngredientPreparation :execrows
-UPDATE valid_ingredient_preparations SET archived_at = NOW() WHERE archived_at IS NULL AND id = sqlc.arg(id);
-
 -- name: CreateValidIngredientPreparation :exec
 INSERT INTO valid_ingredient_preparations (
 	id,
@@ -21,6 +18,21 @@ SELECT EXISTS (
 	WHERE valid_ingredient_preparations.archived_at IS NULL
 		AND valid_ingredient_preparations.id = sqlc.arg(id)
 );
+
+-- name: UpdateValidIngredientPreparation :execrows
+UPDATE valid_ingredient_preparations SET
+	notes = sqlc.arg(notes),
+	valid_preparation_id = sqlc.arg(valid_preparation_id),
+	valid_ingredient_id = sqlc.arg(valid_ingredient_id),
+	last_updated_at = NOW()
+WHERE archived_at IS NULL
+	AND id = sqlc.arg(id);
+
+-- name: ArchiveValidIngredientPreparation :execrows
+UPDATE valid_ingredient_preparations SET
+	archived_at = NOW()
+WHERE archived_at IS NULL
+	AND id = sqlc.arg(id);
 
 -- name: GetValidIngredientPreparationsForIngredient :many
 SELECT
@@ -636,12 +648,3 @@ WHERE
 	AND valid_ingredient_preparations.id > COALESCE(sqlc.narg(cursor), '')
 ORDER BY valid_ingredient_preparations.id ASC
 LIMIT COALESCE(sqlc.narg(result_limit), 50);
-
--- name: UpdateValidIngredientPreparation :execrows
-UPDATE valid_ingredient_preparations SET
-	notes = sqlc.arg(notes),
-	valid_preparation_id = sqlc.arg(valid_preparation_id),
-	valid_ingredient_id = sqlc.arg(valid_ingredient_id),
-	last_updated_at = NOW()
-WHERE archived_at IS NULL
-	AND id = sqlc.arg(id);

--- a/backend/internal/repositories/postgres/mealplanning/sqlc_queries/valid_ingredient_state_ingredients.generated.sql
+++ b/backend/internal/repositories/postgres/mealplanning/sqlc_queries/valid_ingredient_state_ingredients.generated.sql
@@ -1,6 +1,3 @@
--- name: ArchiveValidIngredientStateIngredient :execrows
-UPDATE valid_ingredient_state_ingredients SET archived_at = NOW() WHERE archived_at IS NULL AND id = sqlc.arg(id);
-
 -- name: CreateValidIngredientStateIngredient :exec
 INSERT INTO valid_ingredient_state_ingredients (
 	id,
@@ -21,6 +18,21 @@ SELECT EXISTS (
 	WHERE valid_ingredient_state_ingredients.archived_at IS NULL
 		AND valid_ingredient_state_ingredients.id = sqlc.arg(id)
 );
+
+-- name: UpdateValidIngredientStateIngredient :execrows
+UPDATE valid_ingredient_state_ingredients SET
+	notes = sqlc.arg(notes),
+	valid_ingredient_state = sqlc.arg(valid_ingredient_state),
+	valid_ingredient = sqlc.arg(valid_ingredient),
+	last_updated_at = NOW()
+WHERE archived_at IS NULL
+	AND id = sqlc.arg(id);
+
+-- name: ArchiveValidIngredientStateIngredient :execrows
+UPDATE valid_ingredient_state_ingredients SET
+	archived_at = NOW()
+WHERE archived_at IS NULL
+	AND id = sqlc.arg(id);
 
 -- name: GetValidIngredientStateIngredientsForIngredient :many
 SELECT
@@ -474,12 +486,3 @@ SELECT EXISTS(
 	AND valid_ingredient_state = sqlc.arg(valid_ingredient_state)
 	AND archived_at IS NULL
 );
-
--- name: UpdateValidIngredientStateIngredient :execrows
-UPDATE valid_ingredient_state_ingredients SET
-	notes = sqlc.arg(notes),
-	valid_ingredient_state = sqlc.arg(valid_ingredient_state),
-	valid_ingredient = sqlc.arg(valid_ingredient),
-	last_updated_at = NOW()
-WHERE archived_at IS NULL
-	AND id = sqlc.arg(id);

--- a/backend/internal/repositories/postgres/mealplanning/sqlc_queries/valid_measurement_unit_conversions.generated.sql
+++ b/backend/internal/repositories/postgres/mealplanning/sqlc_queries/valid_measurement_unit_conversions.generated.sql
@@ -1,6 +1,3 @@
--- name: ArchiveValidMeasurementUnitConversion :execrows
-UPDATE valid_measurement_unit_conversions SET archived_at = NOW() WHERE archived_at IS NULL AND id = sqlc.arg(id);
-
 -- name: CreateValidMeasurementUnitConversion :exec
 INSERT INTO valid_measurement_unit_conversions (
 	id,
@@ -25,6 +22,23 @@ SELECT EXISTS (
 	WHERE valid_measurement_unit_conversions.archived_at IS NULL
 		AND valid_measurement_unit_conversions.id = sqlc.arg(id)
 );
+
+-- name: UpdateValidMeasurementUnitConversion :execrows
+UPDATE valid_measurement_unit_conversions SET
+	from_unit = sqlc.arg(from_unit),
+	to_unit = sqlc.arg(to_unit),
+	only_for_ingredient = sqlc.arg(only_for_ingredient),
+	modifier = sqlc.arg(modifier),
+	notes = sqlc.arg(notes),
+	last_updated_at = NOW()
+WHERE archived_at IS NULL
+	AND id = sqlc.arg(id);
+
+-- name: ArchiveValidMeasurementUnitConversion :execrows
+UPDATE valid_measurement_unit_conversions SET
+	archived_at = NOW()
+WHERE archived_at IS NULL
+	AND id = sqlc.arg(id);
 
 -- name: GetValidMeasurementUnitConversionsForMeasurementUnit :many
 SELECT
@@ -337,17 +351,6 @@ WHERE
 	AND valid_measurement_unit_conversions.archived_at IS NULL
 	AND valid_measurement_units_from.archived_at IS NULL
 	AND valid_measurement_units_to.archived_at IS NULL;
-
--- name: UpdateValidMeasurementUnitConversion :execrows
-UPDATE valid_measurement_unit_conversions SET
-	from_unit = sqlc.arg(from_unit),
-	to_unit = sqlc.arg(to_unit),
-	only_for_ingredient = sqlc.arg(only_for_ingredient),
-	modifier = sqlc.arg(modifier),
-	notes = sqlc.arg(notes),
-	last_updated_at = NOW()
-WHERE archived_at IS NULL
-	AND id = sqlc.arg(id);
 
 -- name: GetMeasurementUnitConversionMismatches :many
 WITH ingredient_units AS (

--- a/backend/internal/repositories/postgres/mealplanning/sqlc_queries/valid_prep_task_configs.generated.sql
+++ b/backend/internal/repositories/postgres/mealplanning/sqlc_queries/valid_prep_task_configs.generated.sql
@@ -1,6 +1,3 @@
--- name: ArchiveValidPrepTaskConfig :execrows
-UPDATE valid_prep_task_configs SET archived_at = NOW() WHERE archived_at IS NULL AND id = sqlc.arg(id);
-
 -- name: CreateValidPrepTaskConfig :exec
 INSERT INTO valid_prep_task_configs (
 	id,
@@ -35,6 +32,28 @@ SELECT EXISTS (
 	WHERE valid_prep_task_configs.archived_at IS NULL
 		AND valid_prep_task_configs.id = sqlc.arg(id)
 );
+
+-- name: UpdateValidPrepTaskConfig :execrows
+UPDATE valid_prep_task_configs SET
+	valid_ingredient_id = sqlc.arg(valid_ingredient_id),
+	valid_preparation_id = sqlc.arg(valid_preparation_id),
+	minimum_storage_duration_in_seconds = sqlc.arg(minimum_storage_duration_in_seconds),
+	maximum_storage_duration_in_seconds = sqlc.narg(maximum_storage_duration_in_seconds),
+	storage_container_type = sqlc.arg(storage_container_type),
+	minimum_storage_temperature_in_celsius = sqlc.narg(minimum_storage_temperature_in_celsius),
+	maximum_storage_temperature_in_celsius = sqlc.narg(maximum_storage_temperature_in_celsius),
+	storage_instructions = sqlc.arg(storage_instructions),
+	notes = sqlc.arg(notes),
+	source = sqlc.arg(source),
+	last_updated_at = NOW()
+WHERE archived_at IS NULL
+	AND id = sqlc.arg(id);
+
+-- name: ArchiveValidPrepTaskConfig :execrows
+UPDATE valid_prep_task_configs SET
+	archived_at = NOW()
+WHERE archived_at IS NULL
+	AND id = sqlc.arg(id);
 
 -- name: GetValidPrepTaskConfigsForIngredient :many
 SELECT
@@ -592,19 +611,3 @@ WHERE
 	AND valid_ingredients.archived_at IS NULL
 	AND valid_preparations.archived_at IS NULL
 	AND valid_prep_task_configs.id = sqlc.arg(id);
-
--- name: UpdateValidPrepTaskConfig :execrows
-UPDATE valid_prep_task_configs SET
-	valid_ingredient_id = sqlc.arg(valid_ingredient_id),
-	valid_preparation_id = sqlc.arg(valid_preparation_id),
-	minimum_storage_duration_in_seconds = sqlc.arg(minimum_storage_duration_in_seconds),
-	maximum_storage_duration_in_seconds = sqlc.narg(maximum_storage_duration_in_seconds),
-	storage_container_type = sqlc.arg(storage_container_type),
-	minimum_storage_temperature_in_celsius = sqlc.narg(minimum_storage_temperature_in_celsius),
-	maximum_storage_temperature_in_celsius = sqlc.narg(maximum_storage_temperature_in_celsius),
-	storage_instructions = sqlc.arg(storage_instructions),
-	notes = sqlc.arg(notes),
-	source = sqlc.arg(source),
-	last_updated_at = NOW()
-WHERE archived_at IS NULL
-	AND id = sqlc.arg(id);

--- a/backend/internal/repositories/postgres/mealplanning/sqlc_queries/valid_preparation_instruments.generated.sql
+++ b/backend/internal/repositories/postgres/mealplanning/sqlc_queries/valid_preparation_instruments.generated.sql
@@ -1,6 +1,3 @@
--- name: ArchiveValidPreparationInstrument :execrows
-UPDATE valid_preparation_instruments SET archived_at = NOW() WHERE archived_at IS NULL AND id = sqlc.arg(id);
-
 -- name: CreateValidPreparationInstrument :exec
 INSERT INTO valid_preparation_instruments (
 	id,
@@ -21,6 +18,21 @@ SELECT EXISTS (
 	WHERE valid_preparation_instruments.archived_at IS NULL
 		AND valid_preparation_instruments.id = sqlc.arg(id)
 );
+
+-- name: UpdateValidPreparationInstrument :execrows
+UPDATE valid_preparation_instruments SET
+	notes = sqlc.arg(notes),
+	valid_preparation_id = sqlc.arg(valid_preparation_id),
+	valid_instrument_id = sqlc.arg(valid_instrument_id),
+	last_updated_at = NOW()
+WHERE archived_at IS NULL
+	AND id = sqlc.arg(id);
+
+-- name: ArchiveValidPreparationInstrument :execrows
+UPDATE valid_preparation_instruments SET
+	archived_at = NOW()
+WHERE archived_at IS NULL
+	AND id = sqlc.arg(id);
 
 -- name: GetValidPreparationInstrumentsForInstrument :many
 SELECT
@@ -439,12 +451,3 @@ SELECT EXISTS(
 	AND valid_preparation_id = sqlc.arg(valid_preparation_id)
 	AND archived_at IS NULL
 );
-
--- name: UpdateValidPreparationInstrument :execrows
-UPDATE valid_preparation_instruments SET
-	notes = sqlc.arg(notes),
-	valid_preparation_id = sqlc.arg(valid_preparation_id),
-	valid_instrument_id = sqlc.arg(valid_instrument_id),
-	last_updated_at = NOW()
-WHERE archived_at IS NULL
-	AND id = sqlc.arg(id);

--- a/backend/internal/repositories/postgres/mealplanning/sqlc_queries/valid_preparation_vessels.generated.sql
+++ b/backend/internal/repositories/postgres/mealplanning/sqlc_queries/valid_preparation_vessels.generated.sql
@@ -1,6 +1,3 @@
--- name: ArchiveValidPreparationVessel :execrows
-UPDATE valid_preparation_vessels SET archived_at = NOW() WHERE archived_at IS NULL AND id = sqlc.arg(id);
-
 -- name: CreateValidPreparationVessel :exec
 INSERT INTO valid_preparation_vessels (
 	id,
@@ -21,6 +18,21 @@ SELECT EXISTS (
 	WHERE valid_preparation_vessels.archived_at IS NULL
 		AND valid_preparation_vessels.id = sqlc.arg(id)
 );
+
+-- name: UpdateValidPreparationVessel :execrows
+UPDATE valid_preparation_vessels SET
+	notes = sqlc.arg(notes),
+	valid_preparation_id = sqlc.arg(valid_preparation_id),
+	valid_vessel_id = sqlc.arg(valid_vessel_id),
+	last_updated_at = NOW()
+WHERE archived_at IS NULL
+	AND id = sqlc.arg(id);
+
+-- name: ArchiveValidPreparationVessel :execrows
+UPDATE valid_preparation_vessels SET
+	archived_at = NOW()
+WHERE archived_at IS NULL
+	AND id = sqlc.arg(id);
 
 -- name: GetValidPreparationVesselsForPreparation :many
 SELECT
@@ -499,12 +511,3 @@ SELECT EXISTS(
 	AND valid_preparation_id = sqlc.arg(valid_preparation_id)
 	AND archived_at IS NULL
 );
-
--- name: UpdateValidPreparationVessel :execrows
-UPDATE valid_preparation_vessels SET
-	notes = sqlc.arg(notes),
-	valid_preparation_id = sqlc.arg(valid_preparation_id),
-	valid_vessel_id = sqlc.arg(valid_vessel_id),
-	last_updated_at = NOW()
-WHERE archived_at IS NULL
-	AND id = sqlc.arg(id);

--- a/backend/internal/repositories/postgres/oauth/generated/oauth2_clients.generated.sql_generated.go
+++ b/backend/internal/repositories/postgres/oauth/generated/oauth2_clients.generated.sql_generated.go
@@ -132,7 +132,7 @@ SELECT
 		SELECT COUNT(oauth2_clients.id)
 		FROM oauth2_clients
 		WHERE oauth2_clients.archived_at IS NULL
-			AND oauth2_clients.created_at > COALESCE($1, (SELECT NOW() - '999 years'::INTERVAL))
+				AND oauth2_clients.created_at > COALESCE($1, (SELECT NOW() - '999 years'::INTERVAL))
 			AND oauth2_clients.created_at < COALESCE($2, (SELECT NOW() + '999 years'::INTERVAL))
 					AND (NOT COALESCE($3, false)::boolean OR oauth2_clients.archived_at IS NULL)
 			AND oauth2_clients.id > COALESCE($4, '')

--- a/backend/internal/repositories/postgres/oauth/sqlc_queries/oauth2_clients.generated.sql
+++ b/backend/internal/repositories/postgres/oauth/sqlc_queries/oauth2_clients.generated.sql
@@ -1,9 +1,3 @@
--- name: ArchiveOAuth2Client :execrows
-UPDATE oauth2_clients SET
-	archived_at = NOW()
-WHERE archived_at IS NULL
-	AND id = sqlc.arg(id);
-
 -- name: CreateOAuth2Client :exec
 INSERT INTO oauth2_clients (
 	id,
@@ -19,19 +13,6 @@ INSERT INTO oauth2_clients (
 	sqlc.arg(client_secret)
 );
 
--- name: GetOAuth2ClientByClientID :one
-SELECT
-	oauth2_clients.id,
-	oauth2_clients.name,
-	oauth2_clients.description,
-	oauth2_clients.client_id,
-	oauth2_clients.client_secret,
-	oauth2_clients.created_at,
-	oauth2_clients.archived_at
-FROM oauth2_clients
-WHERE oauth2_clients.archived_at IS NULL
-	AND oauth2_clients.client_id = sqlc.arg(client_id);
-
 -- name: GetOAuth2ClientByDatabaseID :one
 SELECT
 	oauth2_clients.id,
@@ -44,6 +25,25 @@ SELECT
 FROM oauth2_clients
 WHERE oauth2_clients.archived_at IS NULL
 	AND oauth2_clients.id = sqlc.arg(id);
+
+-- name: ArchiveOAuth2Client :execrows
+UPDATE oauth2_clients SET
+	archived_at = NOW()
+WHERE archived_at IS NULL
+	AND id = sqlc.arg(id);
+
+-- name: GetOAuth2ClientByClientID :one
+SELECT
+	oauth2_clients.id,
+	oauth2_clients.name,
+	oauth2_clients.description,
+	oauth2_clients.client_id,
+	oauth2_clients.client_secret,
+	oauth2_clients.created_at,
+	oauth2_clients.archived_at
+FROM oauth2_clients
+WHERE oauth2_clients.archived_at IS NULL
+	AND oauth2_clients.client_id = sqlc.arg(client_id);
 
 -- name: GetOAuth2Clients :many
 SELECT
@@ -58,7 +58,7 @@ SELECT
 		SELECT COUNT(oauth2_clients.id)
 		FROM oauth2_clients
 		WHERE oauth2_clients.archived_at IS NULL
-			AND oauth2_clients.created_at > COALESCE(sqlc.narg(created_after), (SELECT NOW() - '999 years'::INTERVAL))
+				AND oauth2_clients.created_at > COALESCE(sqlc.narg(created_after), (SELECT NOW() - '999 years'::INTERVAL))
 			AND oauth2_clients.created_at < COALESCE(sqlc.narg(created_before), (SELECT NOW() + '999 years'::INTERVAL))
 					AND (NOT COALESCE(sqlc.narg(include_archived), false)::boolean OR oauth2_clients.archived_at IS NULL)
 			AND oauth2_clients.id > COALESCE(sqlc.narg(cursor), '')

--- a/backend/internal/repositories/postgres/payments/generated/products.generated.sql_generated.go
+++ b/backend/internal/repositories/postgres/payments/generated/products.generated.sql_generated.go
@@ -28,7 +28,7 @@ SELECT EXISTS (
 	SELECT products.id
 	FROM products
 	WHERE products.archived_at IS NULL
-	AND products.id = $1
+		AND products.id = $1
 )
 `
 
@@ -101,7 +101,7 @@ SELECT
 	products.archived_at
 FROM products
 WHERE products.archived_at IS NULL
-AND products.id = $1
+	AND products.id = $1
 `
 
 func (q *Queries) GetProduct(ctx context.Context, db DBTX, id string) (*Products, error) {

--- a/backend/internal/repositories/postgres/payments/generated/purchases.generated.sql_generated.go
+++ b/backend/internal/repositories/postgres/payments/generated/purchases.generated.sql_generated.go
@@ -68,7 +68,7 @@ SELECT
 	purchases.archived_at
 FROM purchases
 WHERE purchases.archived_at IS NULL
-AND purchases.id = $1
+	AND purchases.id = $1
 `
 
 func (q *Queries) GetPurchase(ctx context.Context, db DBTX, id string) (*Purchases, error) {

--- a/backend/internal/repositories/postgres/payments/generated/subscriptions.generated.sql_generated.go
+++ b/backend/internal/repositories/postgres/payments/generated/subscriptions.generated.sql_generated.go
@@ -80,7 +80,7 @@ SELECT
 	subscriptions.archived_at
 FROM subscriptions
 WHERE subscriptions.archived_at IS NULL
-AND subscriptions.id = $1
+	AND subscriptions.id = $1
 `
 
 func (q *Queries) GetSubscription(ctx context.Context, db DBTX, id string) (*Subscriptions, error) {

--- a/backend/internal/repositories/postgres/payments/sqlc_queries/products.generated.sql
+++ b/backend/internal/repositories/postgres/payments/sqlc_queries/products.generated.sql
@@ -1,6 +1,3 @@
--- name: ArchiveProduct :execrows
-UPDATE products SET archived_at = NOW(), last_updated_at = NOW() WHERE archived_at IS NULL AND id = sqlc.arg(id);
-
 -- name: CreateProduct :exec
 INSERT INTO products (
 	id,
@@ -22,14 +19,6 @@ INSERT INTO products (
 	sqlc.arg(external_product_id)
 );
 
--- name: CheckProductExistence :one
-SELECT EXISTS (
-	SELECT products.id
-	FROM products
-	WHERE products.archived_at IS NULL
-	AND products.id = sqlc.arg(id)
-);
-
 -- name: GetProduct :one
 SELECT
 	products.id,
@@ -45,7 +34,31 @@ SELECT
 	products.archived_at
 FROM products
 WHERE products.archived_at IS NULL
-AND products.id = sqlc.arg(id);
+	AND products.id = sqlc.arg(id);
+
+-- name: CheckProductExistence :one
+SELECT EXISTS (
+	SELECT products.id
+	FROM products
+	WHERE products.archived_at IS NULL
+		AND products.id = sqlc.arg(id)
+);
+
+-- name: UpdateProduct :execrows
+UPDATE products SET
+	name = sqlc.arg(name),
+	description = sqlc.arg(description),
+	kind = sqlc.arg(kind),
+	amount_cents = sqlc.arg(amount_cents),
+	currency = sqlc.arg(currency),
+	billing_interval_months = sqlc.arg(billing_interval_months),
+	external_product_id = sqlc.arg(external_product_id),
+	last_updated_at = NOW()
+WHERE archived_at IS NULL
+	AND id = sqlc.arg(id);
+
+-- name: ArchiveProduct :execrows
+UPDATE products SET archived_at = NOW(), last_updated_at = NOW() WHERE archived_at IS NULL AND id = sqlc.arg(id);
 
 -- name: GetProductByExternalID :one
 SELECT
@@ -168,16 +181,3 @@ WHERE products.archived_at IS NULL
 	AND products.id > COALESCE(sqlc.narg(cursor), '')
 ORDER BY products.id ASC
 LIMIT COALESCE(sqlc.narg(result_limit), 50);
-
--- name: UpdateProduct :execrows
-UPDATE products SET
-	name = sqlc.arg(name),
-	description = sqlc.arg(description),
-	kind = sqlc.arg(kind),
-	amount_cents = sqlc.arg(amount_cents),
-	currency = sqlc.arg(currency),
-	billing_interval_months = sqlc.arg(billing_interval_months),
-	external_product_id = sqlc.arg(external_product_id),
-	last_updated_at = NOW()
-WHERE archived_at IS NULL
-	AND id = sqlc.arg(id);

--- a/backend/internal/repositories/postgres/payments/sqlc_queries/purchases.generated.sql
+++ b/backend/internal/repositories/postgres/payments/sqlc_queries/purchases.generated.sql
@@ -31,7 +31,7 @@ SELECT
 	purchases.archived_at
 FROM purchases
 WHERE purchases.archived_at IS NULL
-AND purchases.id = sqlc.arg(id);
+	AND purchases.id = sqlc.arg(id);
 
 -- name: GetPurchasesForAccount :many
 SELECT

--- a/backend/internal/repositories/postgres/payments/sqlc_queries/subscriptions.generated.sql
+++ b/backend/internal/repositories/postgres/payments/sqlc_queries/subscriptions.generated.sql
@@ -1,6 +1,3 @@
--- name: ArchiveSubscription :execrows
-UPDATE subscriptions SET archived_at = NOW(), last_updated_at = NOW() WHERE archived_at IS NULL AND id = sqlc.arg(id);
-
 -- name: CreateSubscription :exec
 INSERT INTO subscriptions (
 	id,
@@ -34,7 +31,20 @@ SELECT
 	subscriptions.archived_at
 FROM subscriptions
 WHERE subscriptions.archived_at IS NULL
-AND subscriptions.id = sqlc.arg(id);
+	AND subscriptions.id = sqlc.arg(id);
+
+-- name: UpdateSubscription :execrows
+UPDATE subscriptions SET
+	external_subscription_id = sqlc.arg(external_subscription_id),
+	status = sqlc.arg(status),
+	current_period_start = sqlc.arg(current_period_start),
+	current_period_end = sqlc.arg(current_period_end),
+	last_updated_at = NOW()
+WHERE archived_at IS NULL
+	AND id = sqlc.arg(id);
+
+-- name: ArchiveSubscription :execrows
+UPDATE subscriptions SET archived_at = NOW(), last_updated_at = NOW() WHERE archived_at IS NULL AND id = sqlc.arg(id);
 
 -- name: GetSubscriptionByExternalID :one
 SELECT
@@ -105,16 +115,6 @@ WHERE subscriptions.archived_at IS NULL
 	AND subscriptions.id > COALESCE(sqlc.narg(cursor), '')
 ORDER BY subscriptions.id ASC
 LIMIT COALESCE(sqlc.narg(result_limit), 50);
-
--- name: UpdateSubscription :execrows
-UPDATE subscriptions SET
-	external_subscription_id = sqlc.arg(external_subscription_id),
-	status = sqlc.arg(status),
-	current_period_start = sqlc.arg(current_period_start),
-	current_period_end = sqlc.arg(current_period_end),
-	last_updated_at = NOW()
-WHERE archived_at IS NULL
-	AND id = sqlc.arg(id);
 
 -- name: UpdateSubscriptionStatus :execrows
 UPDATE subscriptions SET status = sqlc.arg(status), last_updated_at = NOW()

--- a/backend/internal/repositories/postgres/settings/generated/service_settings.generated.sql_generated.go
+++ b/backend/internal/repositories/postgres/settings/generated/service_settings.generated.sql_generated.go
@@ -28,7 +28,7 @@ SELECT EXISTS (
 	SELECT service_settings.id
 	FROM service_settings
 	WHERE service_settings.archived_at IS NULL
-	AND service_settings.id = $1
+		AND service_settings.id = $1
 )
 `
 

--- a/backend/internal/repositories/postgres/settings/sqlc_queries/service_setting_configurations.generated.sql
+++ b/backend/internal/repositories/postgres/settings/sqlc_queries/service_setting_configurations.generated.sql
@@ -1,9 +1,3 @@
--- name: ArchiveServiceSettingConfiguration :execrows
-UPDATE service_setting_configurations SET
-	archived_at = NOW()
-WHERE archived_at IS NULL
-	AND id = sqlc.arg(id);
-
 -- name: CreateServiceSettingConfiguration :exec
 INSERT INTO service_setting_configurations (
 	id,
@@ -28,6 +22,23 @@ SELECT EXISTS (
 	WHERE service_setting_configurations.archived_at IS NULL
 		AND service_setting_configurations.id = sqlc.arg(id)
 );
+
+-- name: UpdateServiceSettingConfiguration :execrows
+UPDATE service_setting_configurations SET
+	value = sqlc.arg(value),
+	notes = sqlc.arg(notes),
+	service_setting_id = sqlc.arg(service_setting_id),
+	belongs_to_user = sqlc.arg(belongs_to_user),
+	belongs_to_account = sqlc.arg(belongs_to_account),
+	last_updated_at = NOW()
+WHERE archived_at IS NULL
+	AND id = sqlc.arg(id);
+
+-- name: ArchiveServiceSettingConfiguration :execrows
+UPDATE service_setting_configurations SET
+	archived_at = NOW()
+WHERE archived_at IS NULL
+	AND id = sqlc.arg(id);
 
 -- name: GetServiceSettingConfigurationByID :one
 SELECT
@@ -236,14 +247,3 @@ WHERE service_settings.archived_at IS NULL
 	AND service_setting_configurations.id > COALESCE(sqlc.narg(cursor), '')
 ORDER BY service_setting_configurations.id ASC
 LIMIT COALESCE(sqlc.narg(result_limit), 50);
-
--- name: UpdateServiceSettingConfiguration :execrows
-UPDATE service_setting_configurations SET
-	value = sqlc.arg(value),
-	notes = sqlc.arg(notes),
-	service_setting_id = sqlc.arg(service_setting_id),
-	belongs_to_user = sqlc.arg(belongs_to_user),
-	belongs_to_account = sqlc.arg(belongs_to_account),
-	last_updated_at = NOW()
-WHERE archived_at IS NULL
-	AND id = sqlc.arg(id);

--- a/backend/internal/repositories/postgres/settings/sqlc_queries/service_settings.generated.sql
+++ b/backend/internal/repositories/postgres/settings/sqlc_queries/service_settings.generated.sql
@@ -1,6 +1,3 @@
--- name: ArchiveServiceSetting :execrows
-UPDATE service_settings SET archived_at = NOW() WHERE id = sqlc.arg(id);
-
 -- name: CreateServiceSetting :exec
 INSERT INTO service_settings (
 	id,
@@ -20,13 +17,32 @@ INSERT INTO service_settings (
 	sqlc.arg(admins_only)
 );
 
+-- name: GetServiceSetting :one
+SELECT
+	service_settings.id,
+	service_settings.name,
+	service_settings.type,
+	service_settings.description,
+	service_settings.default_value,
+	service_settings.enumeration,
+	service_settings.admins_only,
+	service_settings.created_at,
+	service_settings.last_updated_at,
+	service_settings.archived_at
+FROM service_settings
+WHERE service_settings.archived_at IS NULL
+	AND service_settings.id = sqlc.arg(id);
+
 -- name: CheckServiceSettingExistence :one
 SELECT EXISTS (
 	SELECT service_settings.id
 	FROM service_settings
 	WHERE service_settings.archived_at IS NULL
-	AND service_settings.id = sqlc.arg(id)
+		AND service_settings.id = sqlc.arg(id)
 );
+
+-- name: ArchiveServiceSetting :execrows
+UPDATE service_settings SET archived_at = NOW() WHERE id = sqlc.arg(id);
 
 -- name: GetServiceSettings :many
 SELECT
@@ -78,22 +94,6 @@ WHERE service_settings.archived_at IS NULL
 	AND service_settings.id > COALESCE(sqlc.narg(cursor), '')
 ORDER BY service_settings.id ASC
 LIMIT COALESCE(sqlc.narg(result_limit), 50);
-
--- name: GetServiceSetting :one
-SELECT
-	service_settings.id,
-	service_settings.name,
-	service_settings.type,
-	service_settings.description,
-	service_settings.default_value,
-	service_settings.enumeration,
-	service_settings.admins_only,
-	service_settings.created_at,
-	service_settings.last_updated_at,
-	service_settings.archived_at
-FROM service_settings
-WHERE service_settings.archived_at IS NULL
-	AND service_settings.id = sqlc.arg(id);
 
 -- name: SearchForServiceSettings :many
 SELECT

--- a/backend/internal/repositories/postgres/uploadedmedia/sqlc_queries/uploaded_media.generated.sql
+++ b/backend/internal/repositories/postgres/uploadedmedia/sqlc_queries/uploaded_media.generated.sql
@@ -11,6 +11,19 @@ INSERT INTO uploaded_media (
 	sqlc.arg(created_by_user)
 );
 
+-- name: GetUploadedMedia :one
+SELECT
+	uploaded_media.id,
+	uploaded_media.storage_path,
+	uploaded_media.mime_type,
+	uploaded_media.created_at,
+	uploaded_media.last_updated_at,
+	uploaded_media.archived_at,
+	uploaded_media.created_by_user
+FROM uploaded_media
+WHERE uploaded_media.archived_at IS NULL
+	AND uploaded_media.id = sqlc.arg(id);
+
 -- name: UpdateUploadedMedia :execrows
 UPDATE uploaded_media SET
 	storage_path = sqlc.arg(storage_path),
@@ -25,19 +38,6 @@ UPDATE uploaded_media SET
 	archived_at = NOW()
 WHERE archived_at IS NULL
 	AND id = sqlc.arg(id);
-
--- name: GetUploadedMedia :one
-SELECT
-	uploaded_media.id,
-	uploaded_media.storage_path,
-	uploaded_media.mime_type,
-	uploaded_media.created_at,
-	uploaded_media.last_updated_at,
-	uploaded_media.archived_at,
-	uploaded_media.created_by_user
-FROM uploaded_media
-WHERE uploaded_media.archived_at IS NULL
-	AND uploaded_media.id = sqlc.arg(id);
 
 -- name: CheckUploadedMediaExistence :one
 SELECT EXISTS(

--- a/backend/internal/repositories/postgres/waitlists/sqlc_queries/waitlist_signups.generated.sql
+++ b/backend/internal/repositories/postgres/waitlists/sqlc_queries/waitlist_signups.generated.sql
@@ -13,6 +13,20 @@ INSERT INTO waitlist_signups (
 	sqlc.arg(belongs_to_account)
 );
 
+-- name: GetWaitlistSignupByID :one
+SELECT
+	waitlist_signups.id,
+	waitlist_signups.notes,
+	waitlist_signups.belongs_to_waitlist,
+	waitlist_signups.created_at,
+	waitlist_signups.last_updated_at,
+	waitlist_signups.archived_at,
+	waitlist_signups.belongs_to_user,
+	waitlist_signups.belongs_to_account
+FROM waitlist_signups
+WHERE waitlist_signups.archived_at IS NULL
+	AND waitlist_signups.id = sqlc.arg(id);
+
 -- name: UpdateWaitlistSignup :execrows
 UPDATE waitlist_signups SET
 	notes = sqlc.arg(notes),
@@ -41,20 +55,6 @@ FROM waitlist_signups
 WHERE waitlist_signups.archived_at IS NULL
 	AND waitlist_signups.id = sqlc.arg(id)
 	AND waitlist_signups.belongs_to_waitlist = sqlc.arg(belongs_to_waitlist);
-
--- name: GetWaitlistSignupByID :one
-SELECT
-	waitlist_signups.id,
-	waitlist_signups.notes,
-	waitlist_signups.belongs_to_waitlist,
-	waitlist_signups.created_at,
-	waitlist_signups.last_updated_at,
-	waitlist_signups.archived_at,
-	waitlist_signups.belongs_to_user,
-	waitlist_signups.belongs_to_account
-FROM waitlist_signups
-WHERE waitlist_signups.archived_at IS NULL
-	AND waitlist_signups.id = sqlc.arg(id);
 
 -- name: CheckWaitlistSignupExistence :one
 SELECT EXISTS(

--- a/backend/internal/repositories/postgres/waitlists/sqlc_queries/waitlists.generated.sql
+++ b/backend/internal/repositories/postgres/waitlists/sqlc_queries/waitlists.generated.sql
@@ -11,6 +11,19 @@ INSERT INTO waitlists (
 	sqlc.arg(valid_until)
 );
 
+-- name: GetWaitlist :one
+SELECT
+	waitlists.id,
+	waitlists.name,
+	waitlists.description,
+	waitlists.valid_until,
+	waitlists.created_at,
+	waitlists.last_updated_at,
+	waitlists.archived_at
+FROM waitlists
+WHERE waitlists.archived_at IS NULL
+	AND waitlists.id = sqlc.arg(id);
+
 -- name: UpdateWaitlist :execrows
 UPDATE waitlists SET
 	name = sqlc.arg(name),
@@ -26,19 +39,6 @@ UPDATE waitlists SET
 	archived_at = NOW()
 WHERE archived_at IS NULL
 	AND id = sqlc.arg(id);
-
--- name: GetWaitlist :one
-SELECT
-	waitlists.id,
-	waitlists.name,
-	waitlists.description,
-	waitlists.valid_until,
-	waitlists.created_at,
-	waitlists.last_updated_at,
-	waitlists.archived_at
-FROM waitlists
-WHERE waitlists.archived_at IS NULL
-	AND waitlists.id = sqlc.arg(id);
 
 -- name: CheckWaitlistExistence :one
 SELECT EXISTS(

--- a/backend/internal/repositories/postgres/webhooks/generated/webhook_trigger_configs.generated.sql_generated.go
+++ b/backend/internal/repositories/postgres/webhooks/generated/webhook_trigger_configs.generated.sql_generated.go
@@ -17,8 +17,8 @@ WHERE webhook_trigger_configs.archived_at IS NULL
 	AND webhook_trigger_configs.belongs_to_webhook IN (
 		SELECT webhooks.id FROM webhooks
 		WHERE webhooks.id = $2
-			AND webhooks.belongs_to_account = $3
-			AND webhooks.archived_at IS NULL
+				AND webhooks.belongs_to_account = $3
+				AND webhooks.archived_at IS NULL
 	)
 `
 

--- a/backend/internal/repositories/postgres/webhooks/sqlc_queries/webhook_trigger_configs.generated.sql
+++ b/backend/internal/repositories/postgres/webhooks/sqlc_queries/webhook_trigger_configs.generated.sql
@@ -17,6 +17,6 @@ WHERE webhook_trigger_configs.archived_at IS NULL
 	AND webhook_trigger_configs.belongs_to_webhook IN (
 		SELECT webhooks.id FROM webhooks
 		WHERE webhooks.id = sqlc.arg(belongs_to_webhook)
-			AND webhooks.belongs_to_account = sqlc.arg(belongs_to_account)
-			AND webhooks.archived_at IS NULL
+				AND webhooks.belongs_to_account = sqlc.arg(belongs_to_account)
+				AND webhooks.archived_at IS NULL
 	);

--- a/backend/internal/repositories/postgres/webhooks/sqlc_queries/webhooks.generated.sql
+++ b/backend/internal/repositories/postgres/webhooks/sqlc_queries/webhooks.generated.sql
@@ -1,10 +1,3 @@
--- name: ArchiveWebhook :execrows
-UPDATE webhooks SET
-	archived_at = NOW()
-WHERE archived_at IS NULL
-	AND id = sqlc.arg(id)
-	AND belongs_to_account = sqlc.arg(belongs_to_account);
-
 -- name: CreateWebhook :exec
 INSERT INTO webhooks (
 	id,
@@ -23,6 +16,13 @@ INSERT INTO webhooks (
 	sqlc.arg(created_by_user),
 	sqlc.arg(belongs_to_account)
 );
+
+-- name: ArchiveWebhook :execrows
+UPDATE webhooks SET
+	archived_at = NOW()
+WHERE archived_at IS NULL
+	AND id = sqlc.arg(id)
+	AND belongs_to_account = sqlc.arg(belongs_to_account);
 
 -- name: CheckWebhookExistence :one
 SELECT EXISTS(


### PR DESCRIPTION
Finishes Phase 1 of #1292. #1317 converted the seven `valid_*` leaf tables; this
converts the remaining 59, so 66 tables now get their standard queries from
`querygen.StandardCRUD` instead of assembling them by hand.

```
cmd/tools/codegen/queries    15,921 -> 13,524 lines   (-2,397)
StandardCRUD calls                 7 -> 66
```

Options used across the 66 calls: `WithEntity` ×66, `WithOmitted` ×64,
`WithOwnership` ×18, `WithDatabaseOwned` ×10, `WithImmutable` ×8,
`WithQueryName` ×7, `WithNullable` ×3.

## The list is still omitted everywhere

All 64 tables that have a list keep the hand-written one. #1318 owns the swap,
and that swap *is* the behavior change — `include_archived` starting to work and
`total_count` starting to respect it. Keeping it out is what lets this diff be a
no-op.

## Options were derived, not chosen

Since this phase may not change behavior, each table's option set is read back
out of the SQL the hand-written generator already emitted. A shape converts only
when its baseline form is exactly what `StandardCRUD` would emit:

- the sqlc annotation type matches (an `:exec` query cannot become `:execrows`)
- it keys on `id`
- it guards on `archived_at` iff the column list holds the column
- its `INSERT` binds exactly the derivable column list, all as plain `arg`/`narg`
- its `UPDATE` assigns nothing but `col = arg(col)`, and touches
  `last_updated_at` iff the table has it
- at most one ownership column, and the value that converts the most shapes wins

Everything that fails those checks stays hand-written:

| left alone | why |
|---|---|
| `password_reset_tokens` create | binds `NOW() + (30 * '1 minutes'::INTERVAL)`, not an argument |
| `oauth2_client_tokens` | no `archived_at`; `INSERT` binds hash columns the column list does not name |
| `meal_plan_recipe_option_selections` | keys on a three-column composite, no archived guard |
| `FinalizeMealPlan` | `:exec`, and does not touch `last_updated_at` |
| `ArchiveAccount`, `ArchiveProduct`, `ArchiveSubscription` | set `last_updated_at` alongside `archived_at` |
| `queue_test_messages` | no soft delete at all |
| `identity_admin.go`, `maintenance_maintenance.go` | register no table |

`ArchiveAccount` and `FinalizeMealPlan` are the two worth a second opinion —
they're reasonable candidates to normalize in #1318, but normalizing them here
would have made this diff non-empty.

## Verification

Per query, not per line: `StandardCRUD` lays a statement out differently, and
sqlc sorts by query name, so file order never reaches the generated Go.

**Of 548 queries: 493 byte-identical, 55 differ only by layout or by the order of
ANDed predicates, 0 differ otherwise.** The reorder claim is checked
mechanically — each `WHERE`'s conjuncts are sorted and the redundant table
qualifier in `UPDATE t SET ... WHERE t.col` is dropped before comparing — not by
reading the diff.

### The reordering is a real diff, just not a behavioral one

The hand-written archives and updates put the ownership predicate before `id`;
`StandardCRUD` puts `id` first. Same query, but it renumbers the bound
parameters and reorders the fields of the sqlc params structs. That is a larger
churn than #1317's pure-whitespace diff, so:

**Comparing every `Queries` method signature and every params/row struct's field
*set* across the 40 regenerated files finds 0 differences.** Only field order and
`$N` numbering moved, and call sites name their fields.

### Checks

- `go build ./...`, `go vet` — clean
- full unit suite — green
- `make integration_tests` — **307 tests, 821 subtests, 0 failures, 0 skips**
- `go run ./cmd/tools/codegen/queries --check` — generator idempotent
- `gofmt` / `gci` clean; `goconst` 43 → 41 (pre-existing, verified against a
  pristine `HEAD` worktree)

## Not in this PR

`helpers.go` is untouched. Lifting the reindex scan orphaned
`buildReindexScanQuery`, bringing the dead functions there to four (three were
already dead on `main`). Phase 3 of #1292 removes that half wholesale once #1318
has landed, and pulling one function out early would only mix concerns.

Part of #1292.

🤖 Generated with [Claude Code](https://claude.com/claude-code)