### PR TITLE
Derive DestroyAllData from the schema instead of the query-builder registry

### DIFF
--- a/backend/cmd/tools/codegen/queries/auth_password_reset_tokens.go
+++ b/backend/cmd/tools/codegen/queries/auth_password_reset_tokens.go
@@ -17,10 +17,6 @@ const (
 	passwordResetTokenExpiresAtColumn = "expires_at"
 )
 
-func init() {
-	registerTableName(passwordResetTokensTableName)
-}
-
 var passwordResetTokensColumns = []string{
 	idColumn,
 	passwordResetTokenColumn,

--- a/backend/cmd/tools/codegen/queries/auth_user_sessions.go
+++ b/backend/cmd/tools/codegen/queries/auth_user_sessions.go
@@ -23,10 +23,6 @@ const (
 	revokedAtColumn      = "revoked_at"
 )
 
-func init() {
-	registerTableName(userSessionsTableName)
-}
-
 var userSessionsColumns = []string{
 	idColumn,
 	belongsToUserColumn,

--- a/backend/cmd/tools/codegen/queries/comments_comments.go
+++ b/backend/cmd/tools/codegen/queries/comments_comments.go
@@ -14,10 +14,6 @@ const (
 	commentsTableName = "comments"
 )
 
-func init() {
-	registerTableName(commentsTableName)
-}
-
 var commentsColumns = []string{
 	idColumn,
 	"content",

--- a/backend/cmd/tools/codegen/queries/identity_account_invitations.go
+++ b/backend/cmd/tools/codegen/queries/identity_account_invitations.go
@@ -22,10 +22,6 @@ const (
 	accountInvitationsExpiresAtColumn  = "expires_at"
 )
 
-func init() {
-	registerTableName(accountInvitationsTableName)
-}
-
 var accountInvitationsColumns = []string{
 	idColumn,
 	fromUserColumn,

--- a/backend/cmd/tools/codegen/queries/identity_account_user_memberships.go
+++ b/backend/cmd/tools/codegen/queries/identity_account_user_memberships.go
@@ -16,10 +16,6 @@ const (
 	defaultAccountColumn = "default_account"
 )
 
-func init() {
-	registerTableName(accountUserMembershipsTableName)
-}
-
 var accountUserMembershipsColumns = []string{
 	idColumn,
 	belongsToAccountColumn,

--- a/backend/cmd/tools/codegen/queries/identity_accounts.go
+++ b/backend/cmd/tools/codegen/queries/identity_accounts.go
@@ -17,10 +17,6 @@ const (
 	webhookHMACSecretColumn = "webhook_hmac_secret"
 )
 
-func init() {
-	registerTableName(accountsTableName)
-}
-
 var accountsColumns = []string{
 	idColumn,
 	nameColumn,

--- a/backend/cmd/tools/codegen/queries/identity_permissions.go
+++ b/backend/cmd/tools/codegen/queries/identity_permissions.go
@@ -14,10 +14,6 @@ const (
 	permissionsTableName = "permissions"
 )
 
-func init() {
-	registerTableName(permissionsTableName)
-}
-
 var permissionsColumns = []string{
 	idColumn,
 	nameColumn,

--- a/backend/cmd/tools/codegen/queries/identity_user_role_assignments.go
+++ b/backend/cmd/tools/codegen/queries/identity_user_role_assignments.go
@@ -16,10 +16,6 @@ const (
 	accountIDColumn = "account_id"
 )
 
-func init() {
-	registerTableName(userRoleAssignmentsTableName)
-}
-
 var userRoleAssignmentsColumns = []string{
 	idColumn,
 	userIDColumn,

--- a/backend/cmd/tools/codegen/queries/identity_user_role_hierarchy.go
+++ b/backend/cmd/tools/codegen/queries/identity_user_role_hierarchy.go
@@ -17,10 +17,6 @@ const (
 	childRoleIDColumn  = "child_role_id"
 )
 
-func init() {
-	registerTableName(userRoleHierarchyTableName)
-}
-
 var userRoleHierarchyColumns = []string{
 	idColumn,
 	parentRoleIDColumn,

--- a/backend/cmd/tools/codegen/queries/identity_user_role_permissions.go
+++ b/backend/cmd/tools/codegen/queries/identity_user_role_permissions.go
@@ -17,10 +17,6 @@ const (
 	permissionIDColumn = "permission_id"
 )
 
-func init() {
-	registerTableName(userRolePermissionsTableName)
-}
-
 var userRolePermissionsColumns = []string{
 	idColumn,
 	roleIDColumn,

--- a/backend/cmd/tools/codegen/queries/identity_user_roles.go
+++ b/backend/cmd/tools/codegen/queries/identity_user_roles.go
@@ -16,10 +16,6 @@ const (
 	scopeColumn = "scope"
 )
 
-func init() {
-	registerTableName(userRolesTableName)
-}
-
 var userRolesColumns = []string{
 	idColumn,
 	nameColumn,

--- a/backend/cmd/tools/codegen/queries/identity_users.go
+++ b/backend/cmd/tools/codegen/queries/identity_users.go
@@ -37,12 +37,6 @@ const (
 	lastAcceptedPrivacyPolicyColumn     = "last_accepted_privacy_policy"
 )
 
-func init() {
-	registerTableName(usersTableName)
-	registerTableName(userAvatarsTableName)
-	registerTableName(uploadedMediaTable)
-}
-
 // avatarJoinColumns are the uploaded_media columns selected when joining for avatar.
 var avatarJoinColumns = []string{
 	"id", "storage_path", "mime_type", "created_at", "last_updated_at", "archived_at", "created_by_user",

--- a/backend/cmd/tools/codegen/queries/internalops_queue_test_messages.go
+++ b/backend/cmd/tools/codegen/queries/internalops_queue_test_messages.go
@@ -6,10 +6,6 @@ import (
 
 const queueTestMessagesTableName = "queue_test_messages"
 
-func init() {
-	registerTableName(queueTestMessagesTableName)
-}
-
 func buildQueueTestMessagesQueries(database string) []*Query {
 	switch database {
 	case postgres:

--- a/backend/cmd/tools/codegen/queries/issuereports_issue_reports.go
+++ b/backend/cmd/tools/codegen/queries/issuereports_issue_reports.go
@@ -18,10 +18,6 @@ const (
 	relevantRecordIDColumn = "relevant_record_id"
 )
 
-func init() {
-	registerTableName(issueReportsTableName)
-}
-
 var issueReportsColumns = []string{
 	idColumn,
 	issueTypeColumn,

--- a/backend/cmd/tools/codegen/queries/maintenance_maintenance.go
+++ b/backend/cmd/tools/codegen/queries/maintenance_maintenance.go
@@ -1,36 +1,38 @@
 package main
 
-import (
-	"fmt"
-	"slices"
-	"strings"
-	"sync"
-)
+// destroyAllData truncates every table the schema has, discovered when the query runs
+// rather than listed when it is generated.
+//
+// The list used to be assembled by registerTableName calls sprinkled through the query
+// builders, which made "is this table truncated?" a question about whether somebody wrote
+// a query builder for it rather than about whether the table exists. Eleven tables had
+// fallen out by the time anyone checked: the media and image tables nobody ever wrote a
+// builder for, and the ones whose queries come from platform rather than from this
+// generator — sessions, webauthn_credentials, webauthn_sessions, user_device_tokens, and
+// every webhook, audit, data privacy, metering, operations, outbox, saga and
+// authorization server table. A domain moving onto platform's resources kit drops out the
+// same way, silently, the moment it stops generating queries here — and the symptom is an
+// unrelated test failing later, or passing for the wrong reason on auth state a previous
+// test left behind.
+//
+// pg_tables is the schema itself, so it cannot drift from the migrations. goose's version
+// table is the one exclusion: truncating it would leave a fully migrated database claiming
+// it had never been migrated.
+const destroyAllData = `DO $$
+DECLARE
+	truncation TEXT;
+BEGIN
+	SELECT 'TRUNCATE ' || string_agg(format('%I.%I', schemaname, tablename), ', ') || ' CASCADE'
+	INTO truncation
+	FROM pg_tables
+	WHERE schemaname = 'public'
+	  AND tablename <> 'goose_db_version';
 
-var (
-	allTablesHat sync.Mutex
-	allTables    = map[string]bool{}
-)
-
-func registerTableName(table string) {
-	allTablesHat.Lock()
-	defer allTablesHat.Unlock()
-	allTables[table] = true
-}
-
-func getAllTables() []string {
-	allTablesHat.Lock()
-	defer allTablesHat.Unlock()
-
-	tables := make([]string, 0, len(allTables))
-	for t := range allTables {
-		tables = append(tables, t)
-	}
-
-	slices.Sort(tables)
-
-	return tables
-}
+	IF truncation IS NOT NULL THEN
+		EXECUTE truncation;
+	END IF;
+END
+$$;`
 
 func buildMaintenanceQueries(database string) []*Query {
 	switch database {
@@ -41,7 +43,7 @@ func buildMaintenanceQueries(database string) []*Query {
 					Name: "DestroyAllData",
 					Type: ExecType,
 				},
-				Content: fmt.Sprintf(`TRUNCATE %s CASCADE;`, strings.Join(getAllTables(), ", ")),
+				Content: destroyAllData,
 			},
 		}
 		return append(queries, buildQueueTestMessagesQueries(database)...)

--- a/backend/cmd/tools/codegen/queries/maintenance_maintenance_test.go
+++ b/backend/cmd/tools/codegen/queries/maintenance_maintenance_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// sessionsTableName is not a constant this package otherwise has, precisely because no
+// builder here generates queries against the session table — which is what put it among
+// the tables the old registry-derived TRUNCATE missed.
+const sessionsTableName = "sessions"
+
+func Test_buildMaintenanceQueries(T *testing.T) {
+	T.Parallel()
+
+	T.Run("truncates whatever the schema holds rather than a list fixed at generation time", func(t *testing.T) {
+		t.Parallel()
+
+		queries := buildMaintenanceQueries(postgres)
+		require.NotEmpty(t, queries)
+
+		destroy := queries[0]
+		require.Equal(t, "DestroyAllData", destroy.Annotation.Name)
+
+		assert.Contains(t, destroy.Content, "FROM pg_tables")
+		assert.Contains(t, destroy.Content, "schemaname = 'public'")
+		// The migrator's bookkeeping is the one table left standing.
+		assert.Contains(t, destroy.Content, "tablename <> 'goose_db_version'")
+
+		// The regression this guards: a table named here is a table somebody has to
+		// remember to add, which is how eleven of them went missing. Nothing else in this
+		// statement is a table name, so finding one means the list came back.
+		for _, table := range []string{
+			usersTableName,
+			sessionsTableName,
+			recipesTableName,
+			webhooksTableName,
+		} {
+			assert.NotContains(t, destroy.Content, table)
+		}
+	})
+
+	T.Run("with unsupported database", func(t *testing.T) {
+		t.Parallel()
+
+		assert.Nil(t, buildMaintenanceQueries("mariadb"))
+	})
+}

--- a/backend/cmd/tools/codegen/queries/mealplanning_account_instrument_ownerships.go
+++ b/backend/cmd/tools/codegen/queries/mealplanning_account_instrument_ownerships.go
@@ -14,10 +14,6 @@ const (
 	accountInstrumentOwnershipsTableName = "account_instrument_ownerships"
 )
 
-func init() {
-	registerTableName(accountInstrumentOwnershipsTableName)
-}
-
 var accountInstrumentOwnershipsColumns = []string{
 	idColumn,
 	notesColumn,

--- a/backend/cmd/tools/codegen/queries/mealplanning_meal_components.go
+++ b/backend/cmd/tools/codegen/queries/mealplanning_meal_components.go
@@ -9,10 +9,6 @@ const (
 	belongsToMealColumn     = "belongs_to_meal"
 )
 
-func init() {
-	registerTableName(mealComponentsTableName)
-}
-
 var mealComponentsColumns = []string{
 	idColumn,
 	belongsToMealColumn,

--- a/backend/cmd/tools/codegen/queries/mealplanning_meal_list_items.go
+++ b/backend/cmd/tools/codegen/queries/mealplanning_meal_list_items.go
@@ -16,10 +16,6 @@ const (
 	mealListIDColumn = "meal_list_id"
 )
 
-func init() {
-	registerTableName(mealListItemsTableName)
-}
-
 var mealListItemsColumns = []string{
 	idColumn,
 	mealIDColumn,

--- a/backend/cmd/tools/codegen/queries/mealplanning_meal_lists.go
+++ b/backend/cmd/tools/codegen/queries/mealplanning_meal_lists.go
@@ -14,10 +14,6 @@ const (
 	mealListsTableName = "meal_lists"
 )
 
-func init() {
-	registerTableName(mealListsTableName)
-}
-
 var mealListsColumns = []string{
 	idColumn,
 	nameColumn,

--- a/backend/cmd/tools/codegen/queries/mealplanning_meal_plan_events.go
+++ b/backend/cmd/tools/codegen/queries/mealplanning_meal_plan_events.go
@@ -18,10 +18,6 @@ const (
 	belongsToMealPlanColumn      = "belongs_to_meal_plan"
 )
 
-func init() {
-	registerTableName(mealPlanEventsTableName)
-}
-
 var mealPlanEventsColumns = []string{
 	idColumn,
 	notesColumn,

--- a/backend/cmd/tools/codegen/queries/mealplanning_meal_plan_grocery_list_items.go
+++ b/backend/cmd/tools/codegen/queries/mealplanning_meal_plan_grocery_list_items.go
@@ -16,10 +16,6 @@ const (
 	mealPlanGroceryListItemIDColumn = "meal_plan_grocery_list_item_id"
 )
 
-func init() {
-	registerTableName(mealPlanGroceryListItemsTableName)
-}
-
 var mealPlanGroceryListItemsColumns = []string{
 	idColumn,
 	"belongs_to_meal_plan",

--- a/backend/cmd/tools/codegen/queries/mealplanning_meal_plan_option_votes.go
+++ b/backend/cmd/tools/codegen/queries/mealplanning_meal_plan_option_votes.go
@@ -17,10 +17,6 @@ const (
 	belongsToMealPlanOptionColumn = "belongs_to_meal_plan_option"
 )
 
-func init() {
-	registerTableName(mealPlanOptionVotesTableName)
-}
-
 var mealPlanOptionVotesColumns = []string{
 	idColumn,
 	"rank",

--- a/backend/cmd/tools/codegen/queries/mealplanning_meal_plan_options.go
+++ b/backend/cmd/tools/codegen/queries/mealplanning_meal_plan_options.go
@@ -19,10 +19,6 @@ const (
 	mealPlanOptionsMealScaleColumn = "meal_scale"
 )
 
-func init() {
-	registerTableName(mealPlanOptionsTableName)
-}
-
 var mealPlanOptionsColumns = []string{
 	idColumn,
 	"assigned_cook",

--- a/backend/cmd/tools/codegen/queries/mealplanning_meal_plan_recipe_option_selections.go
+++ b/backend/cmd/tools/codegen/queries/mealplanning_meal_plan_recipe_option_selections.go
@@ -18,10 +18,6 @@ const (
 	ingredientIndexColumn                 = "ingredient_index"
 )
 
-func init() {
-	registerTableName(mealPlanRecipeOptionSelectionsTableName)
-}
-
 var mealPlanRecipeOptionSelectionsColumns = []string{
 	idColumn,
 	belongsToMealPlanOptionColumn,

--- a/backend/cmd/tools/codegen/queries/mealplanning_meal_plan_tasks.go
+++ b/backend/cmd/tools/codegen/queries/mealplanning_meal_plan_tasks.go
@@ -20,10 +20,6 @@ const (
 	mealPlanTaskStatusColumn             = "status"
 )
 
-func init() {
-	registerTableName(mealPlanTasksTableName)
-}
-
 var mealPlanTasksColumns = []string{
 	idColumn,
 	mealPlanTaskStatusColumn,

--- a/backend/cmd/tools/codegen/queries/mealplanning_meal_plans.go
+++ b/backend/cmd/tools/codegen/queries/mealplanning_meal_plans.go
@@ -22,10 +22,6 @@ const (
 	electionMethodColumn                 = "election_method"
 )
 
-func init() {
-	registerTableName(mealPlansTableName)
-}
-
 var mealPlansColumns = []string{
 	idColumn,
 	notesColumn,

--- a/backend/cmd/tools/codegen/queries/mealplanning_meals.go
+++ b/backend/cmd/tools/codegen/queries/mealplanning_meals.go
@@ -16,10 +16,6 @@ const (
 	mealIDColumn = "meal_id"
 )
 
-func init() {
-	registerTableName(mealsTableName)
-}
-
 var mealsColumns = []string{
 	idColumn,
 	nameColumn,

--- a/backend/cmd/tools/codegen/queries/mealplanning_recipe_list_items.go
+++ b/backend/cmd/tools/codegen/queries/mealplanning_recipe_list_items.go
@@ -16,10 +16,6 @@ const (
 	recipeListIDColumn = "recipe_list_id"
 )
 
-func init() {
-	registerTableName(recipeListItemsTableName)
-}
-
 var recipeListItemsColumns = []string{
 	idColumn,
 	recipeIDColumn,

--- a/backend/cmd/tools/codegen/queries/mealplanning_recipe_lists.go
+++ b/backend/cmd/tools/codegen/queries/mealplanning_recipe_lists.go
@@ -14,10 +14,6 @@ const (
 	recipeListsTableName = "recipe_lists"
 )
 
-func init() {
-	registerTableName(recipeListsTableName)
-}
-
 var recipeListsColumns = []string{
 	idColumn,
 	nameColumn,

--- a/backend/cmd/tools/codegen/queries/mealplanning_recipe_media.go
+++ b/backend/cmd/tools/codegen/queries/mealplanning_recipe_media.go
@@ -14,10 +14,6 @@ const (
 	recipeMediaTableName = "recipe_media"
 )
 
-func init() {
-	registerTableName(recipeMediaTableName)
-}
-
 var recipeMediaColumns = []string{
 	idColumn,
 	belongsToRecipeColumn,

--- a/backend/cmd/tools/codegen/queries/mealplanning_recipe_prep_task_steps.go
+++ b/backend/cmd/tools/codegen/queries/mealplanning_recipe_prep_task_steps.go
@@ -10,10 +10,6 @@ const (
 	satisfiesRecipeStepColumn = "satisfies_recipe_step"
 )
 
-func init() {
-	registerTableName(recipePrepTaskStepsTableName)
-}
-
 var recipePrepTaskStepsColumns = []string{
 	idColumn,
 	belongsToRecipeStepColumn,

--- a/backend/cmd/tools/codegen/queries/mealplanning_recipe_prep_tasks.go
+++ b/backend/cmd/tools/codegen/queries/mealplanning_recipe_prep_tasks.go
@@ -15,10 +15,6 @@ const (
 	belongsToRecipePrepTaskColumn = "belongs_to_recipe_prep_task"
 )
 
-func init() {
-	registerTableName(recipePrepTasksTableName)
-}
-
 var recipePrepTasksColumns = []string{
 	idColumn,
 	nameColumn,

--- a/backend/cmd/tools/codegen/queries/mealplanning_recipe_ratings.go
+++ b/backend/cmd/tools/codegen/queries/mealplanning_recipe_ratings.go
@@ -14,10 +14,6 @@ const (
 	recipeRatingsTableName = "recipe_ratings"
 )
 
-func init() {
-	registerTableName(recipeRatingsTableName)
-}
-
 var recipeRatingsColumns = []string{
 	idColumn,
 	belongsToRecipeColumn,

--- a/backend/cmd/tools/codegen/queries/mealplanning_recipe_step_completion_condition_ingredients.go
+++ b/backend/cmd/tools/codegen/queries/mealplanning_recipe_step_completion_condition_ingredients.go
@@ -16,10 +16,6 @@ const (
 	belongsToRecipeStepCompletionConditionColumn = "belongs_to_recipe_step_completion_condition"
 )
 
-func init() {
-	registerTableName(recipeStepCompletionConditionIngredientsTableName)
-}
-
 var recipeStepCompletionConditionIngredientsColumns = []string{
 	idColumn,
 	belongsToRecipeStepCompletionConditionColumn,

--- a/backend/cmd/tools/codegen/queries/mealplanning_recipe_step_completion_conditions.go
+++ b/backend/cmd/tools/codegen/queries/mealplanning_recipe_step_completion_conditions.go
@@ -17,10 +17,6 @@ const (
 	recipeStepCompletionConditionIDColumn = "recipe_step_completion_condition_id"
 )
 
-func init() {
-	registerTableName(recipeStepCompletionConditionsTableName)
-}
-
 var recipeStepCompletionConditionsColumns = []string{
 	idColumn,
 	"optional",

--- a/backend/cmd/tools/codegen/queries/mealplanning_recipe_step_ingredients.go
+++ b/backend/cmd/tools/codegen/queries/mealplanning_recipe_step_ingredients.go
@@ -18,10 +18,6 @@ const (
 	measurementUnitColumn        = "measurement_unit"
 )
 
-func init() {
-	registerTableName(recipeStepIngredientsTableName)
-}
-
 var recipeStepIngredientsColumns = []string{
 	idColumn,
 	nameColumn,

--- a/backend/cmd/tools/codegen/queries/mealplanning_recipe_step_instruments.go
+++ b/backend/cmd/tools/codegen/queries/mealplanning_recipe_step_instruments.go
@@ -17,10 +17,6 @@ const (
 	instrumentIDColumn           = "instrument_id"
 )
 
-func init() {
-	registerTableName(recipeStepInstrumentsTableName)
-}
-
 var recipeStepInstrumentsColumns = []string{
 	idColumn,
 	instrumentIDColumn,

--- a/backend/cmd/tools/codegen/queries/mealplanning_recipe_step_products.go
+++ b/backend/cmd/tools/codegen/queries/mealplanning_recipe_step_products.go
@@ -16,10 +16,6 @@ const (
 	recipeStepProductIDColumn = "recipe_step_product_id"
 )
 
-func init() {
-	registerTableName(recipeStepProductsTableName)
-}
-
 var recipeStepProductsColumns = []string{
 	idColumn,
 	nameColumn,

--- a/backend/cmd/tools/codegen/queries/mealplanning_recipe_step_vessels.go
+++ b/backend/cmd/tools/codegen/queries/mealplanning_recipe_step_vessels.go
@@ -16,10 +16,6 @@ const (
 	recipeStepVesselIDColumn = "recipe_step_vessel_id"
 )
 
-func init() {
-	registerTableName(recipeStepVesselsTableName)
-}
-
 var recipeStepVesselsColumns = []string{
 	idColumn,
 	nameColumn,

--- a/backend/cmd/tools/codegen/queries/mealplanning_recipe_steps.go
+++ b/backend/cmd/tools/codegen/queries/mealplanning_recipe_steps.go
@@ -18,10 +18,6 @@ const (
 	belongsToRecipeStepColumn = "belongs_to_recipe_step"
 )
 
-func init() {
-	registerTableName(recipeStepsTableName)
-}
-
 var recipeStepsColumns = []string{
 	idColumn,
 	indexColumn,

--- a/backend/cmd/tools/codegen/queries/mealplanning_recipes.go
+++ b/backend/cmd/tools/codegen/queries/mealplanning_recipes.go
@@ -20,10 +20,6 @@ const (
 	statusColumn           = "status"
 )
 
-func init() {
-	registerTableName(recipesTableName)
-}
-
 var recipesColumns = []string{
 	idColumn,
 	nameColumn,

--- a/backend/cmd/tools/codegen/queries/mealplanning_user_ingredient_preferences.go
+++ b/backend/cmd/tools/codegen/queries/mealplanning_user_ingredient_preferences.go
@@ -16,10 +16,6 @@ const (
 	userIngredientPreferencesIngredientColumn = "ingredient"
 )
 
-func init() {
-	registerTableName(userIngredientPreferencesTableName)
-}
-
 var userIngredientPreferencesColumns = []string{
 	idColumn,
 	userIngredientPreferencesIngredientColumn,

--- a/backend/cmd/tools/codegen/queries/mealplanning_valid_ingredient_group_members.go
+++ b/backend/cmd/tools/codegen/queries/mealplanning_valid_ingredient_group_members.go
@@ -10,10 +10,6 @@ const (
 	validIngredientGroupMemberValidIngredientColumn = "valid_ingredient"
 )
 
-func init() {
-	registerTableName(validIngredientGroupMembersTableName)
-}
-
 var validIngredientGroupMembersColumns = []string{
 	idColumn,
 	belongsToGroupColumn,

--- a/backend/cmd/tools/codegen/queries/mealplanning_valid_ingredient_groups.go
+++ b/backend/cmd/tools/codegen/queries/mealplanning_valid_ingredient_groups.go
@@ -14,10 +14,6 @@ const (
 	validIngredientGroupsTableName = "valid_ingredient_groups"
 )
 
-func init() {
-	registerTableName(validIngredientGroupsTableName)
-}
-
 var validIngredientGroupsColumns = []string{
 	idColumn,
 	nameColumn,

--- a/backend/cmd/tools/codegen/queries/mealplanning_valid_ingredient_measurement_units.go
+++ b/backend/cmd/tools/codegen/queries/mealplanning_valid_ingredient_measurement_units.go
@@ -16,10 +16,6 @@ const (
 	validMeasurementUnitIDColumn             = "valid_measurement_unit_id"
 )
 
-func init() {
-	registerTableName(validIngredientMeasurementUnitsTableName)
-}
-
 var validIngredientMeasurementUnitsColumns = []string{
 	idColumn,
 	notesColumn,

--- a/backend/cmd/tools/codegen/queries/mealplanning_valid_ingredient_preparations.go
+++ b/backend/cmd/tools/codegen/queries/mealplanning_valid_ingredient_preparations.go
@@ -14,10 +14,6 @@ const (
 	validIngredientPreparationsTableName = "valid_ingredient_preparations"
 )
 
-func init() {
-	registerTableName(validIngredientPreparationsTableName)
-}
-
 var validIngredientPreparationsColumns = []string{
 	idColumn,
 	notesColumn,

--- a/backend/cmd/tools/codegen/queries/mealplanning_valid_ingredient_state_ingredients.go
+++ b/backend/cmd/tools/codegen/queries/mealplanning_valid_ingredient_state_ingredients.go
@@ -17,10 +17,6 @@ const (
 	validIngredientColumn      = "valid_ingredient"
 )
 
-func init() {
-	registerTableName(validIngredientStateIngredientsTableName)
-}
-
 var validIngredientStateIngredientsColumns = []string{
 	idColumn,
 	notesColumn,

--- a/backend/cmd/tools/codegen/queries/mealplanning_valid_ingredient_states.go
+++ b/backend/cmd/tools/codegen/queries/mealplanning_valid_ingredient_states.go
@@ -14,10 +14,6 @@ const (
 	validIngredientStatesTableName = "valid_ingredient_states"
 )
 
-func init() {
-	registerTableName(validIngredientStatesTableName)
-}
-
 var validIngredientStatesColumns = []string{
 	idColumn,
 	nameColumn,

--- a/backend/cmd/tools/codegen/queries/mealplanning_valid_ingredients.go
+++ b/backend/cmd/tools/codegen/queries/mealplanning_valid_ingredients.go
@@ -15,10 +15,6 @@ const (
 	validIngredientIDColumn   = "valid_ingredient_id"
 )
 
-func init() {
-	registerTableName(validIngredientsTableName)
-}
-
 var validIngredientsColumns = []string{
 	idColumn,
 	nameColumn,

--- a/backend/cmd/tools/codegen/queries/mealplanning_valid_instruments.go
+++ b/backend/cmd/tools/codegen/queries/mealplanning_valid_instruments.go
@@ -16,10 +16,6 @@ const (
 	validInstrumentIDColumn = "valid_instrument_id"
 )
 
-func init() {
-	registerTableName(validInstrumentsTableName)
-}
-
 var validInstrumentsColumns = []string{
 	idColumn,
 	nameColumn,

--- a/backend/cmd/tools/codegen/queries/mealplanning_valid_measurement_unit_conversions.go
+++ b/backend/cmd/tools/codegen/queries/mealplanning_valid_measurement_unit_conversions.go
@@ -18,10 +18,6 @@ const (
 	validMeasurementUnitConversionsOnlyForIngredientColumn = "only_for_ingredient"
 )
 
-func init() {
-	registerTableName(validMeasurementUnitConversionsTableName)
-}
-
 var validMeasurementUnitConversionsColumns = []string{
 	idColumn,
 	"from_unit",

--- a/backend/cmd/tools/codegen/queries/mealplanning_valid_measurement_units.go
+++ b/backend/cmd/tools/codegen/queries/mealplanning_valid_measurement_units.go
@@ -16,10 +16,6 @@ const (
 	validMeasurementUnitsUniversalColumn = "universal"
 )
 
-func init() {
-	registerTableName(validMeasurementUnitsTableName)
-}
-
 var validMeasurementUnitsColumns = []string{
 	idColumn,
 	nameColumn,

--- a/backend/cmd/tools/codegen/queries/mealplanning_valid_prep_task_configs.go
+++ b/backend/cmd/tools/codegen/queries/mealplanning_valid_prep_task_configs.go
@@ -14,10 +14,6 @@ const (
 	validPrepTaskConfigsTableName = "valid_prep_task_configs"
 )
 
-func init() {
-	registerTableName(validPrepTaskConfigsTableName)
-}
-
 var validPrepTaskConfigsColumns = []string{
 	idColumn,
 	validIngredientIDColumn,

--- a/backend/cmd/tools/codegen/queries/mealplanning_valid_preparation_instruments.go
+++ b/backend/cmd/tools/codegen/queries/mealplanning_valid_preparation_instruments.go
@@ -14,10 +14,6 @@ const (
 	validPreparationInstrumentsTableName = "valid_preparation_instruments"
 )
 
-func init() {
-	registerTableName(validPreparationInstrumentsTableName)
-}
-
 var validPreparationInstrumentsColumns = []string{
 	idColumn,
 	notesColumn,

--- a/backend/cmd/tools/codegen/queries/mealplanning_valid_preparation_vessels.go
+++ b/backend/cmd/tools/codegen/queries/mealplanning_valid_preparation_vessels.go
@@ -14,10 +14,6 @@ const (
 	validPreparationVesselsTableName = "valid_preparation_vessels"
 )
 
-func init() {
-	registerTableName(validPreparationVesselsTableName)
-}
-
 var validPreparationVesselsColumns = []string{
 	idColumn,
 	notesColumn,

--- a/backend/cmd/tools/codegen/queries/mealplanning_valid_preparations.go
+++ b/backend/cmd/tools/codegen/queries/mealplanning_valid_preparations.go
@@ -17,10 +17,6 @@ const (
 	restrictToIngredientsColumn = "restrict_to_ingredients"
 )
 
-func init() {
-	registerTableName(validPreparationsTableName)
-}
-
 var validPreparationsColumns = []string{
 	idColumn,
 	nameColumn,

--- a/backend/cmd/tools/codegen/queries/mealplanning_valid_vessels.go
+++ b/backend/cmd/tools/codegen/queries/mealplanning_valid_vessels.go
@@ -16,10 +16,6 @@ const (
 	capacityUnitColumn    = "capacity_unit"
 )
 
-func init() {
-	registerTableName(validVesselsTableName)
-}
-
 var validVesselsColumns = []string{
 	idColumn,
 	nameColumn,

--- a/backend/cmd/tools/codegen/queries/notifications_user_notifications.go
+++ b/backend/cmd/tools/codegen/queries/notifications_user_notifications.go
@@ -16,10 +16,6 @@ const (
 	userNotificationStatusDismissed = "dismissed"
 )
 
-func init() {
-	registerTableName(userNotificationsTableName)
-}
-
 var (
 	userNotificationsColumns = []string{
 		idColumn,

--- a/backend/cmd/tools/codegen/queries/oauth_oauth2_clients.go
+++ b/backend/cmd/tools/codegen/queries/oauth_oauth2_clients.go
@@ -15,10 +15,6 @@ const (
 	clientIDColumn         = "client_id"
 )
 
-func init() {
-	registerTableName(oauth2ClientsTableName)
-}
-
 var oauth2ClientsColumns = []string{
 	idColumn,
 	nameColumn,

--- a/backend/cmd/tools/codegen/queries/payments_products.go
+++ b/backend/cmd/tools/codegen/queries/payments_products.go
@@ -14,10 +14,6 @@ const (
 	productsTableName = "products"
 )
 
-func init() {
-	registerTableName(productsTableName)
-}
-
 var productsColumns = []string{
 	idColumn,
 	nameColumn,

--- a/backend/cmd/tools/codegen/queries/payments_purchases.go
+++ b/backend/cmd/tools/codegen/queries/payments_purchases.go
@@ -14,10 +14,6 @@ const (
 	purchasesTableName = "purchases"
 )
 
-func init() {
-	registerTableName(purchasesTableName)
-}
-
 var purchasesColumns = []string{
 	idColumn,
 	belongsToAccountColumn,

--- a/backend/cmd/tools/codegen/queries/payments_subscriptions.go
+++ b/backend/cmd/tools/codegen/queries/payments_subscriptions.go
@@ -15,10 +15,6 @@ const (
 	externalSubscriptionIDColumn = "external_subscription_id"
 )
 
-func init() {
-	registerTableName(subscriptionsTableName)
-}
-
 var subscriptionsColumns = []string{
 	idColumn,
 	belongsToAccountColumn,

--- a/backend/cmd/tools/codegen/queries/payments_transactions.go
+++ b/backend/cmd/tools/codegen/queries/payments_transactions.go
@@ -14,10 +14,6 @@ const (
 	paymentTransactionsTableName = "payment_transactions"
 )
 
-func init() {
-	registerTableName(paymentTransactionsTableName)
-}
-
 var paymentTransactionsColumns = []string{
 	idColumn,
 	belongsToAccountColumn,

--- a/backend/cmd/tools/codegen/queries/settings_service_setting_configurations.go
+++ b/backend/cmd/tools/codegen/queries/settings_service_setting_configurations.go
@@ -17,10 +17,6 @@ const (
 	serviceSettingValueColumn = "value"
 )
 
-func init() {
-	registerTableName(serviceSettingConfigurationsTableName)
-}
-
 var serviceSettingConfigurationsColumns = []string{
 	idColumn,
 	serviceSettingValueColumn,

--- a/backend/cmd/tools/codegen/queries/settings_service_settings.go
+++ b/backend/cmd/tools/codegen/queries/settings_service_settings.go
@@ -14,10 +14,6 @@ const (
 	serviceSettingsTableName = "service_settings"
 )
 
-func init() {
-	registerTableName(serviceSettingsTableName)
-}
-
 var serviceSettingsColumns = []string{
 	idColumn,
 	nameColumn,

--- a/backend/cmd/tools/codegen/queries/uploadedmedia_uploaded_media.go
+++ b/backend/cmd/tools/codegen/queries/uploadedmedia_uploaded_media.go
@@ -16,10 +16,6 @@ const (
 	mimeTypeColumn         = "mime_type"
 )
 
-func init() {
-	registerTableName(uploadedMediaTableName)
-}
-
 var uploadedMediaColumns = []string{
 	idColumn,
 	storagePathColumn,

--- a/backend/cmd/tools/codegen/queries/waitlists_waitlist_signups.go
+++ b/backend/cmd/tools/codegen/queries/waitlists_waitlist_signups.go
@@ -16,10 +16,6 @@ const (
 	waitlistSignupNotesColumn = "notes"
 )
 
-func init() {
-	registerTableName(waitlistSignupsTableName)
-}
-
 var waitlistSignupColumns = []string{
 	idColumn,
 	waitlistSignupNotesColumn,

--- a/backend/cmd/tools/codegen/queries/waitlists_waitlists.go
+++ b/backend/cmd/tools/codegen/queries/waitlists_waitlists.go
@@ -14,10 +14,6 @@ const (
 	waitlistsTableName = "waitlists"
 )
 
-func init() {
-	registerTableName(waitlistsTableName)
-}
-
 var waitlistsColumns = []string{
 	idColumn,
 	nameColumn,

--- a/backend/cmd/tools/codegen/queries/webhooks_webhook_trigger_configs.go
+++ b/backend/cmd/tools/codegen/queries/webhooks_webhook_trigger_configs.go
@@ -14,10 +14,6 @@ const (
 	triggerEventColumn             = "trigger_event"
 )
 
-func init() {
-	registerTableName(webhookTriggerConfigsTableName)
-}
-
 var (
 	webhookTriggerConfigsColumns = []string{
 		idColumn,

--- a/backend/cmd/tools/codegen/queries/webhooks_webhooks.go
+++ b/backend/cmd/tools/codegen/queries/webhooks_webhooks.go
@@ -14,10 +14,6 @@ const (
 	webhooksTableName = "webhooks"
 )
 
-func init() {
-	registerTableName(webhooksTableName)
-}
-
 var (
 	webhooksColumns = []string{
 		idColumn,

--- a/backend/docs/adding_a_new_domain.md
+++ b/backend/docs/adding_a_new_domain.md
@@ -89,9 +89,13 @@ The query pipeline has two stages:
 Create a file like `your_domain_entity_name.go` (e.g., `settings_service_settings.go`). Each file:
 
 1. Defines `const tableName = "your_table_name"`
-2. Calls `registerTableName(tableName)` in `init()`
-3. Defines `var columns = []string{...}` (include `idColumn`, `createdAtColumn`, `lastUpdatedAtColumn`, `archivedAtColumn` from shared constants)
-4. Implements `buildXxxQueries(database string) []*Query` returning a slice of `Query` structs
+2. Defines `var columns = []string{...}` (include `idColumn`, `createdAtColumn`, `lastUpdatedAtColumn`, `archivedAtColumn` from shared constants)
+3. Implements `buildXxxQueries(database string) []*Query` returning a slice of `Query` structs
+
+There is nothing to register your table with. `DestroyAllData` — the `TRUNCATE` that
+empties a database between tests — reads `pg_tables` when it runs, so a table is covered
+by virtue of existing rather than by virtue of somebody having written a query builder
+for it.
 
 #### Query types
 

--- a/backend/internal/repositories/postgres/internalops/generated/internalops.generated.sql_generated.go
+++ b/backend/internal/repositories/postgres/internalops/generated/internalops.generated.sql_generated.go
@@ -33,7 +33,21 @@ func (q *Queries) CreateQueueTestMessage(ctx context.Context, db DBTX, arg *Crea
 }
 
 const destroyAllData = `-- name: DestroyAllData :exec
-TRUNCATE account_instrument_ownerships, account_invitations, account_user_memberships, accounts, comments, issue_reports, meal_components, meal_list_items, meal_lists, meal_plan_events, meal_plan_grocery_list_items, meal_plan_option_votes, meal_plan_options, meal_plan_recipe_option_selections, meal_plan_tasks, meal_plans, meals, oauth2_clients, password_reset_tokens, payment_transactions, permissions, products, purchases, queue_test_messages, recipe_list_items, recipe_lists, recipe_media, recipe_prep_task_steps, recipe_prep_tasks, recipe_ratings, recipe_step_completion_condition_ingredients, recipe_step_completion_conditions, recipe_step_ingredients, recipe_step_instruments, recipe_step_products, recipe_step_vessels, recipe_steps, recipes, service_setting_configurations, service_settings, subscriptions, uploaded_media, user_avatars, user_ingredient_preferences, user_notifications, user_role_assignments, user_role_hierarchy, user_role_permissions, user_roles, user_sessions, users, valid_ingredient_group_members, valid_ingredient_groups, valid_ingredient_measurement_units, valid_ingredient_preparations, valid_ingredient_state_ingredients, valid_ingredient_states, valid_ingredients, valid_instruments, valid_measurement_unit_conversions, valid_measurement_units, valid_prep_task_configs, valid_preparation_instruments, valid_preparation_vessels, valid_preparations, valid_vessels, waitlist_signups, waitlists, webhook_trigger_configs, webhooks CASCADE
+DO $$
+DECLARE
+	truncation TEXT;
+BEGIN
+	SELECT 'TRUNCATE ' || string_agg(format('%I.%I', schemaname, tablename), ', ') || ' CASCADE'
+	INTO truncation
+	FROM pg_tables
+	WHERE schemaname = 'public'
+	  AND tablename <> 'goose_db_version';
+
+	IF truncation IS NOT NULL THEN
+		EXECUTE truncation;
+	END IF;
+END
+$$
 `
 
 func (q *Queries) DestroyAllData(ctx context.Context, db DBTX) error {

--- a/backend/internal/repositories/postgres/internalops/maintenance_test.go
+++ b/backend/internal/repositories/postgres/internalops/maintenance_test.go
@@ -1,0 +1,130 @@
+package internalops
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"testing"
+
+	"github.com/primandproper/platform-go/v12/database"
+	"github.com/primandproper/platform-go/v12/identifiers"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// gooseVersionTable is where the migrator records what it has applied. It is the one
+// table in the public schema DestroyAllData deliberately leaves alone: truncating it
+// would leave a fully migrated database claiming it had never been migrated.
+const gooseVersionTable = "goose_db_version"
+
+// TestQuerier_Integration_DestroyAllData pins the property the query is for — that it
+// empties every table the schema has, not merely the ones somebody wrote a query builder
+// for.
+//
+// The old statement was a literal list assembled at generation time from
+// registerTableName calls in cmd/tools/codegen/queries, so a table with no generated
+// queries was silently absent from it: eleven were, including sessions and
+// webauthn_credentials, which is auth state surviving from one integration test into the
+// next. The statement now reads pg_tables when it runs, and this test is what says so.
+//
+// It also covers the platform-owned tables — the webhook, audit, saga, metering, outbox,
+// operations and authorization server ones — which never passed through this repository's
+// generator at all and so were never in the list either.
+func TestQuerier_Integration_DestroyAllData(t *testing.T) {
+	ctx := t.Context()
+	dbc := buildDatabaseClientForTest(t)
+
+	// sessions is one of the tables the registry-derived list missed, and it takes rows
+	// without needing a user to belong to. queue_test_messages was in that list, so
+	// seeding both says the fix added tables rather than swapped one set for another.
+	_, err := dbc.writeDB.ExecContext(ctx,
+		"INSERT INTO sessions (token, data, expiry) VALUES ($1, $2, NOW() + INTERVAL '1 hour')",
+		identifiers.New(), []byte("session data"),
+	)
+	require.NoError(t, err)
+	require.NoError(t, dbc.CreateQueueTestMessage(ctx, identifiers.New(), "destroy-all-data-"+identifiers.New()[:8]))
+
+	require.NotZero(t, countRows(ctx, t, dbc.readDB, "sessions"))
+	require.NotZero(t, countRows(ctx, t, dbc.readDB, "queue_test_messages"))
+
+	appliedMigrations := countRows(ctx, t, dbc.readDB, gooseVersionTable)
+	require.NotZero(t, appliedMigrations)
+
+	before := relfilenodes(ctx, t, dbc.readDB)
+	require.NotEmpty(t, before)
+	// The tables the registry missed, named so a regression that drops them again fails
+	// here by name rather than as a missing key in the sweep below. Two of the eleven —
+	// user_data_disclosures and webhook_trigger_events — are not here because 00029 and
+	// 00026 have since dropped them for their platform equivalents.
+	for _, table := range []string{
+		"ingredient_media", "meal_images", "preparation_media", "recipe_images",
+		"recipe_step_images", "sessions", "user_device_tokens", "webauthn_credentials",
+		"webauthn_sessions",
+	} {
+		require.Contains(t, before, table)
+	}
+
+	require.NoError(t, dbc.generatedQuerier.DestroyAllData(ctx, dbc.writeDB))
+
+	assert.Zero(t, countRows(ctx, t, dbc.readDB, "sessions"))
+	assert.Zero(t, countRows(ctx, t, dbc.readDB, "queue_test_messages"))
+
+	// Emptiness is not enough to prove coverage, because a table nobody seeded is empty
+	// whether or not the statement named it. TRUNCATE rewrites a table's file, though, so
+	// a table whose filenode did not move is one the statement skipped.
+	after := relfilenodes(ctx, t, dbc.readDB)
+	for table, filenode := range before {
+		if table == gooseVersionTable {
+			continue
+		}
+
+		assert.NotEqual(t, filenode, after[table], "%s was not truncated", table)
+	}
+
+	assert.Equal(t, before[gooseVersionTable], after[gooseVersionTable], "the migration record was truncated")
+	assert.Equal(t, appliedMigrations, countRows(ctx, t, dbc.readDB, gooseVersionTable))
+}
+
+// relfilenodes maps every ordinary table in the public schema to the file backing it.
+// Ordinary is relkind 'r': a partitioned table has no file of its own, and neither does a
+// view or a sequence.
+func relfilenodes(ctx context.Context, t *testing.T, db database.SQLQueryExecutor) map[string]int64 {
+	t.Helper()
+
+	rows, err := db.QueryContext(ctx, `SELECT c.relname, pg_relation_filenode(c.oid)
+		FROM pg_class AS c
+			JOIN pg_namespace AS n ON n.oid = c.relnamespace
+		WHERE n.nspname = 'public' AND c.relkind = 'r'`)
+	require.NoError(t, err)
+
+	defer func() { assert.NoError(t, rows.Close()) }()
+
+	filenodes := map[string]int64{}
+	for rows.Next() {
+		var (
+			table    string
+			filenode sql.NullInt64
+		)
+
+		require.NoError(t, rows.Scan(&table, &filenode))
+
+		if filenode.Valid {
+			filenodes[table] = filenode.Int64
+		}
+	}
+
+	require.NoError(t, rows.Err())
+
+	return filenodes
+}
+
+func countRows(ctx context.Context, t *testing.T, db database.SQLQueryExecutor, table string) int {
+	t.Helper()
+
+	var count int
+	// The table names this is called with are constants in this file, not input.
+	require.NoError(t, db.QueryRowContext(ctx, fmt.Sprintf("SELECT COUNT(*) FROM %s", table)).Scan(&count))
+
+	return count
+}

--- a/backend/internal/repositories/postgres/internalops/sqlc_queries/internalops.generated.sql
+++ b/backend/internal/repositories/postgres/internalops/sqlc_queries/internalops.generated.sql
@@ -1,5 +1,19 @@
 -- name: DestroyAllData :exec
-TRUNCATE account_instrument_ownerships, account_invitations, account_user_memberships, accounts, comments, issue_reports, meal_components, meal_list_items, meal_lists, meal_plan_events, meal_plan_grocery_list_items, meal_plan_option_votes, meal_plan_options, meal_plan_recipe_option_selections, meal_plan_tasks, meal_plans, meals, oauth2_clients, password_reset_tokens, payment_transactions, permissions, products, purchases, queue_test_messages, recipe_list_items, recipe_lists, recipe_media, recipe_prep_task_steps, recipe_prep_tasks, recipe_ratings, recipe_step_completion_condition_ingredients, recipe_step_completion_conditions, recipe_step_ingredients, recipe_step_instruments, recipe_step_products, recipe_step_vessels, recipe_steps, recipes, service_setting_configurations, service_settings, subscriptions, uploaded_media, user_avatars, user_ingredient_preferences, user_notifications, user_role_assignments, user_role_hierarchy, user_role_permissions, user_roles, user_sessions, users, valid_ingredient_group_members, valid_ingredient_groups, valid_ingredient_measurement_units, valid_ingredient_preparations, valid_ingredient_state_ingredients, valid_ingredient_states, valid_ingredients, valid_instruments, valid_measurement_unit_conversions, valid_measurement_units, valid_prep_task_configs, valid_preparation_instruments, valid_preparation_vessels, valid_preparations, valid_vessels, waitlist_signups, waitlists, webhook_trigger_configs, webhooks CASCADE;
+DO $$
+DECLARE
+	truncation TEXT;
+BEGIN
+	SELECT 'TRUNCATE ' || string_agg(format('%I.%I', schemaname, tablename), ', ') || ' CASCADE'
+	INTO truncation
+	FROM pg_tables
+	WHERE schemaname = 'public'
+	  AND tablename <> 'goose_db_version';
+
+	IF truncation IS NOT NULL THEN
+		EXECUTE truncation;
+	END IF;
+END
+$$;
 
 -- name: CreateQueueTestMessage :exec
 INSERT INTO queue_test_messages (id, queue_name) VALUES (sqlc.arg(id), sqlc.arg(queue_name));


### PR DESCRIPTION
Closes #1351.

## The problem

`DestroyAllData` was a literal table list assembled at generation time from `registerTableName` calls sprinkled through `cmd/tools/codegen/queries/`. A table got into the truncation as a side effect of somebody writing a query builder for it, so "is this table truncated?" was a question about the generator rather than about the schema — and a table with no generated queries was silently absent.

## The fix

The statement now reads `pg_tables` when it runs:

```sql
-- name: DestroyAllData :exec
DO $$
DECLARE
	truncation TEXT;
BEGIN
	SELECT 'TRUNCATE ' || string_agg(format('%I.%I', schemaname, tablename), ', ') || ' CASCADE'
	INTO truncation
	FROM pg_tables
	WHERE schemaname = 'public'
	  AND tablename <> 'goose_db_version';

	IF truncation IS NOT NULL THEN
		EXECUTE truncation;
	END IF;
END
$$;
```

`pg_tables` is the schema itself, so it cannot drift from the migrations. `goose_db_version` is the one exclusion — truncating it would leave a fully migrated database claiming it had never been migrated.

There is nothing left to register a table with, so the registry goes too: `registerTableName`, `getAllTables`, and all 72 call sites across 70 builder files. `docs/adding_a_new_domain.md` no longer tells people to call it.

## Two corrections to the issue's numbers

- **Eleven is now nine.** `user_data_disclosures` and `webhook_trigger_events` were dropped by 00029 and 00026 in favour of their platform equivalents, so they are not in the schema to miss any more.
- **The gap was wider than eleven.** Every platform-owned table was absent as well — `webhooks_*`, `ddb_audit_log_*`, `ddb_oauth2_*`, `ddb_dataprivacy_requests`, `saga_instances`, `metering_*`, `outbox_messages`, `operations`. Run against the old statement, the new test names **25** tables it left standing.

## Tests

`TestQuerier_Integration_DestroyAllData` seeds `sessions` (previously missed) and `queue_test_messages` (previously covered), runs the truncation, and then checks coverage over *every* table in the schema.

Row counts alone can't prove coverage — a table nobody seeded is empty whether or not the statement named it. So the test compares `pg_relation_filenode` before and after: `TRUNCATE` rewrites a table's file, so a table whose filenode did not move is one the statement skipped. It also asserts the migration record survived, both filenode and row count.

Verified to have teeth by running it against the pre-change generated query — it fails, naming all 25 missed tables.

There is also a generator-level unit test asserting the emitted statement queries `pg_tables` and contains no table names at all, so a reintroduced list fails there without needing a container.

## Verification

- `make test` — passes (`EXIT=0`), including the container-backed Postgres suites
- `sqlc compile`, `sqlc vet`, `sqlc generate` — all accept the `DO` block
- `go run ./cmd/tools/codegen/queries --check` — generated files match
- `golangci-lint` on both changed packages — 0 issues

## One thing deliberately left alone

The truncation wipes the RBAC and service-setting rows that 00019 and 00021 seed. That was already true of the old statement — those tables were in the list — so this change does not alter it, but it is worth knowing about if anything starts calling `DestroyAllData`, which nothing currently does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)