### PR TITLE
De-flake the meal planning integration suite: voting deadlines (#1342) and nested read ordering

### DIFF
--- a/backend/cmd/tools/codegen/queries/mealplanning_meal_plan_events.go
+++ b/backend/cmd/tools/codegen/queries/mealplanning_meal_plan_events.go
@@ -129,13 +129,15 @@ GROUP BY %s.%s
 FROM %s
 WHERE
 	%s.%s IS NULL
-	AND %s.%s = sqlc.arg(%s);`,
+	AND %s.%s = sqlc.arg(%s)
+ORDER BY %s.%s ASC;`,
 						strings.Join(applyToEach(mealPlanEventsColumns, func(i int, s string) string {
 							return fmt.Sprintf("%s.%s", mealPlanEventsTableName, s)
 						}), ",\n\t"),
 						mealPlanEventsTableName,
 						mealPlanEventsTableName, archivedAtColumn,
 						mealPlanEventsTableName, belongsToMealPlanColumn, mealPlanIDColumn,
+						mealPlanEventsTableName, idColumn,
 					)),
 				},
 				{

--- a/backend/cmd/tools/codegen/queries/mealplanning_meal_plan_options.go
+++ b/backend/cmd/tools/codegen/queries/mealplanning_meal_plan_options.go
@@ -158,7 +158,8 @@ WHERE
 	AND meal_plan_events.id = sqlc.arg(meal_plan_event_id)
 	AND meal_plan_events.belongs_to_meal_plan = sqlc.arg(meal_plan_id)
 	AND meal_plans.archived_at IS NULL
-	AND meal_plans.id = sqlc.arg(meal_plan_id);`,
+	AND meal_plans.id = sqlc.arg(meal_plan_id)
+ORDER BY meal_plan_options.id ASC;`,
 						strings.Join(fullSelectColumns, ",\n\t"),
 						mealPlanOptionsTableName,
 					)),

--- a/backend/internal/repositories/postgres/mealplanning/generated/meal_plan_events.generated.sql_generated.go
+++ b/backend/internal/repositories/postgres/mealplanning/generated/meal_plan_events.generated.sql_generated.go
@@ -108,6 +108,7 @@ FROM meal_plan_events
 WHERE
 	meal_plan_events.archived_at IS NULL
 	AND meal_plan_events.belongs_to_meal_plan = $1
+ORDER BY meal_plan_events.id ASC
 `
 
 func (q *Queries) GetAllMealPlanEventsForMealPlan(ctx context.Context, db DBTX, mealPlanID string) ([]*MealPlanEvents, error) {

--- a/backend/internal/repositories/postgres/mealplanning/generated/meal_plan_options.generated.sql_generated.go
+++ b/backend/internal/repositories/postgres/mealplanning/generated/meal_plan_options.generated.sql_generated.go
@@ -212,6 +212,7 @@ WHERE
 	AND meal_plan_events.belongs_to_meal_plan = $2
 	AND meal_plans.archived_at IS NULL
 	AND meal_plans.id = $2
+ORDER BY meal_plan_options.id ASC
 `
 
 type GetAllMealPlanOptionsForMealPlanEventParams struct {

--- a/backend/internal/repositories/postgres/mealplanning/sqlc_queries/meal_plan_events.generated.sql
+++ b/backend/internal/repositories/postgres/mealplanning/sqlc_queries/meal_plan_events.generated.sql
@@ -126,7 +126,8 @@ SELECT
 FROM meal_plan_events
 WHERE
 	meal_plan_events.archived_at IS NULL
-	AND meal_plan_events.belongs_to_meal_plan = sqlc.arg(meal_plan_id);
+	AND meal_plan_events.belongs_to_meal_plan = sqlc.arg(meal_plan_id)
+ORDER BY meal_plan_events.id ASC;
 
 -- name: UpdateMealPlanEvent :execrows
 UPDATE meal_plan_events SET

--- a/backend/internal/repositories/postgres/mealplanning/sqlc_queries/meal_plan_options.generated.sql
+++ b/backend/internal/repositories/postgres/mealplanning/sqlc_queries/meal_plan_options.generated.sql
@@ -106,7 +106,8 @@ WHERE
 	AND meal_plan_events.id = sqlc.arg(meal_plan_event_id)
 	AND meal_plan_events.belongs_to_meal_plan = sqlc.arg(meal_plan_id)
 	AND meal_plans.archived_at IS NULL
-	AND meal_plans.id = sqlc.arg(meal_plan_id);
+	AND meal_plans.id = sqlc.arg(meal_plan_id)
+ORDER BY meal_plan_options.id ASC;
 
 -- name: GetMealPlanOptions :many
 SELECT

--- a/backend/testing/integration/apiserver/mealplanning_finalization_helpers.go
+++ b/backend/testing/integration/apiserver/mealplanning_finalization_helpers.go
@@ -25,6 +25,20 @@ const (
 	finalizationPollInterval = 100 * time.Millisecond
 )
 
+// votingDeadlineForSetup is the deadline a test gives a plan it intends to vote on itself.
+//
+// The deadline is a wall-clock budget on everything the test does between creating the plan and
+// casting its last ballot, because the predicate behind GetMealPlansAwaitingFinalizationSaga is
+// database-wide: once a plan's deadline passes while it is still awaiting votes, the next
+// RunFinalizeMealPlanWorker or RunMealPlanTaskCreatorWorker call from *any* parallel test in the
+// package sweeps it up, attaches a saga, and finalizes it. The remaining votes are then refused
+// with "meal plan event is not eligible for voting".
+//
+// An hour is not a wait — no test ever reaches it. It is long enough that no amount of load
+// makes the deadline the thing that fails. Tests that need an expired deadline set one
+// explicitly once they are done voting, which is what actually drives finalization.
+const votingDeadlineForSetup = time.Hour
+
 // awaitMealPlanFinalized waits for the finalization saga's first step to tally a meal plan's
 // ballots and mark it finalized, and returns the plan as it stands afterwards.
 func awaitMealPlanFinalized(t *testing.T, ctx context.Context, c client.Client, mealPlanID string) *mealplanning.MealPlan {

--- a/backend/testing/integration/apiserver/mealplanning_meal_plan_recipe_option_selections_test.go
+++ b/backend/testing/integration/apiserver/mealplanning_meal_plan_recipe_option_selections_test.go
@@ -103,7 +103,7 @@ func TestMealPlans_WithRecipeOptionSelections(T *testing.T) {
 		exampleMealPlan := &mealplanning.MealPlan{
 			Notes:          t.Name(),
 			Status:         string(mealplanning.MealPlanStatusAwaitingVotes),
-			VotingDeadline: now.Add(10 * time.Second),
+			VotingDeadline: now.Add(votingDeadlineForSetup),
 			ElectionMethod: mealplanning.MealPlanElectionMethodSchulze,
 			Events: []*mealplanning.MealPlanEvent{
 				{
@@ -547,7 +547,7 @@ func createMealPlanWithAlternativeIngredientsForSelectionTests(t *testing.T) *se
 		Notes:  t.Name(),
 		Status: string(mealplanning.MealPlanStatusFinalized),
 		// voting deadline must be before every event's start time (events start 24h out); see MealPlanCreationRequestInput.ValidateWithContext.
-		VotingDeadline: now.Add(1 * time.Hour),
+		VotingDeadline: now.Add(votingDeadlineForSetup),
 		ElectionMethod: mealplanning.MealPlanElectionMethodSchulze,
 		Events: []*mealplanning.MealPlanEvent{
 			{

--- a/backend/testing/integration/apiserver/mealplanning_meal_plan_tasks_test.go
+++ b/backend/testing/integration/apiserver/mealplanning_meal_plan_tasks_test.go
@@ -129,7 +129,7 @@ func createFinalizedMealPlanWithTasks(t *testing.T) (string, client.Client) {
 	exampleMealPlan := &mealplanning.MealPlan{
 		Notes:          t.Name(),
 		Status:         string(mealplanning.MealPlanStatusAwaitingVotes),
-		VotingDeadline: now.Add(10 * time.Second),
+		VotingDeadline: now.Add(votingDeadlineForSetup),
 		ElectionMethod: mealplanning.MealPlanElectionMethodSchulze,
 		Events: []*mealplanning.MealPlanEvent{
 			{

--- a/backend/testing/integration/apiserver/mealplanning_meal_plans_test.go
+++ b/backend/testing/integration/apiserver/mealplanning_meal_plans_test.go
@@ -245,13 +245,12 @@ func TestMealPlans_CompleteLifecycleForAllVotesReceived(T *testing.T) {
 			createdMeals = append(createdMeals, createdMeal)
 		}
 
-		const baseDeadline = 10 * time.Second
 		now := time.Now()
 
 		exampleMealPlan := &mealplanning.MealPlan{
 			Notes:          t.Name(),
 			Status:         string(mealplanning.MealPlanStatusAwaitingVotes),
-			VotingDeadline: now.Add(baseDeadline),
+			VotingDeadline: now.Add(votingDeadlineForSetup),
 			ElectionMethod: mealplanning.MealPlanElectionMethodSchulze,
 			Events: []*mealplanning.MealPlanEvent{
 				{
@@ -512,7 +511,7 @@ func TestMealPlans_FinalizeMealPlan(T *testing.T) {
 		exampleMealPlan := &mealplanning.MealPlan{
 			Notes:          t.Name(),
 			Status:         string(mealplanning.MealPlanStatusAwaitingVotes),
-			VotingDeadline: now.Add(10 * time.Second),
+			VotingDeadline: now.Add(votingDeadlineForSetup),
 			ElectionMethod: mealplanning.MealPlanElectionMethodSchulze,
 			Events: []*mealplanning.MealPlanEvent{
 				{
@@ -723,13 +722,12 @@ func TestMealPlans_CompleteLifecycleForSomeVotesReceived(T *testing.T) {
 			createdMeals = append(createdMeals, createdMeal)
 		}
 
-		const baseDeadline = time.Minute
 		now := time.Now()
 
 		exampleMealPlan := &mealplanning.MealPlan{
 			Notes:          t.Name(),
 			Status:         string(mealplanning.MealPlanStatusAwaitingVotes),
-			VotingDeadline: now.Add(baseDeadline),
+			VotingDeadline: now.Add(votingDeadlineForSetup),
 			ElectionMethod: mealplanning.MealPlanElectionMethodSchulze,
 			Events: []*mealplanning.MealPlanEvent{
 				{

--- a/backend/testing/integration/apiserver/mealplanning_recipes_test.go
+++ b/backend/testing/integration/apiserver/mealplanning_recipes_test.go
@@ -934,7 +934,7 @@ func TestRecipes_GetMealPlanTasksForRecipe(T *testing.T) {
 			GroceryListInitialized: true,
 			TasksCreated:           true,
 			// voting deadline must be before every event's start time; see MealPlanCreationRequestInput.ValidateWithContext.
-			VotingDeadline: now.Add(1 * time.Hour),
+			VotingDeadline: now.Add(votingDeadlineForSetup),
 			ElectionMethod: mealplanning.MealPlanElectionMethodSchulze,
 			Events: []*mealplanning.MealPlanEvent{
 				{


### PR DESCRIPTION
Closes #1342. Two independent causes of intermittent failure in the meal planning integration
suite, one test-only and one in the read path. The second was found by this PR's own CI failing
on the first push.

---

## 1. Tests racing their own voting deadline (#1342)

Four tests gave a plan a **10-second** voting deadline and then spent an unbounded amount of wall
clock casting votes against it. The deadline is not what those tests assert on — each forces an
expired one explicitly once voting is done, and that is what actually drives finalization. It was
only a budget on setup, and the shortest in the suite by a factor of thirty.

When setup outran it, the plan sat past its deadline while still `awaiting_votes`, which is
exactly what `GetMealPlansAwaitingFinalizationSaga` matches — and that predicate is database-wide,
not scoped to an account or a test. So the next `RunFinalizeMealPlanWorker` or
`RunMealPlanTaskCreatorWorker` call from *any* parallel test in the package swept the plan up,
attached a saga, and finalized it. The rest of the vote loop then failed with:

```
rpc error: code = FailedPrecondition desc = meal plan event is not eligible for voting
```

One shared `votingDeadlineForSetup = time.Hour` constant now covers every site that budgets a vote
loop, documented in `mealplanning_finalization_helpers.go` next to the finalization poll bounds:

| Site | Was |
|---|---|
| `mealplanning_meal_plan_tasks_test.go:132` | 10s |
| `mealplanning_meal_plan_recipe_option_selections_test.go:106` | 10s |
| `mealplanning_meal_plans_test.go:253` (`baseDeadline`) | 10s |
| `mealplanning_meal_plans_test.go:514` | 10s |
| `mealplanning_meal_plans_test.go:730` (`baseDeadline`) | 1m |
| `mealplanning_meal_plan_recipe_option_selections_test.go:550` | 1h |
| `mealplanning_recipes_test.go:937` | 1h |

The last three are not in the ticket. The two one-hour sites are already the value the ticket
proposes and just move onto the constant. The one-minute site at `:730` is the same defect a
factor of six further out — same shape (create `awaiting_votes`, vote, force the deadline into the
past, finalize), and the subtest that prompted the ticket sat at 34s, so a minute is not a
comfortable margin.

The three five-minute deadlines in `mealplanning_meal_plan_grocery_list_items_test.go` are left
alone: those tests never call `CreateMealPlanOptionVote`, so their deadline is not a budget over a
vote loop.

## 2. The nested meal plan read path had no row order

`GetMealPlan` builds `Events[].Options[]` out of two queries that had no `ORDER BY`:
`GetAllMealPlanEventsForMealPlan` and `GetAllMealPlanOptionsForMealPlanEvent`
(`meal_plan_events.go:120` and `:138`). The order of a plan's events, and of the options within
each event, was whatever Postgres happened to return — arbitrary, and not stable between two reads
of the same plan. **This is a real defect in the read path, not just a test artifact:** any client
reading a meal plan today gets its events and options back in unspecified order.

Their paginated siblings `GetMealPlanEvents` and `GetMealPlanOptions` already order by
`<table>.id ASC`. These two were the only readers of this data that did not, and they are the ones
that build the nested structure every client sees. Both now order the same way, changed in
`cmd/tools/codegen/queries/` and regenerated with `make querier`.

IDs are `rs/xid`, which is k-sortable — a second-resolution timestamp prefix plus a monotonic
per-process counter — so id order is insertion order here, not merely a stable arbitrary one.

This is what failed CI on the first push of this PR, at
`mealplanning_meal_plan_recipe_option_selections_test.go:216`:

```
Error:    Not equal:
          expected: "da37f404fjmohljlt18g"
          actual  : "da37f484fjmohljltjhg"
Messages: expected meal1 to be chosen
```

The test votes rank 0 at `Options[0]` and asserts `meal1` won, so when the rows came back the
other way its four users unanimously elected meal2. The cascading `optionIndex` failure at `:239`
is downstream of the same thing — the grocery list was then built from the wrong meal's recipe.

The test keeps its positional assumption deliberately. It is a guarantee now, and something
should be holding the read path to it.

## Not in this PR

The ticket's second suggestion — that the worker endpoints being global is *why* another test's
plan is reachable for finalization at all, and that scoping the saga starter would kill the class
rather than this instance. That is a larger production change and wants its own ticket.

## Verification

Full package, which is the load condition that produces both flakes:

```
go test -count=1 -p 1 ./testing/integration/apiserver/
```

Note that a green run is consistent with these fixes but does not by itself prove a race is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kza69KHibNZ8y1yfnKYMAS
