### PR TITLE
iOS: move the OAuth2 exchange onto the OAuth 2.1 server (POST /authorize, S256, registered redirect URI)

### DIFF
--- a/ios/ios/Services/Auth/AuthenticationManager.swift
+++ b/ios/ios/Services/Auth/AuthenticationManager.swift
@@ -443,26 +443,22 @@ class AuthenticationManager: AuthenticationManaging {
     // Generate state for OAuth2 flow
     let state = UUID().uuidString
 
-    // Build authorization URL
-    guard var components = URLComponents(string: APIConfiguration.oauth2AuthorizeURL) else {
-      return (false, "Failed to build authorization URL")
-    }
-    components.queryItems = [
-      URLQueryItem(name: "response_type", value: "code"),
-      URLQueryItem(name: "client_id", value: await oauth2ClientID()),
-      URLQueryItem(name: "redirect_uri", value: APIConfiguration.serverURL),
-      URLQueryItem(name: "state", value: state),
-      URLQueryItem(name: "code_challenge_method", value: "plain"),
-    ]
-
-    guard let authURL = components.url else {
-      return (false, "Failed to build authorization URL")
-    }
+    // PKCE, held across both legs: the challenge goes to /authorize, the verifier to /token.
+    let pkce = PKCE()
 
     // Step 1: Get authorization code
-    var request = URLRequest(url: authURL)
-    request.httpMethod = "GET"
-    request.setValue("Bearer \(jwtToken)", forHTTPHeaderField: "Authorization")
+    guard
+      let request = OAuth2Exchange.authorizationRequest(
+        authorizeURL: APIConfiguration.oauth2AuthorizeURL,
+        bearerToken: jwtToken,
+        clientID: await oauth2ClientID(),
+        redirectURI: APIConfiguration.oauth2RedirectURI,
+        state: state,
+        challenge: pkce.challenge
+      )
+    else {
+      return (false, "Failed to build authorization URL")
+    }
 
     // Configure session to not follow redirects
     let delegate = NoRedirectDelegate()
@@ -492,7 +488,7 @@ class AuthenticationManager: AuthenticationManaging {
       print("📝 Received OAuth2 authorization code")
 
       // Step 2: Exchange code for access token
-      return await exchangeCodeForToken(code: code)
+      return await exchangeCodeForToken(code: code, codeVerifier: pkce.verifier)
     } catch {
       print("❌ Error getting authorization code: \(error)")
       return (false, "Failed to get authorization code: \(error.localizedDescription)")
@@ -500,30 +496,21 @@ class AuthenticationManager: AuthenticationManaging {
   }
 
   /// Exchange OAuth2 authorization code for access token
-  private func exchangeCodeForToken(code: String) async -> (success: Bool, error: String?) {
-    guard let tokenURL = URL(string: APIConfiguration.oauth2TokenURL) else {
+  private func exchangeCodeForToken(code: String, codeVerifier: String) async -> (
+    success: Bool, error: String?
+  ) {
+    guard
+      let request = OAuth2Exchange.tokenRequest(
+        tokenURL: APIConfiguration.oauth2TokenURL,
+        clientID: await oauth2ClientID(),
+        clientSecret: await oauth2ClientSecret(),
+        code: code,
+        codeVerifier: codeVerifier,
+        redirectURI: APIConfiguration.oauth2RedirectURI
+      )
+    else {
       return (false, "Invalid token URL")
     }
-
-    var request = URLRequest(url: tokenURL)
-    request.httpMethod = "POST"
-    request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
-
-    // Build form data
-    let formData = [
-      "grant_type": "authorization_code",
-      "code": code,
-      "redirect_uri": APIConfiguration.serverURL,
-      "client_id": await oauth2ClientID(),
-      "client_secret": await oauth2ClientSecret(),
-    ]
-
-    // Encode form data
-    let formString = formData.map {
-      "\($0.key)=\($0.value.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? $0.value)"
-    }
-    .joined(separator: "&")
-    request.httpBody = formString.data(using: .utf8)
 
     do {
       let (data, response) = try await URLSession.shared.data(for: request)
@@ -545,15 +532,20 @@ class AuthenticationManager: AuthenticationManaging {
       }
 
       let refreshToken = json["refresh_token"] as? String ?? ""
-      let expiresIn = json["expires_in"] as? Int ?? 86400  // Default to 24 hours
+      let expiresIn =
+        (json["expires_in"] as? Int).map { TimeInterval($0) }
+        ?? OAuth2Exchange.defaultAccessTokenLifetime
 
       // Calculate expiration time
-      let expiresAt = Date().addingTimeInterval(TimeInterval(expiresIn))
+      let expiresAt = Date().addingTimeInterval(expiresIn)
 
       await MainActor.run {
         self.oauth2AccessToken = accessToken
         self.oauth2RefreshToken = refreshToken
         self.oauth2TokenExpiresAt = expiresAt
+        // Refresh tokens rotate, so the freshly issued one has to replace whatever is in the
+        // Keychain. Presenting a spent one revokes the whole family and forces a re-login.
+        self.persistCredentials()
       }
 
       return (true, nil)
@@ -582,28 +574,17 @@ class AuthenticationManager: AuthenticationManaging {
       return false
     }
 
-    guard let tokenURL = URL(string: APIConfiguration.oauth2TokenURL) else {
+    guard
+      let request = OAuth2Exchange.refreshRequest(
+        tokenURL: APIConfiguration.oauth2TokenURL,
+        clientID: await oauth2ClientID(),
+        clientSecret: await oauth2ClientSecret(),
+        refreshToken: oauth2RefreshToken
+      )
+    else {
       print("❌ Invalid token URL")
       return false
     }
-
-    var request = URLRequest(url: tokenURL)
-    request.httpMethod = "POST"
-    request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
-
-    // Build form data for refresh
-    let formData = [
-      "grant_type": "refresh_token",
-      "refresh_token": oauth2RefreshToken,
-      "client_id": await oauth2ClientID(),
-      "client_secret": await oauth2ClientSecret(),
-    ]
-
-    let formString = formData.map {
-      "\($0.key)=\($0.value.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? $0.value)"
-    }
-    .joined(separator: "&")
-    request.httpBody = formString.data(using: .utf8)
 
     do {
       let (data, response) = try await URLSession.shared.data(for: request)
@@ -623,8 +604,10 @@ class AuthenticationManager: AuthenticationManaging {
       }
 
       let refreshToken = json["refresh_token"] as? String ?? oauth2RefreshToken
-      let expiresIn = json["expires_in"] as? Int ?? 86400
-      let expiresAt = Date().addingTimeInterval(TimeInterval(expiresIn))
+      let expiresIn =
+        (json["expires_in"] as? Int).map { TimeInterval($0) }
+        ?? OAuth2Exchange.defaultAccessTokenLifetime
+      let expiresAt = Date().addingTimeInterval(expiresIn)
 
       await MainActor.run {
         self.oauth2AccessToken = accessToken

--- a/ios/ios/Services/Auth/OAuth2Exchange.swift
+++ b/ios/ios/Services/Auth/OAuth2Exchange.swift
@@ -1,0 +1,167 @@
+//
+//  OAuth2Exchange.swift
+//  ios
+//
+//  The wire format of the OAuth 2.1 authorization code exchange, kept apart from
+//  AuthenticationManager so each step's request can be asserted directly in tests.
+//
+
+import CryptoKit
+import Foundation
+
+/// A PKCE (RFC 7636) verifier and the S256 challenge derived from it.
+///
+/// The authorization server requires a challenge and accepts `S256` only. An absent
+/// `code_challenge_method` is refused rather than defaulted, because RFC 7636 defaults it to
+/// `plain`.
+struct PKCE {
+  /// The only challenge method the authorization server accepts.
+  static let challengeMethod = "S256"
+
+  /// The high-entropy secret, replayed on the token request to prove the code is ours.
+  let verifier: String
+
+  /// `base64url(SHA256(verifier))`, sent on the authorization request.
+  var challenge: String {
+    Self.base64URLEncoded(Data(SHA256.hash(data: Data(verifier.utf8))))
+  }
+
+  /// Generates a fresh verifier: 32 random bytes, base64url-encoded to 43 characters, the low
+  /// end of the 43–128 RFC 7636 allows.
+  init() {
+    let bytes = SymmetricKey(size: .bits256).withUnsafeBytes { Data($0) }
+    self.verifier = Self.base64URLEncoded(bytes)
+  }
+
+  /// Wraps a caller-supplied verifier, so tests can pin the RFC 7636 vector.
+  init(verifier: String) {
+    self.verifier = verifier
+  }
+
+  /// base64url per RFC 4648 §5, unpadded, as RFC 7636 §4.2 requires.
+  static func base64URLEncoded(_ data: Data) -> String {
+    data.base64EncodedString()
+      .replacingOccurrences(of: "+", with: "-")
+      .replacingOccurrences(of: "/", with: "_")
+      .replacingOccurrences(of: "=", with: "")
+  }
+}
+
+/// Builds the HTTP requests of the authorization code exchange against the OAuth 2.1 server.
+enum OAuth2Exchange {
+  /// Lifetime assumed when a token response omits `expires_in`. Access tokens are 15 minutes;
+  /// assuming longer would leave the app presenting a dead token instead of refreshing.
+  static let defaultAccessTokenLifetime: TimeInterval = 900
+
+  /// The authorization request that issues a code.
+  ///
+  /// POST, not GET: a `GET /authorize` renders an HTML login form — the answer for a browser
+  /// arriving without a session — and only a POST runs the authenticator that reads the bearer
+  /// token. The authorization parameters stay in the query string either way, so nothing moves
+  /// into a body.
+  ///
+  /// - Parameter redirectURI: matched byte for byte against the client's registered URIs, so it
+  ///   must be one of them exactly, trailing slash included.
+  static func authorizationRequest(
+    authorizeURL: String,
+    bearerToken: String,
+    clientID: String,
+    redirectURI: String,
+    state: String,
+    challenge: String
+  ) -> URLRequest? {
+    guard var components = URLComponents(string: authorizeURL) else { return nil }
+
+    components.queryItems = [
+      URLQueryItem(name: "response_type", value: "code"),
+      URLQueryItem(name: "client_id", value: clientID),
+      URLQueryItem(name: "redirect_uri", value: redirectURI),
+      URLQueryItem(name: "state", value: state),
+      URLQueryItem(name: "code_challenge", value: challenge),
+      URLQueryItem(name: "code_challenge_method", value: PKCE.challengeMethod),
+    ]
+
+    guard let url = components.url else { return nil }
+
+    var request = URLRequest(url: url)
+    request.httpMethod = "POST"
+    request.setValue("Bearer \(bearerToken)", forHTTPHeaderField: "Authorization")
+    request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+
+    return request
+  }
+
+  /// The request that redeems an authorization code. `redirect_uri` is checked again here,
+  /// byte for byte against the one the code was issued for, and `code_verifier` against the
+  /// challenge that came with it.
+  static func tokenRequest(
+    tokenURL: String,
+    clientID: String,
+    clientSecret: String,
+    code: String,
+    codeVerifier: String,
+    redirectURI: String
+  ) -> URLRequest? {
+    formPost(
+      url: tokenURL,
+      parameters: [
+        "grant_type": "authorization_code",
+        "code": code,
+        "code_verifier": codeVerifier,
+        "redirect_uri": redirectURI,
+        "client_id": clientID,
+        "client_secret": clientSecret,
+      ]
+    )
+  }
+
+  /// The request that trades a refresh token for a new pair. Refresh tokens rotate: the token
+  /// in the response replaces the stored one, and presenting a spent one revokes the whole
+  /// family and forces a full re-login.
+  static func refreshRequest(
+    tokenURL: String,
+    clientID: String,
+    clientSecret: String,
+    refreshToken: String
+  ) -> URLRequest? {
+    formPost(
+      url: tokenURL,
+      parameters: [
+        "grant_type": "refresh_token",
+        "refresh_token": refreshToken,
+        "client_id": clientID,
+        "client_secret": clientSecret,
+      ]
+    )
+  }
+
+  /// Encodes an `application/x-www-form-urlencoded` body. Keys are sorted so the body is a
+  /// function of its parameters alone.
+  static func formEncoded(_ parameters: [String: String]) -> String {
+    parameters
+      .sorted { $0.key < $1.key }
+      .map { "\(percentEncoded($0.key))=\(percentEncoded($0.value))" }
+      .joined(separator: "&")
+  }
+
+  private static func formPost(url: String, parameters: [String: String]) -> URLRequest? {
+    guard let url = URL(string: url) else { return nil }
+
+    var request = URLRequest(url: url)
+    request.httpMethod = "POST"
+    request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+    request.httpBody = formEncoded(parameters).data(using: .utf8)
+
+    return request
+  }
+
+  /// Everything outside RFC 3986's unreserved set is escaped. `.urlQueryAllowed` would leave
+  /// `+`, `&`, `=` and `/` alone, and all four carry meaning in a form body — a client secret
+  /// containing one would arrive mangled or split into another parameter.
+  private static let unreservedCharacters = CharacterSet(
+    charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~")
+
+  private static func percentEncoded(_ value: String) -> String {
+    value.addingPercentEncoding(withAllowedCharacters: unreservedCharacters) ?? value
+  }
+}

--- a/ios/ios/Services/Networking/APIConfiguration.swift
+++ b/ios/ios/Services/Networking/APIConfiguration.swift
@@ -153,13 +153,23 @@ struct APIConfiguration {
     Bundle.main.infoDictionary?["OAuth2ClientSecret"] as? String ?? ""
   }
 
-  // OAuth2 endpoints
+  // OAuth2 endpoints, as served by the OAuth 2.1 authorization server.
   static var oauth2AuthorizeURL: String {
-    return "\(serverURL)/oauth2/authorize"
+    return "\(serverURL)/authorize"
   }
 
   static var oauth2TokenURL: String {
-    return "\(serverURL)/oauth2/token"
+    return "\(serverURL)/token"
+  }
+
+  /// The redirect URI sent at `/authorize` and again at `/token`.
+  ///
+  /// Nothing listens here: the authorization code is read off the `Location` header of the 302
+  /// rather than followed. It is matched byte for byte against the client's registered URIs,
+  /// so it has to be `serverURL` exactly — the address `ddb-bootstrap init --api-server-url`
+  /// registers for every first-party client.
+  static var oauth2RedirectURI: String {
+    return serverURL
   }
 }
 

--- a/ios/iosTests/OAuth2ExchangeTests.swift
+++ b/ios/iosTests/OAuth2ExchangeTests.swift
@@ -1,0 +1,229 @@
+//
+//  OAuth2ExchangeTests.swift
+//  iosTests
+//
+//  Covers the wire format of the OAuth 2.1 authorization code exchange: the parts the
+//  authorization server refuses outright if the app gets them wrong.
+//
+
+import Foundation
+@testable import ios
+import Testing
+
+struct OAuth2ExchangeTests {
+    // MARK: - Helpers
+
+    /// Query parameters of a request's URL, as a dictionary.
+    private func queryParameters(of request: URLRequest) -> [String: String] {
+        guard let url = request.url,
+            let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+            let items = components.queryItems
+        else {
+            return [:]
+        }
+        return items.reduce(into: [:]) { $0[$1.name] = $1.value }
+    }
+
+    /// Form parameters of a request's `application/x-www-form-urlencoded` body.
+    private func bodyParameters(of request: URLRequest) -> [String: String] {
+        guard let body = request.httpBody, let encoded = String(data: body, encoding: .utf8) else {
+            return [:]
+        }
+        return encoded.split(separator: "&").reduce(into: [:]) { result, pair in
+            let halves = pair.split(separator: "=", maxSplits: 1)
+            guard halves.count == 2 else { return }
+            let name = String(halves[0]).removingPercentEncoding ?? String(halves[0])
+            let value = String(halves[1]).removingPercentEncoding ?? String(halves[1])
+            result[name] = value
+        }
+    }
+
+    // MARK: - PKCE
+
+    @Test("PKCE derives the RFC 7636 Appendix B challenge from its verifier")
+    func testPKCEMatchesRFCVector() {
+        let pkce = PKCE(verifier: "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk")
+
+        #expect(pkce.challenge == "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM")
+    }
+
+    @Test("PKCE challenge method is S256, the only one the server accepts")
+    func testPKCEChallengeMethodIsS256() {
+        #expect(PKCE.challengeMethod == "S256")
+    }
+
+    @Test("base64url encoding is unpadded and uses the URL-safe alphabet")
+    func testBase64URLEncoding() {
+        let encoded = PKCE.base64URLEncoded(Data((0..<32).map { UInt8($0) }))
+
+        #expect(encoded == "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8")
+        #expect(!encoded.contains("="))
+        #expect(!encoded.contains("+"))
+        #expect(!encoded.contains("/"))
+    }
+
+    @Test("Generated verifiers are unpadded base64url within the RFC 7636 length range")
+    func testGeneratedVerifierShape() {
+        let verifier = PKCE().verifier
+
+        #expect(verifier.count >= 43)
+        #expect(verifier.count <= 128)
+        #expect(!verifier.contains("="))
+        #expect(!verifier.contains("+"))
+        #expect(!verifier.contains("/"))
+    }
+
+    @Test("Each PKCE instance generates a distinct verifier")
+    func testGeneratedVerifiersAreDistinct() {
+        let verifiers = Set((0..<16).map { _ in PKCE().verifier })
+
+        #expect(verifiers.count == 16)
+    }
+
+    @Test("A generated verifier's challenge is not the verifier itself")
+    func testGeneratedChallengeIsHashed() {
+        let pkce = PKCE()
+
+        #expect(pkce.challenge != pkce.verifier)
+        #expect(pkce.challenge.count == 43)
+    }
+
+    // MARK: - Authorization request
+
+    private func authorizationRequest(
+        challenge: String = "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
+    ) -> URLRequest? {
+        OAuth2Exchange.authorizationRequest(
+            authorizeURL: "https://api.example.com/authorize",
+            bearerToken: "jwt-token",
+            clientID: "client-id",
+            redirectURI: "https://api.example.com",
+            state: "state-value",
+            challenge: challenge
+        )
+    }
+
+    @Test("Authorization request is a POST, so the server authenticates instead of rendering a form")
+    func testAuthorizationRequestIsPOST() throws {
+        let request = try #require(authorizationRequest())
+
+        #expect(request.httpMethod == "POST")
+        #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer jwt-token")
+        #expect(
+            request.value(forHTTPHeaderField: "Content-Type") == "application/x-www-form-urlencoded")
+    }
+
+    @Test("Authorization parameters stay in the query string, not the body")
+    func testAuthorizationParametersAreInTheQuery() throws {
+        let request = try #require(authorizationRequest())
+        let query = queryParameters(of: request)
+
+        #expect(request.httpBody == nil)
+        #expect(query["response_type"] == "code")
+        #expect(query["client_id"] == "client-id")
+        #expect(query["redirect_uri"] == "https://api.example.com")
+        #expect(query["state"] == "state-value")
+    }
+
+    @Test("Authorization request sends an S256 challenge, never plain")
+    func testAuthorizationRequestSendsS256Challenge() throws {
+        let request = try #require(authorizationRequest())
+        let query = queryParameters(of: request)
+
+        #expect(query["code_challenge"] == "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM")
+        #expect(query["code_challenge_method"] == "S256")
+    }
+
+    // MARK: - Token request
+
+    private func tokenRequest(clientSecret: String = "client-secret") -> URLRequest? {
+        OAuth2Exchange.tokenRequest(
+            tokenURL: "https://api.example.com/token",
+            clientID: "client-id",
+            clientSecret: clientSecret,
+            code: "auth-code",
+            codeVerifier: "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk",
+            redirectURI: "https://api.example.com"
+        )
+    }
+
+    @Test("Token request posts the code alongside its verifier and redirect URI")
+    func testTokenRequestBody() throws {
+        let request = try #require(tokenRequest())
+        let body = bodyParameters(of: request)
+
+        #expect(request.httpMethod == "POST")
+        #expect(
+            request.value(forHTTPHeaderField: "Content-Type") == "application/x-www-form-urlencoded")
+        #expect(body["grant_type"] == "authorization_code")
+        #expect(body["code"] == "auth-code")
+        #expect(body["code_verifier"] == "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk")
+        #expect(body["redirect_uri"] == "https://api.example.com")
+        #expect(body["client_id"] == "client-id")
+        #expect(body["client_secret"] == "client-secret")
+    }
+
+    @Test("Token request escapes secrets that contain form-significant characters")
+    func testTokenRequestEscapesSecret() throws {
+        let request = try #require(tokenRequest(clientSecret: "a+b&c=d/e"))
+
+        #expect(bodyParameters(of: request)["client_secret"] == "a+b&c=d/e")
+    }
+
+    @Test("Refresh request presents the stored refresh token")
+    func testRefreshRequestBody() throws {
+        let request = try #require(
+            OAuth2Exchange.refreshRequest(
+                tokenURL: "https://api.example.com/token",
+                clientID: "client-id",
+                clientSecret: "client-secret",
+                refreshToken: "refresh-token"
+            ))
+        let body = bodyParameters(of: request)
+
+        #expect(request.httpMethod == "POST")
+        #expect(body["grant_type"] == "refresh_token")
+        #expect(body["refresh_token"] == "refresh-token")
+        #expect(body["client_id"] == "client-id")
+        #expect(body["client_secret"] == "client-secret")
+    }
+
+    // MARK: - Form encoding
+
+    @Test("Form encoding escapes every character that carries meaning in a body")
+    func testFormEncodingEscapesReservedCharacters() {
+        let encoded = OAuth2Exchange.formEncoded(["key": "a+b&c=d/e f"])
+
+        #expect(encoded == "key=a%2Bb%26c%3Dd%2Fe%20f")
+    }
+
+    @Test("Form encoding sorts by key, so a body is a function of its parameters")
+    func testFormEncodingIsSorted() {
+        let encoded = OAuth2Exchange.formEncoded(["b": "2", "a": "1", "c": "3"])
+
+        #expect(encoded == "a=1&b=2&c=3")
+    }
+
+    // MARK: - Access token lifetime
+
+    @Test("Assumed access token lifetime matches the server's 15 minutes")
+    func testDefaultAccessTokenLifetime() {
+        #expect(OAuth2Exchange.defaultAccessTokenLifetime == 900)
+    }
+
+    // MARK: - Endpoints
+
+    @Test("OAuth2 endpoints point at the authorization server's paths")
+    func testOAuth2Endpoints() {
+        #expect(APIConfiguration.oauth2AuthorizeURL == "\(APIConfiguration.serverURL)/authorize")
+        #expect(APIConfiguration.oauth2TokenURL == "\(APIConfiguration.serverURL)/token")
+        #expect(!APIConfiguration.oauth2AuthorizeURL.contains("/oauth2/"))
+        #expect(!APIConfiguration.oauth2TokenURL.contains("/oauth2/"))
+    }
+
+    @Test("Redirect URI is the server URL exactly, since matching is byte for byte")
+    func testRedirectURIMatchesServerURL() {
+        #expect(APIConfiguration.oauth2RedirectURI == APIConfiguration.serverURL)
+        #expect(!APIConfiguration.oauth2RedirectURI.hasSuffix("/"))
+    }
+}


### PR DESCRIPTION
Closes #1345.

#1343 moved the API server onto platform's `oauth2server`, backend only. The iOS app's
OAuth2 exchange does not work against it. Three changes, plus two things the issue flagged
as worth checking that turned out to need fixing.

## The three changes

**Endpoints and method.** `/oauth2/authorize` → `/authorize`, `/oauth2/token` → `/token`, and
the authorization request is now a POST. The method is the load-bearing part: a `GET
/authorize` renders an HTML login form — the answer for a browser arriving without a session
— and only a POST runs the authenticator that reads the bearer token. The authorization
parameters stay in the query string, so nothing moved into a body.

**PKCE.** The app sent `code_challenge_method=plain` with no challenge. It now sends
`base64url(SHA256(verifier))` with method `S256` and replays the verifier at `/token`. An
absent method is refused rather than defaulted, because RFC 7636 defaults it to `plain`.

**Redirect URI.** Matching is byte for byte, at `/authorize` and again at `/token` against the
URI the code was issued for. The value is unchanged — `serverURL` — but it is now
`APIConfiguration.oauth2RedirectURI`, so the constraint is stated where it is read.

Confirmed byte for byte for both environments the app can point at:

| Environment | `serverURL` | Registered by |
| --- | --- | --- |
| production | `https://http-api.dinnerdonebetter.com` | `ddb-bootstrap init` default `--api-server-url` (`prodAPIServerURL`, `backend/cmd/tools/bootstrap/main.go:49`) |
| local | `http://localhost:8000` | the address a local bootstrap run passes as `--api-server-url` |

No trailing slash on either side.

## Two fixes from "worth checking while in here"

**Access token lifetime.** Tokens are 15 minutes now, not 24 hours. The refresh logic itself
was fine — `getOAuth2AccessToken` refreshes at 5 minutes remaining — but the fallback used
when a response omits `expires_in` still assumed `86400`, which would have left the app
presenting a dead token for most of a day instead of refreshing. It is now
`OAuth2Exchange.defaultAccessTokenLifetime` (900s), used by both the code exchange and the
refresh.

**Rotating refresh tokens weren't always persisted.** `refreshOAuth2Token` persisted its new
pair, but `exchangeCodeForToken` only set the properties. Reached through the JWT re-exchange
fallback in `getOAuth2AccessToken`, that left the Keychain holding the *spent* refresh token
— and presenting a spent one revokes the whole family and forces a full re-login. It now
persists, as the issue's note about rotation requires.

The RFC 9207 `iss` parameter on the 302 needed nothing: the code is looked up by name among
the redirect's query items.

## Shape

Request building moved out of `AuthenticationManager` into a new
`ios/ios/Services/Auth/OAuth2Exchange.swift`, holding `PKCE` and one builder per leg
(authorize / token / refresh). That is what makes the wire format assertable without a live
server, and it is where the "why POST", "why S256", and "why byte for byte" reasoning now
lives next to the code it explains.

While there, form bodies are encoded against RFC 3986's unreserved set instead of
`.urlQueryAllowed`, which leaves `+`, `&`, `=` and `/` untouched — a client secret containing
any of them arrived mangled, or split into another parameter entirely.

## Tests

`ios/iosTests/OAuth2ExchangeTests.swift`, 17 cases: the RFC 7636 Appendix B challenge vector,
unpadded base64url, generated-verifier shape and uniqueness, POST + bearer + parameters-in-
query on the authorization request, `code_challenge_method=S256` and never `plain`, the
verifier and redirect URI on the token request, secret escaping, the refresh body, the
15-minute fallback, and the endpoint paths and redirect URI.

**These have not been run.** The iOS suite needs `xcodebuild`, and this branch was built on
Linux — `make unit-test` fails with `xcodebuild: command not found`. What did run: the app
sources are `swift-format`-clean (`make format-check`), and the new test file parses under
`swift-format`. The expected values for the PKCE vector and the base64url and form encodings
were checked against independent implementations. CI on macOS is the first real compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
