### PR TITLE
refactor(webhooks): make the platform translation a named seam

### DIFF
--- a/backend/internal/domain/notifications/user_notification.go
+++ b/backend/internal/domain/notifications/user_notification.go
@@ -32,6 +32,15 @@ func init() {
 
 type (
 	// UserNotification represents a user notification.
+	//
+	// It is not a duplicate of platform-go's notifications/mobile, despite the shared word.
+	// That package is push delivery: it hands a title and a body to APNs or FCM and is done,
+	// and this application consumes it directly, unwrapped, in
+	// internal/functions/datachangemessagehandler. This is an in-app resource — a row that
+	// belongs to a user, carries a Status the user moves between unread, read, and dismissed,
+	// and is listed and updated through the API. A push has no status to move and no row to
+	// list. Nothing to merge; they are two ways of telling someone something, and an event
+	// often does both.
 	UserNotification struct {
 		_ struct{} `json:"-"`
 

--- a/backend/internal/domain/payments/payment_transaction.go
+++ b/backend/internal/domain/payments/payment_transaction.go
@@ -13,6 +13,15 @@ const (
 
 type (
 	// PaymentTransaction represents an audit record of a payment attempt.
+	//
+	// It is not a duplicate of capitalism.PaymentIntentCreationInput, despite the overlap in
+	// vocabulary. That type is an argument to a provider call — CustomerID, IdempotencyKey, a
+	// currency and an amount, all of which are what Stripe needs to be asked for a payment
+	// intent — and it is gone once the call returns. This is the stored resource the attempt
+	// left behind: it belongs to an account, references a subscription or purchase of ours,
+	// carries the provider's ID as a foreign key rather than as its identity, and is read back
+	// by the API. Different layers, and nothing to fold together; see Subscription for the same
+	// distinction on the recurring side.
 	PaymentTransaction struct {
 		_                     struct{}  `json:"-"`
 		CreatedAt             time.Time `json:"createdAt"`

--- a/backend/internal/domain/payments/subscription.go
+++ b/backend/internal/domain/payments/subscription.go
@@ -24,6 +24,15 @@ const (
 
 type (
 	// Subscription represents a recurring agreement for an account.
+	//
+	// It is not a duplicate of capitalism.SubscriptionCreationInput. That type is a provider
+	// call's arguments — CustomerID, PriceID, IdempotencyKey — naming things that exist in
+	// Stripe and nowhere here. This is the row: it belongs to an account, points at one of our
+	// products, has a status this application transitions and archival timestamps this
+	// application stamps, and holds the provider's own identifier in ExternalSubscriptionID
+	// precisely because the two identities are separate. The platform deliberately has no
+	// counterpart to it — how a subscription is stored, scoped, and expired is an
+	// application's decision.
 	Subscription struct {
 		_                      struct{}   `json:"-"`
 		CurrentPeriodStart     time.Time  `json:"currentPeriodStart"`

--- a/backend/internal/domain/uploadedmedia/uploaded_media.go
+++ b/backend/internal/domain/uploadedmedia/uploaded_media.go
@@ -46,6 +46,15 @@ func init() {
 
 type (
 	// UploadedMedia represents a media file uploaded by a user.
+	//
+	// It is not a duplicate of platform-go's uploads types. Those — ObjectInfo, Attributes —
+	// are blob-store descriptors: what the bucket says about a path, produced by the store and
+	// owned by it. This is the application's record that a user put something there, and it
+	// holds what the bucket cannot know: who uploaded it, when this application accepted it,
+	// and whether it has since been archived. StoragePath is the join between the two, and the
+	// direction of that join is the point — the row references the object, and the object has
+	// never heard of the row. The platform's uploader is consumed directly wherever a file is
+	// actually written; see internal/services/mealplanning/grpc/image_uploads.go.
 	UploadedMedia struct {
 		_             struct{}   `json:"-"`
 		CreatedAt     time.Time  `json:"createdAt"`

--- a/backend/internal/domain/webhooks/webhook.go
+++ b/backend/internal/domain/webhooks/webhook.go
@@ -38,6 +38,27 @@ type (
 	// The signing secret is deliberately absent. It is returned once, from the call that creates
 	// or rotates it, and never read back: a secret an API will hand out on request is one an
 	// attacker with read access can hand out to themselves.
+	//
+	// # Divergence from webhooks.Endpoint
+	//
+	// The platform speaks of an Endpoint, which is deliberately general: it is a delivery target
+	// — a URL, a content type, a signing secret, and Events, a flat list of subscription strings
+	// — and it says nothing about whose it is, because tenancy depth is an application's
+	// decision. Ours is an account's webhook, and this type keeps that.
+	//
+	// Two fields are why both types exist, and neither survives a translation to Endpoint:
+	//
+	//   - BelongsToAccount is the filter on every read and write of this resource. Endpoint has
+	//     no owner to filter on, so the account travels inside the subscription string instead;
+	//     see webhookdispatch.qualify.
+	//   - TriggerConfigs are identified, individually archivable rows, and the API creates and
+	//     archives them one at a time. Endpoint.Events is a bare []string: it can express the
+	//     set, not the identity or the archival timestamp of any member of it.
+	//
+	// Deleting this type in favor of Endpoint would therefore not be an internal cleanup — it
+	// would drop the fields the permission model and the API surface are built on, and rename
+	// the rest, because the platform's JSON tags are not these. webhookdispatch/conversion.go
+	// is where the translation lives, and it is the only place it happens.
 	Webhook struct {
 		_ struct{} `json:"-"`
 

--- a/backend/internal/repositories/postgres/webhookdispatch/conversion.go
+++ b/backend/internal/repositories/postgres/webhookdispatch/conversion.go
@@ -1,0 +1,166 @@
+/*
+This file is the translation boundary between this application's webhook vocabulary and
+platform-go's, and it is the only place either language is spoken in terms of the other.
+
+The application's Webhook is an account-owned resource: a name, an owner, archival timestamps,
+and identified trigger config rows. The platform's Endpoint is a delivery target: a URL, a
+content type, a signing secret, and a flat list of subscription strings. Neither is derivable
+from the other, and almost all of the gap between them is tenancy — see the divergence note on
+Webhook in internal/domain/webhooks/webhook.go for why both types exist.
+
+The rule that makes this a file rather than a struct literal in the middle of Register is the one
+qualify encodes. The platform's Catalog is global by construction — two accounts subscribing to
+"meal_plan_created" are one key to it — so the account has to be folded into the event type here
+or the fan-out delivers every account's events to every account's endpoints. That is the same
+class of decision as audit.ScopeFor, and it gets the same treatment: one implementation, called
+from one place, because a rule applied at several call sites is a rule applied inconsistently.
+
+# There is no fromPlatformEndpoint, and that is deliberate
+
+Nothing reads an Endpoint back out as a Webhook. The two stores hold different things: the
+platform's holds dispatch state — signing secret, retry counters, circuit breaker, attempt log —
+and this application's webhooks and webhook_trigger_configs tables hold the account-facing
+resource, including the trigger config identities and archival timestamps the API returns and the
+platform has no column for. Every read path in internal/repositories/postgres/webhooks therefore
+goes to this application's own tables, and reconstructing a Webhook from an Endpoint would mean
+inventing the fields the generalization dropped.
+
+The only reverse translation that exists is unqualify, and it recovers an event type for
+setAccountSubscriptions' read-modify-write rather than for any read path.
+*/
+
+package webhookdispatch
+
+import (
+	"strings"
+
+	platformerrors "github.com/primandproper/platform-go/v11/errors"
+	"github.com/primandproper/platform-go/v11/tenancy"
+	"github.com/primandproper/platform-go/v11/webhooks"
+)
+
+// accountSeparator joins an account to an event type in a subscription row.
+//
+// A colon, because neither half can contain one: account IDs are the alphanumeric identifiers
+// identifiers.New mints, and event types are Go constants matching [a-z0-9_]+. That is what makes
+// the join unambiguous — a separator either side could contain would let two different pairs
+// render to the same subscription string, and events would reach the wrong account's endpoint.
+const accountSeparator = ":"
+
+// scope is the tenant dimension every stored record and every store call in this package
+// carries.
+//
+// It is Global, and that is behavior-preserving rather than an omission. platform-go's webhooks
+// tables grew an owner dimension in /v11, and this package had already solved the same problem a
+// different way: the account travels inside the subscription's event type, as
+// <accountID>:<eventType>, which is what the qualify/unqualify pair below is for. Two account
+// filters would be one too many. Global matches only itself, so the added dimension selects
+// every row this package writes and excludes nothing it would otherwise have read.
+//
+// Adopting the dimension properly means deleting qualify/unqualify, backfilling real account IDs
+// into the scope column, and then deleting most of this package in favor of the platform's own
+// Dispatcher — which is what the owner dimension was added for, and which is #1303. It is not
+// this change.
+func scope() tenancy.Scope {
+	return tenancy.Global()
+}
+
+// qualify renders the subscription string for one account's interest in one event type.
+func qualify(accountID, eventType string) webhooks.EventType {
+	return webhooks.EventType(accountID + accountSeparator + eventType)
+}
+
+// unqualify recovers the event type from a subscription string, and reports whether it belonged
+// to the given account. A subscription for another account returns false, which is what makes
+// this safe to map over an endpoint's whole subscription set.
+func unqualify(accountID string, subscription webhooks.EventType) (eventType string, ok bool) {
+	return strings.CutPrefix(subscription.String(), accountID+accountSeparator)
+}
+
+// checkKnown rejects event types outside the application's catalog.
+//
+// The check is on the unqualified type, which is the one the catalog is about: the qualified
+// string qualify produces can never be in a catalog, because a catalog holds unqualified types
+// and would need one entry per account to hold these.
+//
+// It is separate from qualifyAll so that a caller which has to read before it can write — see
+// Dispatcher.SetEventTypes — can refuse a bad request without paying for the query.
+func (d *Dispatcher) checkKnown(eventTypes []string) error {
+	for _, eventType := range eventTypes {
+		if !d.catalog.Known(webhooks.EventType(eventType)) {
+			return platformerrors.Wrapf(ErrUnknownEventType, "event type %q", eventType)
+		}
+	}
+
+	return nil
+}
+
+// qualifyAll vets event types against the catalog and renders them for storage.
+func (d *Dispatcher) qualifyAll(accountID string, eventTypes []string) ([]webhooks.EventType, error) {
+	if accountID == "" {
+		return nil, platformerrors.ErrInvalidIDProvided
+	}
+
+	if err := d.checkKnown(eventTypes); err != nil {
+		return nil, err
+	}
+
+	// An empty set is allowed here, producing an endpoint that is registered and subscribed to
+	// nothing. That is a real state — a webhook adopted from before delivery worked starts in
+	// it, and unsubscribing from the last event type returns to it — and it is inert rather
+	// than dangerous, because fan-out reads the subscriptions table. The rule that a webhook is
+	// created subscribed to something is a request-validation rule, and lives there.
+	qualified := make([]webhooks.EventType, 0, len(eventTypes))
+	for _, eventType := range eventTypes {
+		qualified = append(qualified, qualify(accountID, eventType))
+	}
+
+	return qualified, nil
+}
+
+// toPlatformEndpoint renders a registration in the platform's vocabulary.
+//
+// The endpoint comes back subscribed to nothing: setAccountSubscriptions is what puts event types
+// on one, so that the qualification rule has a single implementation whether the endpoint is
+// being created or amended. Registration's Name, owner, and audit fields have no counterpart
+// here on purpose — the platform stores what it takes to deliver, and nothing about whose it is.
+func toPlatformEndpoint(registration *Registration, secret []byte) *webhooks.Endpoint {
+	endpoint := &webhooks.Endpoint{
+		Scope:       scope(),
+		ID:          registration.ID,
+		URL:         registration.URL,
+		ContentType: registration.ContentType,
+		Secret:      webhooks.Secret{Current: secret},
+	}
+	endpoint.EnsureDefaults()
+
+	return endpoint
+}
+
+// setAccountSubscriptions makes the account's subscriptions on an endpoint exactly eventTypes,
+// leaving every other account's alone. It is the only writer of Endpoint.Events.
+//
+// The filter-then-append is not defensiveness: SaveEndpoint replaces an endpoint's whole
+// subscription set, and this application never owns all of it, because the set is keyed by
+// account. Rewriting it from one account's event types would drop any subscription belonging to
+// another. In practice an endpoint has exactly one account — its webhook's — but relying on that
+// here would make a future multi-account endpoint silently lose subscriptions.
+func (d *Dispatcher) setAccountSubscriptions(endpoint *webhooks.Endpoint, accountID string, eventTypes []string) error {
+	qualified, err := d.qualifyAll(accountID, eventTypes)
+	if err != nil {
+		return err
+	}
+
+	subscriptions := make([]webhooks.EventType, 0, len(endpoint.Events)+len(qualified))
+	for _, subscription := range endpoint.Events {
+		if _, mine := unqualify(accountID, subscription); !mine {
+			subscriptions = append(subscriptions, subscription)
+		}
+	}
+
+	subscriptions = append(subscriptions, qualified...)
+
+	endpoint.Events = subscriptions
+
+	return nil
+}

--- a/backend/internal/repositories/postgres/webhookdispatch/conversion_test.go
+++ b/backend/internal/repositories/postgres/webhookdispatch/conversion_test.go
@@ -1,0 +1,195 @@
+package webhookdispatch
+
+import (
+	"testing"
+
+	platformerrors "github.com/primandproper/platform-go/v11/errors"
+	"github.com/primandproper/platform-go/v11/tenancy"
+	"github.com/primandproper/platform-go/v11/webhooks"
+	webhooksmock "github.com/primandproper/platform-go/v11/webhooks/mock"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestToPlatformEndpoint(T *testing.T) {
+	T.Parallel()
+
+	T.Run("standard", func(t *testing.T) {
+		t.Parallel()
+
+		secret := []byte("the-current-signing-secret-bytes")
+
+		endpoint := toPlatformEndpoint(&Registration{
+			ID:          exampleWebhookID,
+			AccountID:   exampleAccountID,
+			URL:         "https://example.com/hook",
+			ContentType: "application/json",
+			EventTypes:  []string{exampleEventType},
+		}, secret)
+
+		require.NotNil(t, endpoint)
+		assert.Equal(t, exampleWebhookID, endpoint.ID)
+		assert.Equal(t, "https://example.com/hook", endpoint.URL)
+		assert.Equal(t, "application/json", endpoint.ContentType)
+		assert.Equal(t, secret, endpoint.Secret.Current)
+		assert.Empty(t, endpoint.Secret.Previous)
+		assert.Equal(t, tenancy.Global(), endpoint.Scope)
+	})
+
+	T.Run("leaves the endpoint subscribed to nothing", func(t *testing.T) {
+		t.Parallel()
+
+		// Registration's event types are deliberately not read here. Subscriptions are
+		// qualified, and the qualification rule has one implementation —
+		// setAccountSubscriptions — so that creating an endpoint and amending one cannot
+		// namespace event types differently.
+		endpoint := toPlatformEndpoint(&Registration{
+			ID:         exampleWebhookID,
+			AccountID:  exampleAccountID,
+			EventTypes: []string{exampleEventType},
+		}, nil)
+
+		require.NotNil(t, endpoint)
+		assert.Empty(t, endpoint.Events)
+	})
+
+	T.Run("with no content type", func(t *testing.T) {
+		t.Parallel()
+
+		// EnsureDefaults is applied here rather than left to the caller: an endpoint stored
+		// with no Content-Type delivers requests a subscriber's framework may refuse to parse.
+		endpoint := toPlatformEndpoint(&Registration{ID: exampleWebhookID}, nil)
+
+		require.NotNil(t, endpoint)
+		assert.NotEmpty(t, endpoint.ContentType)
+	})
+}
+
+func TestDispatcher_setAccountSubscriptions(T *testing.T) {
+	T.Parallel()
+
+	T.Run("standard", func(t *testing.T) {
+		t.Parallel()
+
+		d := buildDispatcherForTest(t, &webhooksmock.StoreMock{})
+		endpoint := &webhooks.Endpoint{ID: exampleWebhookID}
+
+		require.NoError(t, d.setAccountSubscriptions(endpoint, exampleAccountID, []string{exampleEventType}))
+
+		// The account is inside the subscription string; that is the whole tenancy mechanism.
+		assert.Equal(t, []webhooks.EventType{exampleAccountID + ":" + exampleEventType}, endpoint.Events)
+	})
+
+	T.Run("replaces this account's subscriptions and keeps every other account's", func(t *testing.T) {
+		t.Parallel()
+
+		otherAccountSubscription := webhooks.EventType("acct_other:meal_plan_updated")
+
+		d := buildDispatcherForTest(t, &webhooksmock.StoreMock{})
+		endpoint := &webhooks.Endpoint{
+			ID: exampleWebhookID,
+			Events: []webhooks.EventType{
+				exampleAccountID + ":" + exampleEventType,
+				otherAccountSubscription,
+			},
+		}
+
+		require.NoError(t, d.setAccountSubscriptions(endpoint, exampleAccountID, []string{"meal_plan_updated"}))
+
+		// SaveEndpoint replaces an endpoint's whole subscription set, so a rewrite built from
+		// one account's event types alone would silently drop another account's.
+		assert.ElementsMatch(t, []webhooks.EventType{
+			otherAccountSubscription,
+			exampleAccountID + ":meal_plan_updated",
+		}, endpoint.Events)
+	})
+
+	T.Run("with no event types", func(t *testing.T) {
+		t.Parallel()
+
+		d := buildDispatcherForTest(t, &webhooksmock.StoreMock{})
+		endpoint := &webhooks.Endpoint{
+			ID:     exampleWebhookID,
+			Events: []webhooks.EventType{exampleAccountID + ":" + exampleEventType},
+		}
+
+		// Unsubscribing from the last event type is a real state, not an error: the endpoint
+		// stays registered and goes inert, because fan-out reads the subscriptions table.
+		require.NoError(t, d.setAccountSubscriptions(endpoint, exampleAccountID, nil))
+		assert.Empty(t, endpoint.Events)
+	})
+
+	T.Run("with event type outside the catalog", func(t *testing.T) {
+		t.Parallel()
+
+		d := buildDispatcherForTest(t, &webhooksmock.StoreMock{})
+		endpoint := &webhooks.Endpoint{ID: exampleWebhookID}
+
+		err := d.setAccountSubscriptions(endpoint, exampleAccountID, []string{"reciped_created"})
+		require.ErrorIs(t, err, webhooks.ErrUnknownEventType)
+		// The endpoint is left as it was, so a caller that ignores the error does not save a
+		// half-applied subscription set.
+		assert.Empty(t, endpoint.Events)
+	})
+
+	T.Run("with no account", func(t *testing.T) {
+		t.Parallel()
+
+		// An unqualified subscription string is one every account's fan-out would match, so
+		// there is no sensible thing to write without an account.
+		d := buildDispatcherForTest(t, &webhooksmock.StoreMock{})
+		endpoint := &webhooks.Endpoint{ID: exampleWebhookID}
+
+		err := d.setAccountSubscriptions(endpoint, "", []string{exampleEventType})
+		require.ErrorIs(t, err, platformerrors.ErrInvalidIDProvided)
+		assert.Empty(t, endpoint.Events)
+	})
+}
+
+func TestQualification(T *testing.T) {
+	T.Parallel()
+
+	T.Run("round trips", func(t *testing.T) {
+		t.Parallel()
+
+		subscription := qualify(exampleAccountID, exampleEventType)
+		assert.Equal(t, webhooks.EventType(exampleAccountID+":"+exampleEventType), subscription)
+
+		eventType, ok := unqualify(exampleAccountID, subscription)
+		assert.True(t, ok)
+		assert.Equal(t, exampleEventType, eventType)
+	})
+
+	T.Run("rejects another account's subscription", func(t *testing.T) {
+		t.Parallel()
+
+		// The prefix must match in full. A partial match here would leak one account's
+		// subscriptions into another's set on the read-modify-write in SetEventTypes.
+		_, ok := unqualify("acct_abc", qualify(exampleAccountID, exampleEventType))
+		assert.False(t, ok)
+	})
+}
+
+func TestDispatcher_checkKnown(T *testing.T) {
+	T.Parallel()
+
+	T.Run("standard", func(t *testing.T) {
+		t.Parallel()
+
+		d := buildDispatcherForTest(t, &webhooksmock.StoreMock{})
+		require.NoError(t, d.checkKnown([]string{exampleEventType, "meal_plan_updated"}))
+	})
+
+	T.Run("with event type outside the catalog", func(t *testing.T) {
+		t.Parallel()
+
+		// The gate is on the unqualified type, which is the one a catalog can hold: the
+		// qualified string qualify produces would need one catalog entry per account.
+		d := buildDispatcherForTest(t, &webhooksmock.StoreMock{})
+
+		err := d.checkKnown([]string{exampleEventType, "reciped_created"})
+		require.ErrorIs(t, err, webhooks.ErrUnknownEventType)
+		require.ErrorIs(t, err, ErrUnknownEventType)
+	})
+}

--- a/backend/internal/repositories/postgres/webhookdispatch/dispatcher.go
+++ b/backend/internal/repositories/postgres/webhookdispatch/dispatcher.go
@@ -43,7 +43,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
-	"strings"
 
 	"github.com/primandproper/platform-go/v11/clock"
 	"github.com/primandproper/platform-go/v11/database"
@@ -53,7 +52,6 @@ import (
 	"github.com/primandproper/platform-go/v11/observability/logging"
 	"github.com/primandproper/platform-go/v11/observability/metrics"
 	"github.com/primandproper/platform-go/v11/observability/tracing"
-	"github.com/primandproper/platform-go/v11/tenancy"
 	"github.com/primandproper/platform-go/v11/webhooks"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -61,14 +59,6 @@ import (
 )
 
 const o11yName = "webhook_dispatcher"
-
-// accountSeparator joins an account to an event type in a subscription row.
-//
-// A colon, because neither half can contain one: account IDs are the alphanumeric identifiers
-// identifiers.New mints, and event types are Go constants matching [a-z0-9_]+. That is what makes
-// the join unambiguous — a separator either side could contain would let two different pairs
-// render to the same subscription string, and events would reach the wrong account's endpoint.
-const accountSeparator = ":"
 
 // secretBytes is the size of a generated endpoint signing secret. 32 bytes matches the output
 // width of the SHA-256 the signature is computed with; a longer key buys nothing against HMAC.
@@ -200,36 +190,6 @@ func NewDispatcher(
 	return d, nil
 }
 
-// qualify renders the subscription string for one account's interest in one event type.
-// scope is the tenant dimension every stored record and every store call in this package
-// carries.
-//
-// It is Global, and that is behavior-preserving rather than an omission. platform-go's webhooks
-// tables grew an owner dimension in /v11, and this package had already solved the same problem a
-// different way: the account travels inside the subscription's event type, as
-// <accountID>:<eventType>, which is what the qualify/unqualify pair below is for. Two account
-// filters would be one too many. Global matches only itself, so the added dimension selects
-// every row this package writes and excludes nothing it would otherwise have read.
-//
-// Adopting the dimension properly means deleting qualify/unqualify, backfilling real account IDs
-// into the scope column, and then deleting most of this package in favor of the platform's own
-// Dispatcher — which is what the owner dimension was added for, and which is #1303. It is not
-// this change.
-func scope() tenancy.Scope {
-	return tenancy.Global()
-}
-
-func qualify(accountID, eventType string) webhooks.EventType {
-	return webhooks.EventType(accountID + accountSeparator + eventType)
-}
-
-// unqualify recovers the event type from a subscription string, and reports whether it belonged
-// to the given account. A subscription for another account returns false, which is what makes
-// this safe to map over an endpoint's whole subscription set.
-func unqualify(accountID string, subscription webhooks.EventType) (eventType string, ok bool) {
-	return strings.CutPrefix(subscription.String(), accountID+accountSeparator)
-}
-
 // Register stores an endpoint and its subscriptions, returning the signing secret.
 //
 // The secret is generated here and returned exactly once: it is stored to sign with, never read
@@ -257,25 +217,15 @@ func (d *Dispatcher) Register(ctx context.Context, registration *Registration) (
 
 	logger := d.logger.WithValue("webhook_id", registration.ID)
 
-	events, err := d.qualifyAll(registration.AccountID, registration.EventTypes)
-	if err != nil {
-		return "", observability.PrepareAndLogError(err, logger, span, "qualifying webhook event types")
-	}
-
 	rawSecret := make([]byte, secretBytes)
 	if _, err = rand.Read(rawSecret); err != nil {
 		return "", observability.PrepareAndLogError(err, logger, span, "generating webhook signing secret")
 	}
 
-	endpoint := &webhooks.Endpoint{
-		Scope:       scope(),
-		ID:          registration.ID,
-		URL:         registration.URL,
-		ContentType: registration.ContentType,
-		Secret:      webhooks.Secret{Current: rawSecret},
-		Events:      events,
+	endpoint := toPlatformEndpoint(registration, rawSecret)
+	if err = d.setAccountSubscriptions(endpoint, registration.AccountID, registration.EventTypes); err != nil {
+		return "", observability.PrepareAndLogError(err, logger, span, "subscribing webhook endpoint to event types")
 	}
-	endpoint.EnsureDefaults()
 
 	// Vetted before it is stored, not only before it is dialed. A rejection reported at
 	// registration reaches whoever submitted the URL; one discovered at delivery reaches a log
@@ -294,10 +244,8 @@ func (d *Dispatcher) Register(ctx context.Context, registration *Registration) (
 // SetEventTypes replaces the account's subscriptions for one endpoint.
 //
 // Read-modify-write, because SaveEndpoint replaces an endpoint's whole subscription set and this
-// application never owns all of it: the set stored against an endpoint is keyed by account, and
-// rewriting it from the event types alone would drop any subscription belonging to a different
-// account. In practice an endpoint has exactly one account — its webhook's — but relying on that
-// here would make a future multi-account endpoint silently lose subscriptions.
+// application never owns all of it. setAccountSubscriptions is what preserves the rest of it, and
+// is the same call Register makes — see conversion.go.
 func (d *Dispatcher) SetEventTypes(ctx context.Context, endpointID, accountID string, eventTypes []string) error {
 	if d == nil {
 		return ErrNoDispatcher
@@ -308,9 +256,10 @@ func (d *Dispatcher) SetEventTypes(ctx context.Context, endpointID, accountID st
 
 	logger := d.logger.WithValue("webhook_id", endpointID)
 
-	qualified, err := d.qualifyAll(accountID, eventTypes)
-	if err != nil {
-		return observability.PrepareAndLogError(err, logger, span, "qualifying webhook event types")
+	// Vetted before the read, so a request naming an event type nobody publishes costs no
+	// query. The projection into the platform's vocabulary still happens in one place, below.
+	if err := d.checkKnown(eventTypes); err != nil {
+		return observability.PrepareAndLogError(err, logger, span, "checking webhook event types against the catalog")
 	}
 
 	endpoint, err := d.store.GetEndpoint(ctx, scope(), endpointID)
@@ -325,15 +274,9 @@ func (d *Dispatcher) SetEventTypes(ctx context.Context, endpointID, accountID st
 		return observability.PrepareAndLogError(err, logger, span, "reading webhook endpoint")
 	}
 
-	subscriptions := make([]webhooks.EventType, 0, len(endpoint.Events)+len(qualified))
-	for _, subscription := range endpoint.Events {
-		if _, mine := unqualify(accountID, subscription); !mine {
-			subscriptions = append(subscriptions, subscription)
-		}
+	if err = d.setAccountSubscriptions(endpoint, accountID, eventTypes); err != nil {
+		return observability.PrepareAndLogError(err, logger, span, "subscribing webhook endpoint to event types")
 	}
-
-	subscriptions = append(subscriptions, qualified...)
-	endpoint.Events = subscriptions
 
 	if err = d.store.SaveEndpoint(ctx, endpoint); err != nil {
 		return observability.PrepareAndLogError(err, logger, span, "saving webhook endpoint subscriptions")
@@ -517,32 +460,4 @@ func (d *Dispatcher) Dispatch(
 	d.dispatchedCounter.Add(ctx, int64(len(endpointIDs)), eventTypeAttr)
 
 	return nil
-}
-
-// qualifyAll vets event types against the catalog and renders them for storage.
-//
-// The catalog check happens here rather than being left to the platform, because the qualified
-// string this produces can never be in a catalog: it holds unqualified types and would need one
-// entry per account to hold these. Checking the unqualified type is checking the thing the
-// catalog is actually about.
-func (d *Dispatcher) qualifyAll(accountID string, eventTypes []string) ([]webhooks.EventType, error) {
-	if accountID == "" {
-		return nil, platformerrors.ErrInvalidIDProvided
-	}
-
-	// An empty set is allowed here, producing an endpoint that is registered and subscribed to
-	// nothing. That is a real state — a webhook adopted from before delivery worked starts in
-	// it, and unsubscribing from the last event type returns to it — and it is inert rather
-	// than dangerous, because fan-out reads the subscriptions table. The rule that a webhook is
-	// created subscribed to something is a request-validation rule, and lives there.
-	qualified := make([]webhooks.EventType, 0, len(eventTypes))
-	for _, eventType := range eventTypes {
-		if !d.catalog.Known(webhooks.EventType(eventType)) {
-			return nil, platformerrors.Wrapf(ErrUnknownEventType, "event type %q", eventType)
-		}
-
-		qualified = append(qualified, qualify(accountID, eventType))
-	}
-
-	return qualified, nil
 }

--- a/backend/internal/repositories/postgres/webhookdispatch/dispatcher_test.go
+++ b/backend/internal/repositories/postgres/webhookdispatch/dispatcher_test.go
@@ -451,27 +451,3 @@ func TestDispatcher_RotateSecret(T *testing.T) {
 		assert.NotEqual(t, current, saved.Secret.Current)
 	})
 }
-
-func TestQualification(T *testing.T) {
-	T.Parallel()
-
-	T.Run("round trips", func(t *testing.T) {
-		t.Parallel()
-
-		subscription := qualify(exampleAccountID, exampleEventType)
-		assert.Equal(t, webhooks.EventType(exampleAccountID+":"+exampleEventType), subscription)
-
-		eventType, ok := unqualify(exampleAccountID, subscription)
-		assert.True(t, ok)
-		assert.Equal(t, exampleEventType, eventType)
-	})
-
-	T.Run("rejects another account's subscription", func(t *testing.T) {
-		t.Parallel()
-
-		// The prefix must match in full. A partial match here would leak one account's
-		// subscriptions into another's set on the read-modify-write in SetEventTypes.
-		_, ok := unqualify("acct_abc", qualify(exampleAccountID, exampleEventType))
-		assert.False(t, ok)
-	})
-}


### PR DESCRIPTION
Closes #1285.

The ticket's test — *does ddb's API filter on, authorize on, or return a field the platform type
collapses or omits?* — was applied to each overlapping pair. Every one answered **yes, keep both
types**, so no type was deleted and no response-path JSON tag changed. What did change is where
the translation happens.

## Task 1 — webhooks: the conversion is now a file

`Register` built a `webhooks.Endpoint` literal inline, wedged between secret generation and URL
validation. That literal, and the account-namespacing rule that gives per-account isolation inside
platform's flat `Catalog`, now live in
`backend/internal/repositories/postgres/webhookdispatch/conversion.go`:

| function | what it is |
| --- | --- |
| `toPlatformEndpoint` | registration → `webhooks.Endpoint`, subscribed to nothing |
| `setAccountSubscriptions` | the **only** writer of `Endpoint.Events` |
| `qualifyAll` / `qualify` / `unqualify` | the tenancy projection into platform's global catalog |
| `checkKnown` | the catalog gate, on the unqualified type |
| `scope` | the `tenancy.Global()` decision, with its existing rationale |

`Register` now reads as three named steps. `SetEventTypes` calls the same
`setAccountSubscriptions`, which is the point: creating an endpoint and amending one cannot
namespace event types differently if there is one implementation.

**On "`qualifyAll` called from one place."** It has exactly one caller —
`setAccountSubscriptions`. The catalog gate is split out as `checkKnown` so `SetEventTypes` can
keep refusing an unpublished event type *before* it reads the endpoint; there is a test asserting
a bad request costs no query, and that behavior is preserved deliberately rather than traded for
the call count.

**On `fromPlatformEndpoint`.** It has no implementation, and `conversion.go` explains why in
prose instead: nothing round-trips an `Endpoint` into a `Webhook`. The platform's store holds
dispatch state — secret, retry counters, circuit breaker, attempt log — and ddb's tables hold the
account-facing resource, including the trigger config identities and archival timestamps the API
returns and the platform has no column for. Writing the function would mean inventing those
fields. The ticket asked for the absence to be confirmed and said so; adding an unused function
would have made the codebase worse, not better.

`Webhook` in `internal/domain/webhooks/webhook.go` now carries a `# Divergence from
webhooks.Endpoint` section naming the two fields that are why both types exist:
`BelongsToAccount` (the filter on every read and write) and `TriggerConfigs` (identified,
individually archivable rows, against a bare `[]string`).

## Task 2 — the non-duplicates, in writing

One "not a duplicate, because" paragraph each, on the type:

- **`payments.PaymentTransaction`** / **`payments.Subscription`** vs `capitalism.*CreationInput` —
  provider-call arguments that are gone when the call returns, against stored rows that belong to
  an account and hold the provider's ID as a foreign key rather than as their identity.
- **`notifications.UserNotification`** vs `notifications/mobile` — a push has no `Status` to move
  and no row to list; ddb consumes the platform package directly for delivery.
- **`uploadedmedia.UploadedMedia`** vs `uploads.ObjectInfo` / `Attributes` — blob-store
  descriptors owned by the bucket, against ddb's record that a user put something there.
  `StoragePath` is the join, and the direction matters: the row references the object, the object
  has never heard of the row.

## Task 3

Filed as #1329 — platform-owned `primandproper.platform.filtering.v1`, including the registry
collision and the `go mod vendor` / non-Go-consumer distribution constraints. Not touched here.

## Testing

- New `conversion_test.go` covers `toPlatformEndpoint` (field carriage, `tenancy.Global()` scope,
  left unsubscribed, `EnsureDefaults`), `setAccountSubscriptions` (fresh endpoint, another
  account's subscriptions preserved, unsubscribe-to-empty, unknown event type leaves the endpoint
  untouched, missing account), and `checkKnown`. `TestQualification` moved over with the functions
  it tests.
- Full unit suite: `go test -shuffle=on -race -vet=all -failfast` over the `make test` package set
  — passes.
- Container-backed `internal/repositories/postgres/webhooks` — passes.
- `golangci-lint` on the touched packages — clean. (Three pre-existing `govet` inline diagnostics
  in `*/fakes/` under local golangci-lint 2.12.2 are untouched by this change; CI pins 2.10.1.)

## Note on the acceptance criteria

"No `webhooks.Endpoint` literal outside `conversion.go`" holds for production code. Three literals
remain in `dispatcher_test.go`, where they are the values a mocked `webhooks.Store` returns —
simulated storage reads, not conversions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XdmR5SrfLKcCyY3R5gPyzC