### PR TITLE
Audit exactly the comments the reference cascade archives

### DIFF
--- a/backend/cmd/tools/codegen/queries/comments_comments.go
+++ b/backend/cmd/tools/codegen/queries/comments_comments.go
@@ -44,17 +44,24 @@ func buildCommentsQueries(database string) []*Query {
 				{
 					Annotation: QueryAnnotation{
 						Name: "ArchiveCommentsForReference",
-						Type: ExecRowsType,
+						// This returns the rows it archived rather than a count, so the caller can
+						// audit exactly the set it updated. A separate read beforehand would be a
+						// different statement against a different snapshot, and the two would only
+						// agree by luck.
+						Type: ManyType,
 					},
 					Content: buildRawQuery((&builq.Builder{}).Addf(`UPDATE %s SET %s = %s WHERE %s IS NULL
 	AND %s = sqlc.arg(target_type)
-	AND %s = sqlc.arg(referenced_id);`,
+	AND %s = sqlc.arg(referenced_id)
+RETURNING %s, %s;`,
 						commentsTableName,
 						archivedAtColumn,
 						querygen.NowExpression,
 						archivedAtColumn,
 						"target_type",
 						"referenced_id",
+						idColumn,
+						belongsToUserColumn,
 					)),
 				},
 				{

--- a/backend/internal/repositories/postgres/comments/client_test.go
+++ b/backend/internal/repositories/postgres/comments/client_test.go
@@ -92,6 +92,31 @@ func createCommentForTest(t *testing.T, ctx context.Context, input *comments.Com
 	return created
 }
 
+// fetchAllAuditLogEntriesForUser drains the cursor rather than reading one page, because
+// the sets these tests assert on are deliberately larger than a page.
+func fetchAllAuditLogEntriesForUser(t *testing.T, ctx context.Context, auditRepo audit.Repository, userID string) []*audit.AuditLogEntry {
+	t.Helper()
+
+	filter := filtering.DefaultQueryFilter()
+	pageSize := uint16(filtering.MaxQueryFilterLimit)
+	filter.MaxResponseSize = &pageSize
+
+	var entries []*audit.AuditLogEntry
+	for {
+		page, err := auditRepo.GetAuditLogEntriesForUser(ctx, userID, filter)
+		require.NoError(t, err)
+		require.NotNil(t, page)
+
+		entries = append(entries, page.Data...)
+		if len(page.Data) < int(pageSize) {
+			return entries
+		}
+
+		cursor := page.Cursor
+		filter.Cursor = &cursor
+	}
+}
+
 func TestQuerier_Integration_Comments(t *testing.T) {
 	ctx := t.Context()
 	dbc, auditRepo := buildDatabaseClientForTest(t)
@@ -224,6 +249,106 @@ func TestQuerier_Integration_ArchiveCommentsForReference(t *testing.T) {
 	result, err := dbc.GetCommentsForReference(ctx, targetType, referencedID, nil)
 	require.NoError(t, err)
 	assert.Empty(t, result.Data)
+}
+
+// TestQuerier_Integration_ArchiveCommentsForReference_BeyondOnePage covers the case the
+// archive used to get wrong: a reference whose live comments do not fit in one page. The
+// UPDATE has never had a LIMIT, so every comment was archived; the audit entries used to
+// come from a separate, page-limited read, so past filtering.MaxQueryFilterLimit the log
+// was short by the overflow and nothing reported it.
+func TestQuerier_Integration_ArchiveCommentsForReference_BeyondOnePage(t *testing.T) {
+	ctx := t.Context()
+	dbc, auditRepo := buildDatabaseClientForTest(t)
+
+	user := pgtesting.CreateUserForTest(t, nil, dbc.writeDB)
+	referencedID := identifiers.New()
+	targetType := mealplanning.CommentTargetTypeRecipes
+
+	// One more than a single page holds, so a page-limited read cannot describe the whole set.
+	commentCount := filtering.MaxQueryFilterLimit + 1
+	expected := map[string]bool{}
+	for range commentCount {
+		input := fakes.BuildFakeCommentDatabaseCreationInput()
+		input.BelongsToUser = user.ID
+		input.ReferencedID = referencedID
+		input.TargetType = targetType
+
+		created, err := dbc.CreateComment(ctx, input)
+		require.NoError(t, err)
+		require.NotNil(t, created)
+		expected[created.ID] = true
+	}
+
+	require.NoError(t, dbc.ArchiveCommentsForReference(ctx, targetType, referencedID))
+
+	archivedIDs := map[string]bool{}
+	for _, entry := range fetchAllAuditLogEntriesForUser(t, ctx, auditRepo, user.ID) {
+		if entry.ResourceType == resourceTypeComments && entry.EventType == audit.AuditLogEventTypeArchived {
+			archivedIDs[entry.RelevantID] = true
+		}
+	}
+
+	assert.Len(t, archivedIDs, commentCount)
+	for id := range expected {
+		assert.True(t, archivedIDs[id], "no archival audit log entry for comment %q", id)
+	}
+
+	result, err := dbc.GetCommentsForReference(ctx, targetType, referencedID, nil)
+	require.NoError(t, err)
+	assert.Empty(t, result.Data)
+	assert.Zero(t, result.TotalCount)
+}
+
+// TestQuerier_Integration_ArchiveCommentsForReference_OnlyMatchingReference makes sure the
+// RETURNING clause reports the rows the UPDATE actually matched, rather than everything the
+// table holds: comments on another reference stay live and pick up no archival entry.
+func TestQuerier_Integration_ArchiveCommentsForReference_OnlyMatchingReference(t *testing.T) {
+	ctx := t.Context()
+	dbc, auditRepo := buildDatabaseClientForTest(t)
+
+	user := pgtesting.CreateUserForTest(t, nil, dbc.writeDB)
+	targetType := mealplanning.CommentTargetTypeMeals
+	archivedRef, untouchedRef := identifiers.New(), identifiers.New()
+
+	createFor := func(referencedID string) *comments.Comment {
+		input := fakes.BuildFakeCommentDatabaseCreationInput()
+		input.BelongsToUser = user.ID
+		input.ReferencedID = referencedID
+		input.TargetType = targetType
+
+		return createCommentForTest(t, ctx, input, dbc)
+	}
+
+	doomed := createFor(archivedRef)
+	survivor := createFor(untouchedRef)
+
+	require.NoError(t, dbc.ArchiveCommentsForReference(ctx, targetType, archivedRef))
+
+	var archivedRelevantIDs []string
+	for _, entry := range fetchAllAuditLogEntriesForUser(t, ctx, auditRepo, user.ID) {
+		if entry.ResourceType == resourceTypeComments && entry.EventType == audit.AuditLogEventTypeArchived {
+			archivedRelevantIDs = append(archivedRelevantIDs, entry.RelevantID)
+		}
+	}
+	assert.Equal(t, []string{doomed.ID}, archivedRelevantIDs)
+
+	fetched, err := dbc.GetComment(ctx, survivor.ID)
+	require.NoError(t, err)
+	require.NotNil(t, fetched)
+	assert.Nil(t, fetched.ArchivedAt)
+}
+
+// TestQuerier_Integration_ArchiveCommentsForReference_NoComments covers the empty case: a
+// reference with nothing live archives nothing and records nothing.
+func TestQuerier_Integration_ArchiveCommentsForReference_NoComments(t *testing.T) {
+	ctx := t.Context()
+	dbc, auditRepo := buildDatabaseClientForTest(t)
+
+	user := pgtesting.CreateUserForTest(t, nil, dbc.writeDB)
+
+	require.NoError(t, dbc.ArchiveCommentsForReference(ctx, mealplanning.CommentTargetTypeRecipes, identifiers.New()))
+
+	assert.Empty(t, fetchAllAuditLogEntriesForUser(t, ctx, auditRepo, user.ID))
 }
 
 func TestQuerier_CreateComment(T *testing.T) {

--- a/backend/internal/repositories/postgres/comments/comments.go
+++ b/backend/internal/repositories/postgres/comments/comments.go
@@ -376,32 +376,38 @@ func (q *repository) ArchiveCommentsForReference(ctx context.Context, targetType
 	tracing.AttachToSpan(span, "target_type", targetType)
 	tracing.AttachToSpan(span, "referenced_id", referencedID)
 
-	filter := filtering.DefaultQueryFilter()
-	maxSize := uint16(filtering.MaxQueryFilterLimit)
-	filter.MaxResponseSize = &maxSize
-	commentsResult, err := q.GetCommentsForReference(ctx, targetType, referencedID, filter)
-	if err != nil {
-		return observability.PrepareAndLogError(err, logger, span, "fetching comments for archive")
-	}
-
+	// The UPDATE returns the rows it archived, so the audited set and the archived set
+	// are the same set by construction. Reading the comments beforehand would be a
+	// second statement, against the replica, outside this transaction, and bounded by a
+	// page limit the UPDATE does not share — any of which makes the two sets differ.
 	return q.WithTransaction(ctx, func(tx database.SQLQueryExecutor) error {
-		if _, err = q.generatedQuerier.ArchiveCommentsForReference(ctx, tx, &generated.ArchiveCommentsForReferenceParams{
+		archived, err := q.generatedQuerier.ArchiveCommentsForReference(ctx, tx, &generated.ArchiveCommentsForReferenceParams{
 			TargetType:   targetTypeToGenerated(targetType),
 			ReferencedID: referencedID,
-		}); err != nil {
+		})
+		if err != nil {
 			return observability.PrepareAndLogError(err, logger, span, "archiving comments for reference")
 		}
 
-		for _, c := range commentsResult.Data {
-			if err = q.auditLogEntryRepo.Record(ctx, tx, &audit.AuditLogEntry{
+		if len(archived) == 0 {
+			return nil
+		}
+
+		// One Record call rather than one per comment: the set here is unbounded, and
+		// Record pays a chain-head lookup and an INSERT per call, not per entry.
+		entries := make([]*audit.AuditLogEntry, 0, len(archived))
+		for _, c := range archived {
+			entries = append(entries, &audit.AuditLogEntry{
 				ID:            identifiers.New(),
 				ResourceType:  resourceTypeComments,
 				RelevantID:    c.ID,
 				EventType:     audit.AuditLogEventTypeArchived,
 				BelongsToUser: c.BelongsToUser,
-			}); err != nil {
-				return observability.PrepareError(err, span, "creating audit log entry")
-			}
+			})
+		}
+
+		if err = q.auditLogEntryRepo.Record(ctx, tx, entries...); err != nil {
+			return observability.PrepareError(err, span, "creating audit log entries")
 		}
 
 		return nil

--- a/backend/internal/repositories/postgres/comments/generated/comments.generated.sql_generated.go
+++ b/backend/internal/repositories/postgres/comments/generated/comments.generated.sql_generated.go
@@ -26,10 +26,11 @@ func (q *Queries) ArchiveComment(ctx context.Context, db DBTX, id string) (int64
 	return result.RowsAffected()
 }
 
-const archiveCommentsForReference = `-- name: ArchiveCommentsForReference :execrows
+const archiveCommentsForReference = `-- name: ArchiveCommentsForReference :many
 UPDATE comments SET archived_at = CURRENT_TIMESTAMP WHERE archived_at IS NULL
 	AND target_type = $1
 	AND referenced_id = $2
+RETURNING id, belongs_to_user
 `
 
 type ArchiveCommentsForReferenceParams struct {
@@ -37,12 +38,32 @@ type ArchiveCommentsForReferenceParams struct {
 	ReferencedID string
 }
 
-func (q *Queries) ArchiveCommentsForReference(ctx context.Context, db DBTX, arg *ArchiveCommentsForReferenceParams) (int64, error) {
-	result, err := db.ExecContext(ctx, archiveCommentsForReference, arg.TargetType, arg.ReferencedID)
+type ArchiveCommentsForReferenceRow struct {
+	ID            string
+	BelongsToUser string
+}
+
+func (q *Queries) ArchiveCommentsForReference(ctx context.Context, db DBTX, arg *ArchiveCommentsForReferenceParams) ([]*ArchiveCommentsForReferenceRow, error) {
+	rows, err := db.QueryContext(ctx, archiveCommentsForReference, arg.TargetType, arg.ReferencedID)
 	if err != nil {
-		return 0, err
+		return nil, err
 	}
-	return result.RowsAffected()
+	defer rows.Close()
+	items := []*ArchiveCommentsForReferenceRow{}
+	for rows.Next() {
+		var i ArchiveCommentsForReferenceRow
+		if err := rows.Scan(&i.ID, &i.BelongsToUser); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 const createComment = `-- name: CreateComment :exec

--- a/backend/internal/repositories/postgres/comments/generated/querier_generated.go
+++ b/backend/internal/repositories/postgres/comments/generated/querier_generated.go
@@ -10,7 +10,7 @@ import (
 
 type Querier interface {
 	ArchiveComment(ctx context.Context, db DBTX, id string) (int64, error)
-	ArchiveCommentsForReference(ctx context.Context, db DBTX, arg *ArchiveCommentsForReferenceParams) (int64, error)
+	ArchiveCommentsForReference(ctx context.Context, db DBTX, arg *ArchiveCommentsForReferenceParams) ([]*ArchiveCommentsForReferenceRow, error)
 	CreateComment(ctx context.Context, db DBTX, arg *CreateCommentParams) error
 	GetComment(ctx context.Context, db DBTX, id string) (*Comments, error)
 	GetCommentsForReference(ctx context.Context, db DBTX, arg *GetCommentsForReferenceParams) ([]*GetCommentsForReferenceRow, error)

--- a/backend/internal/repositories/postgres/comments/sqlc_queries/comments.generated.sql
+++ b/backend/internal/repositories/postgres/comments/sqlc_queries/comments.generated.sql
@@ -36,10 +36,11 @@ UPDATE comments SET
 WHERE archived_at IS NULL
 	AND id = sqlc.arg(id);
 
--- name: ArchiveCommentsForReference :execrows
+-- name: ArchiveCommentsForReference :many
 UPDATE comments SET archived_at = CURRENT_TIMESTAMP WHERE archived_at IS NULL
 	AND target_type = sqlc.arg(target_type)
-	AND referenced_id = sqlc.arg(referenced_id);
+	AND referenced_id = sqlc.arg(referenced_id)
+RETURNING id, belongs_to_user;
 
 -- name: GetCommentsForReference :many
 SELECT


### PR DESCRIPTION
Closes #1353.

## The problem

`ArchiveCommentsForReference` archived an unbounded set and audited at most one page of it, read from the replica, outside the transaction that did the archiving. Three defects in twelve lines:

1. **The audit log was short by the overflow.** The `UPDATE` has no `LIMIT`; the read that decided which audit entries got written had one, of `filtering.MaxQueryFilterLimit` (250). A reference with 300 live comments archived 300 and recorded 250. Nothing reported it — the `UPDATE` succeeded, every `Record` succeeded, and the difference was a number nobody held.
2. **The read was not in the transaction.** A comment inserted between the read and the `UPDATE` was archived and described by no entry, at any table size.
3. **The read was against the replica.** `GetCommentsForReference` runs through `q.readDB`, so replica lag alone could make the two sets differ.

## The fix

`ArchiveCommentsForReference` becomes `:many` with `RETURNING id, belongs_to_user`:

```sql
-- name: ArchiveCommentsForReference :many
UPDATE comments SET archived_at = CURRENT_TIMESTAMP WHERE archived_at IS NULL
	AND target_type = $1
	AND referenced_id = $2
RETURNING id, belongs_to_user
```

One statement, inside the transaction, against the primary. The archived set and the audited set are the same set by construction rather than by agreement between two queries with different limits — which removes all three defects and deletes the pre-read entirely.

Draining the cursor inside the transaction would have fixed 1–3 as well, but it holds the whole set in memory and keeps two statements that have to agree about what they match.

One change beyond the issue's ask, in the same lines: the entries now go to a single variadic `Record` call rather than one per comment. The `Record` contract already asks for that ("Prefer one call with three entries to three calls with one" — it pays a chain-head lookup and an INSERT per call, not per entry), and it matters more now that the set has no ceiling.

## Changes

- `cmd/tools/codegen/queries/comments_comments.go` — `ExecRowsType` → `ManyType`, `RETURNING` clause added
- `internal/repositories/postgres/comments/sqlc_queries/`, `.../generated/` — regenerated (`make queries`, `sqlc generate`)
- `internal/repositories/postgres/comments/comments.go` — pre-read deleted, loop reads the returned rows, one batched `Record`

## Tests

Three new integration tests in `internal/repositories/postgres/comments/client_test.go`:

- **`_BeyondOnePage`** — the case that was broken: `filtering.MaxQueryFilterLimit + 1` comments on one reference, asserting an archival audit entry for every one. Fails against the old code with 250 entries where 251 were expected.
- **`_OnlyMatchingReference`** — `RETURNING` reports the rows the `UPDATE` matched, not the whole table: a comment on another reference stays live and gets no archival entry.
- **`_NoComments`** — a reference with nothing live archives nothing and records nothing.

A `fetchAllAuditLogEntriesForUser` helper drains the audit cursor, since the sets under assertion are deliberately larger than a page.

`make test` green (full backend suite, `-race -shuffle=on`), `make golang_lint` clean (0 issues), `make queries_lint` (sqlc `compile` + `vet`) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)