### PR TITLE
Web app: move the OAuth2 exchange onto the OAuth 2.1 server (POST /authorize, S256, registered redirect URI)

### DIFF
--- a/frontend/consumer/src/lib/grpc/oauth2.test.ts
+++ b/frontend/consumer/src/lib/grpc/oauth2.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { exchangeJwtForOAuth2Token } from './oauth2';
 
@@ -7,35 +8,125 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
+/** Stubs the pair of calls the flow makes, returning the recorded fetch mock. */
+function stubOAuthServer(tokenResponse?: () => Response) {
+  const fetchMock = vi.fn(async (input: string, _init?: RequestInit) => {
+    const url = String(input);
+    if (url.includes('/authorize')) {
+      // The 302 carries the code, the echoed state, and `iss` (RFC 9207).
+      return new Response(null, {
+        status: 302,
+        headers: {
+          location: `${AUTH_SERVER}/?code=the-code&state=xyz&iss=${encodeURIComponent(AUTH_SERVER)}`,
+        },
+      });
+    }
+    if (url.includes('/token')) {
+      return (
+        tokenResponse?.() ??
+        new Response(JSON.stringify({ access_token: 'access-123', refresh_token: 'refresh-456', expires_in: 900 }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+      );
+    }
+    throw new Error(`unexpected url ${url}`);
+  });
+  vi.stubGlobal('fetch', fetchMock);
+
+  return fetchMock;
+}
+
+type FetchCall = [string, RequestInit | undefined];
+
+function callFor(fetchMock: ReturnType<typeof stubOAuthServer>, path: string): FetchCall {
+  const call = fetchMock.mock.calls.find(([u]) => new URL(String(u)).pathname === path);
+  if (!call) {
+    throw new Error(`no request to ${path}`);
+  }
+
+  return call as unknown as FetchCall;
+}
+
 describe('exchangeJwtForOAuth2Token', () => {
   it('exchanges a JWT for an OAuth2 access token', async () => {
-    const fetchMock = vi.fn(async (input: string, _init?: RequestInit) => {
-      const url = String(input);
-      if (url.includes('/oauth2/authorize')) {
-        return new Response(null, {
-          status: 302,
-          headers: { location: `${AUTH_SERVER}/?code=the-code&state=xyz` },
-        });
-      }
-      if (url.includes('/oauth2/token')) {
-        return new Response(
-          JSON.stringify({ access_token: 'access-123', refresh_token: 'refresh-456', expires_in: 3600 }),
-          { status: 200, headers: { 'content-type': 'application/json' } },
-        );
-      }
-      throw new Error(`unexpected url ${url}`);
-    });
-    vi.stubGlobal('fetch', fetchMock);
+    const fetchMock = stubOAuthServer();
 
     const result = await exchangeJwtForOAuth2Token(AUTH_SERVER, 'client-id', 'client-secret', 'jwt-token');
 
-    expect(result).toEqual({ accessToken: 'access-123', refreshToken: 'refresh-456', expiresIn: 3600 });
+    expect(result).toEqual({ accessToken: 'access-123', refreshToken: 'refresh-456', expiresIn: 900 });
 
     // The authorize call carries the JWT as a bearer; the token call posts the code from the redirect.
-    const authorizeCall = fetchMock.mock.calls.find(([u]) => String(u).includes('/oauth2/authorize'));
-    expect(new Headers((authorizeCall?.[1] as RequestInit)?.headers).get('authorization')).toBe('Bearer jwt-token');
-    const tokenCall = fetchMock.mock.calls.find(([u]) => String(u).includes('/oauth2/token'));
-    expect(String((tokenCall?.[1] as RequestInit)?.body)).toContain('code=the-code');
+    const [, authorizeInit] = callFor(fetchMock, '/authorize');
+    expect(new Headers(authorizeInit?.headers).get('authorization')).toBe('Bearer jwt-token');
+    const [, tokenInit] = callFor(fetchMock, '/token');
+    expect(new URLSearchParams(String(tokenInit?.body)).get('code')).toBe('the-code');
+  });
+
+  it('authorizes at POST /authorize, not GET /oauth2/authorize', async () => {
+    // A GET renders the login form; only a POST runs the authenticator that reads the bearer.
+    const fetchMock = stubOAuthServer();
+
+    await exchangeJwtForOAuth2Token(AUTH_SERVER, 'client-id', 'client-secret', 'jwt-token');
+
+    const [authorizeUrl, authorizeInit] = callFor(fetchMock, '/authorize');
+    expect(authorizeInit?.method).toBe('POST');
+    // The authorization parameters stay in the query string, and nothing travels in a body.
+    expect(new URL(authorizeUrl).searchParams.get('response_type')).toBe('code');
+    expect(authorizeInit?.body).toBeUndefined();
+
+    const [tokenUrl] = callFor(fetchMock, '/token');
+    expect(tokenUrl).toBe(`${AUTH_SERVER}/token`);
+  });
+
+  it('sends an S256 PKCE challenge and redeems it with the matching verifier', async () => {
+    const fetchMock = stubOAuthServer();
+
+    await exchangeJwtForOAuth2Token(AUTH_SERVER, 'client-id', 'client-secret', 'jwt-token');
+
+    const [authorizeUrl] = callFor(fetchMock, '/authorize');
+    const params = new URL(authorizeUrl).searchParams;
+    expect(params.get('code_challenge_method')).toBe('S256');
+
+    const challenge = params.get('code_challenge') ?? '';
+    // 43 unpadded base64url characters is the shape the server checks a challenge for.
+    expect(challenge).toMatch(/^[A-Za-z0-9_-]{43}$/);
+
+    const [, tokenInit] = callFor(fetchMock, '/token');
+    const verifier = new URLSearchParams(String(tokenInit?.body)).get('code_verifier') ?? '';
+    expect(verifier).toMatch(/^[A-Za-z0-9_-]{43}$/);
+    expect(createHash('sha256').update(verifier).digest('base64url')).toBe(challenge);
+  });
+
+  it('sends a fresh verifier and state on each exchange', async () => {
+    const fetchMock = stubOAuthServer();
+
+    await exchangeJwtForOAuth2Token(AUTH_SERVER, 'client-id', 'client-secret', 'jwt-token');
+    const first = new URL(callFor(fetchMock, '/authorize')[0]).searchParams;
+    const firstVerifier = new URLSearchParams(String(callFor(fetchMock, '/token')[1]?.body)).get('code_verifier');
+    fetchMock.mockClear();
+
+    await exchangeJwtForOAuth2Token(AUTH_SERVER, 'client-id', 'client-secret', 'jwt-token');
+    const second = new URL(callFor(fetchMock, '/authorize')[0]).searchParams;
+    const secondVerifier = new URLSearchParams(String(callFor(fetchMock, '/token')[1]?.body)).get('code_verifier');
+
+    expect(second.get('code_challenge')).not.toBe(first.get('code_challenge'));
+    expect(secondVerifier).not.toBe(firstVerifier);
+    expect(second.get('state')).not.toBe(first.get('state'));
+  });
+
+  it('sends the same registered redirect URI at both steps', async () => {
+    // Matching is byte for byte at /authorize and again at /token, so the two must agree
+    // exactly with the URI registered for the client.
+    const fetchMock = stubOAuthServer();
+
+    await exchangeJwtForOAuth2Token(AUTH_SERVER, 'client-id', 'client-secret', 'jwt-token');
+
+    const authorizeRedirect = new URL(callFor(fetchMock, '/authorize')[0]).searchParams.get('redirect_uri');
+    const tokenRedirect = new URLSearchParams(String(callFor(fetchMock, '/token')[1]?.body)).get('redirect_uri');
+
+    expect(authorizeRedirect).toBe(AUTH_SERVER);
+    expect(tokenRedirect).toBe(AUTH_SERVER);
   });
 
   it('throws when the authorize step returns no redirect location', async () => {
@@ -50,22 +141,13 @@ describe('exchangeJwtForOAuth2Token', () => {
   });
 
   it('throws when the token exchange returns a non-2xx status', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn(async (input: string) => {
-        const url = String(input);
-        if (url.includes('/oauth2/authorize')) {
-          return new Response(null, {
-            status: 302,
-            headers: { location: `${AUTH_SERVER}/?code=the-code` },
-          });
-        }
-        // OAuth2 token endpoints return JSON error bodies (RFC 6749 §5.2).
-        return new Response(JSON.stringify({ error: 'invalid_grant' }), {
+    // OAuth2 token endpoints return JSON error bodies (RFC 6749 §5.2).
+    stubOAuthServer(
+      () =>
+        new Response(JSON.stringify({ error: 'invalid_grant' }), {
           status: 400,
           headers: { 'content-type': 'application/json' },
-        });
-      }),
+        }),
     );
 
     await expect(exchangeJwtForOAuth2Token(AUTH_SERVER, 'id', 'secret', 'jwt')).rejects.toThrow(

--- a/frontend/consumer/src/lib/grpc/oauth2.ts
+++ b/frontend/consumer/src/lib/grpc/oauth2.ts
@@ -3,7 +3,7 @@
  * Uses JWT (from LoginForToken) as Bearer token to obtain OAuth2 access token for gRPC.
  */
 
-import { randomBytes } from 'node:crypto';
+import { createHash, randomBytes } from 'node:crypto';
 import { PlatformError } from '@primandproper/errors';
 import { FetchHttpClient, type FetchLike } from '@primandproper/httpclient';
 import { observabilityDeps } from '$lib/observability';
@@ -39,9 +39,23 @@ const oauthHttp = new FetchHttpClient(
 );
 
 /**
+ * Generates a PKCE (RFC 7636) verifier and its S256 challenge. The authorization server requires
+ * a challenge and accepts S256 only — a missing method is refused rather than defaulted, because
+ * RFC 7636 defaults it to `plain`, which this server does not accept at all.
+ *
+ * 32 random bytes encode to 43 unpadded base64url characters, which is both a legal verifier and
+ * the exact shape the server checks an S256 challenge for.
+ */
+function generatePkcePair(): { verifier: string; challenge: string } {
+  const verifier = randomBytes(32).toString('base64url');
+
+  return { verifier, challenge: createHash('sha256').update(verifier).digest('base64url') };
+}
+
+/**
  * Exchanges JWT (from LoginForToken) for OAuth2 access token via authorization code flow.
- * 1. GET /oauth2/authorize with Bearer JWT -> redirect with ?code=...
- * 2. POST /oauth2/token with code -> OAuth2 access token
+ * 1. POST /authorize with Bearer JWT -> redirect with ?code=...
+ * 2. POST /token with the code and the PKCE verifier -> OAuth2 access token
  */
 export async function exchangeJwtForOAuth2Token(
   authServerUrl: string,
@@ -50,15 +64,30 @@ export async function exchangeJwtForOAuth2Token(
   jwt: string,
 ): Promise<OAuth2TokenResult> {
   const state = randomBytes(32).toString('base64url');
-  const authUrl = new URL('/oauth2/authorize', authServerUrl);
+  const { verifier, challenge } = generatePkcePair();
+
+  const authUrl = new URL('/authorize', authServerUrl);
   authUrl.searchParams.set('response_type', 'code');
   authUrl.searchParams.set('client_id', clientId);
+  // Matched byte for byte against the client's registered redirect_uris here, and again at
+  // /token against the URI the code was issued for — not by hostname, not ignoring ports.
+  // `ddb-bootstrap init` registers `--api-server-url` for every first-party client, so this
+  // string has to be that one exactly, trailing slash included.
   authUrl.searchParams.set('redirect_uri', authServerUrl);
   authUrl.searchParams.set('state', state);
-  authUrl.searchParams.set('code_challenge_method', 'plain');
+  authUrl.searchParams.set('code_challenge', challenge);
+  authUrl.searchParams.set('code_challenge_method', 'S256');
 
-  const authRes = await oauthHttp.get(authUrl.toString(), {
-    headers: { Authorization: `Bearer ${jwt}` },
+  // POST rather than GET: a GET renders the login form — the answer for a browser arriving
+  // without a session — and only a POST runs the authenticator that reads this bearer token.
+  // The authorization parameters stay in the query string on both, so the request that issues
+  // the code is the one that was validated. No body travels with it; the content type keeps the
+  // request well-formed for a server that parses the form on every request.
+  const authRes = await oauthHttp.post(authUrl.toString(), undefined, {
+    headers: {
+      'Authorization': `Bearer ${jwt}`,
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
   });
 
   const location = authRes.headers.get('location');
@@ -66,13 +95,15 @@ export async function exchangeJwtForOAuth2Token(
     throw new PlatformError('oauth2/no-redirect', 'No redirect location from oauth2 authorize');
   }
 
+  // The redirect also carries `iss` (RFC 9207) alongside the code and state. Nothing here reads
+  // it; it is not an error parameter.
   const redirectUrl = new URL(location, authServerUrl);
   const code = redirectUrl.searchParams.get('code');
   if (!code) {
     throw new PlatformError('oauth2/no-code', 'Code not returned from oauth2 redirect');
   }
 
-  const tokenUrl = `${authServerUrl.replace(/\/$/, '')}/oauth2/token`;
+  const tokenUrl = `${authServerUrl.replace(/\/$/, '')}/token`;
   const tokenRes = await oauthHttp.post<OAuth2TokenResponse>(
     tokenUrl,
     new URLSearchParams({
@@ -81,6 +112,7 @@ export async function exchangeJwtForOAuth2Token(
       redirect_uri: authServerUrl,
       client_id: clientId,
       client_secret: clientSecret,
+      code_verifier: verifier,
     }),
     { headers: { 'Content-Type': 'application/x-www-form-urlencoded' } },
   );


### PR DESCRIPTION
Closes #1344. Follows #1343, which moved the API server onto platform's `oauth2server`; the consumer web app's exchange in `frontend/consumer/src/lib/grpc/oauth2.ts` did not work against the new server.

## What changed

**Paths and method.** `/oauth2/authorize` → `/authorize`, `/oauth2/token` → `/token`, and the authorize call is a `POST`. The method is the load-bearing part: a `GET /authorize` renders the login form — the answer for a browser arriving without a session — and only a `POST` runs the authenticator that reads the bearer token. The authorization parameters stay in the query string, so nothing moved into a body and the request that issues the code is the one that was validated. The `Content-Type: application/x-www-form-urlencoded` header goes along for the same reason it does in the Go client: the server parses the form on every request, and a bodiless POST with the header is well-formed rather than accidentally acceptable.

**PKCE is S256.** The app sent `code_challenge_method=plain` and no `code_challenge` at all. It now derives a 43-character base64url verifier from 32 random bytes, sends its SHA-256 digest as the challenge with `code_challenge_method=S256`, and redeems it with `code_verifier` on the token request. `node:crypto`'s `createHash` rather than `crypto.subtle.digest` — this runs server-side, `randomBytes` was already imported from there, and it keeps the helper synchronous.

**Redirect URI.** No code change: the app already sends `redirect_uri = authServerUrl`, which is what has to be registered. Confirmed the registration matches — `ddb-bootstrap init` registers `--api-server-url` for every first-party client, defaulting to `https://http-api.dinnerdonebetter.com`, which is exactly `HTTP_API_SERVER_URL` in `frontend/deploy/environments/prod`, no trailing slash on either side; localdev's pair agrees too. A comment on the parameter records that the match is byte for byte at both steps.

## The other things the issue asked about

- **15-minute access tokens.** Nothing to change. `hooks.server.ts` runs this exchange on every request rather than caching the OAuth2 token, so the shorter lifetime never comes up. The refresh path it does have is the session JWT's, over gRPC `exchangeToken`, and it already writes the rotated refresh token back to the cookie.
- **`iss` on the 302** (RFC 9207) is read past, not treated as an error; noted in a comment and covered by the test stub.
- Endpoints stay hardcoded rather than read from discovery — two constants against a round trip on every request.

## Tests

`frontend/consumer/src/lib/grpc/oauth2.test.ts`, rewritten around the new flow: the happy path, `POST /authorize` with the parameters in the query and no body, an S256 challenge that verifies against the verifier the token request sends, a fresh verifier and state per exchange, the same redirect URI at both steps, and the two existing error cases.

`npm run test:run` (consumer, 8 passing), `npm run lint` (clean), `npm run check` (0 errors; the 35 warnings are pre-existing in unrelated `.svelte` files), and `npm run format:check` at the frontend root all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)