### PR TITLE
Delete limitRequestBody now that a Handle route carries the Router's bound

### DIFF
--- a/backend/internal/build/services/api/http/http_routes.go
+++ b/backend/internal/build/services/api/http/http_routes.go
@@ -18,7 +18,9 @@ import (
 	"github.com/primandproper/platform-go/v13/version"
 )
 
-// maxRequestBodyBytes bounds the request body of every route this router serves.
+// maxRequestBodyBytes bounds the request body of every route this router serves, the raw ones
+// included: a Handle route has no binding step to enforce a bound in, so the Router applies its
+// default to those as middleware instead.
 //
 // Nothing between the socket and a handler's read forms an opinion about how much to take: net/http
 // bounds headers and not bodies, so without this the ceiling is whatever a client cares to send. The
@@ -51,23 +53,19 @@ func ProvideAPIRouter(
 
 	registerOpsRoutes(router, healthRegistry)
 
-	// The raw routes below carry limitRequestBody because the Router-wide bound does not reach
-	// them: it is applied where a request is decoded into a typed input, and these are registered
-	// with Handle precisely because they are not.
-	//
 	// The paths are the ones oauth2server publishes in its discovery document — which is derived
 	// from the issuer, so mounting them anywhere else would mean advertising addresses that do
 	// not answer. POST /authorize is what a first-party client uses: it carries the session JWT
 	// in an Authorization header and gets the redirect back, where a browser GETs the same URL
 	// and is shown a login form. RFC 7591 registration is deliberately not routed.
 	router.Handle(http.MethodGet, oauth2server.PathAuthorizationServerMetadata, http.HandlerFunc(authService.AuthorizationServerMetadataHandler))
-	router.Handle(http.MethodGet, oauth2server.PathAuthorize, http.HandlerFunc(authService.AuthorizeHandler), limitRequestBody(maxRequestBodyBytes))
-	router.Handle(http.MethodPost, oauth2server.PathAuthorize, http.HandlerFunc(authService.AuthorizeHandler), limitRequestBody(maxRequestBodyBytes))
-	router.Handle(http.MethodPost, oauth2server.PathToken, http.HandlerFunc(authService.TokenHandler), limitRequestBody(maxRequestBodyBytes))
-	router.Handle(http.MethodPost, oauth2server.PathRevoke, http.HandlerFunc(authService.RevokeHandler), limitRequestBody(maxRequestBodyBytes))
+	router.Handle(http.MethodGet, oauth2server.PathAuthorize, http.HandlerFunc(authService.AuthorizeHandler))
+	router.Handle(http.MethodPost, oauth2server.PathAuthorize, http.HandlerFunc(authService.AuthorizeHandler))
+	router.Handle(http.MethodPost, oauth2server.PathToken, http.HandlerFunc(authService.TokenHandler))
+	router.Handle(http.MethodPost, oauth2server.PathRevoke, http.HandlerFunc(authService.RevokeHandler))
 
 	router.Group("/api/payments/webhooks", func(paymentsRouter *routing.Router) {
-		paymentsRouter.Handle(http.MethodPost, "/{provider}", http.HandlerFunc(paymentsWebhookHandler.Handle), limitRequestBody(maxRequestBodyBytes))
+		paymentsRouter.Handle(http.MethodPost, "/{provider}", http.HandlerFunc(paymentsWebhookHandler.Handle))
 	})
 
 	if err = router.Err(); err != nil {
@@ -117,34 +115,4 @@ func registerOpsRoutes(router *routing.Router, healthRegistry healthcheck.Regist
 			return version.Get(), nil
 		}, routing.WithEnvelope(false))
 	})
-}
-
-// limitRequestBody bounds a raw handler's request body the way WithDefaultMaxRequestBody bounds a
-// typed route's.
-//
-// The two need saying separately because the Router's bound lives in the binding step — the one that
-// turns a request into a typed input — and a route registered with Handle has no such step. Its
-// handler is given the request and does its own reading, so a bound stated at the Router is a bound
-// those routes never see. They are also the ones most worth bounding: every one of them is public
-// and unauthenticated.
-//
-// A body that declares itself over the limit is refused before the handler runs, and refused with a
-// 413 rather than a 400, because that is the only one of the two a client can act on: told 400, it
-// sends the same document again. A body that declares nothing — chunked, or lying about its length —
-// is cut off at the limit instead, and the handler fails on the read it was always going to do.
-func limitRequestBody(limit int64) routing.Middleware {
-	return func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
-			if req.ContentLength > limit {
-				http.Error(res, "request body too large", http.StatusRequestEntityTooLarge)
-				return
-			}
-
-			if req.Body != nil {
-				req.Body = http.MaxBytesReader(res, req.Body, limit)
-			}
-
-			next.ServeHTTP(res, req)
-		})
-	}
 }

--- a/backend/internal/build/services/api/http/http_routes_test.go
+++ b/backend/internal/build/services/api/http/http_routes_test.go
@@ -242,6 +242,23 @@ func Test_ProvideAPIRouter_requestBodyBound(T *testing.T) {
 		assert.False(t, authService.reached)
 	})
 
+	T.Run("an OAuth2 request declaring no length is cut off mid-read", func(t *testing.T) {
+		t.Parallel()
+
+		authService := &stubAuthService{}
+
+		// Chunked, or lying about its Content-Length: there is no length to check up front, so
+		// the handler runs and the read is what fails. Without the bound it would read as much
+		// as arrives.
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/token", strings.NewReader(strings.Repeat("x", maxRequestBodyBytes+1)))
+		req.ContentLength = -1
+		res := httptest.NewRecorder()
+		buildAPIRouter(t, authService, &stubProcessorRegistry{}).ServeHTTP(res, req)
+
+		assert.True(t, authService.reached)
+		assert.Equal(t, http.StatusBadRequest, res.Code)
+	})
+
 	T.Run("a payments webhook within the bound reaches its handler", func(t *testing.T) {
 		t.Parallel()
 
@@ -266,110 +283,5 @@ func Test_ProvideAPIRouter_requestBodyBound(T *testing.T) {
 		// to verify.
 		assert.Equal(t, http.StatusRequestEntityTooLarge, res.Code)
 		assert.False(t, registry.consulted)
-	})
-}
-
-func Test_limitRequestBody(T *testing.T) {
-	T.Parallel()
-
-	// echoBody reports what the wrapped handler saw: the bytes it managed to read, and the error
-	// that stopped it.
-	echoBody := func(read *int, readErr *error) http.Handler {
-		return http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
-			body, err := io.ReadAll(req.Body)
-			*read, *readErr = len(body), err
-
-			res.WriteHeader(http.StatusOK)
-		})
-	}
-
-	T.Run("a body within the bound is handed over whole", func(t *testing.T) {
-		t.Parallel()
-
-		var (
-			read    int
-			readErr error
-		)
-
-		req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/", strings.NewReader("hello"))
-		res := httptest.NewRecorder()
-		limitRequestBody(16)(echoBody(&read, &readErr)).ServeHTTP(res, req)
-
-		assert.Equal(t, http.StatusOK, res.Code)
-		assert.Equal(t, 5, read)
-		assert.NoError(t, readErr)
-	})
-
-	T.Run("a body exactly at the bound is handed over whole", func(t *testing.T) {
-		t.Parallel()
-
-		var (
-			read    int
-			readErr error
-		)
-
-		// The bound is what a request may carry, not what it must stay under: an off-by-one here
-		// rejects the largest legitimate request a client was told it could send.
-		req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/", strings.NewReader(strings.Repeat("x", 16)))
-		res := httptest.NewRecorder()
-		limitRequestBody(16)(echoBody(&read, &readErr)).ServeHTTP(res, req)
-
-		assert.Equal(t, http.StatusOK, res.Code)
-		assert.Equal(t, 16, read)
-		assert.NoError(t, readErr)
-	})
-
-	T.Run("a body declaring itself over the bound never reaches the handler", func(t *testing.T) {
-		t.Parallel()
-
-		var (
-			read    int
-			readErr error
-		)
-
-		req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/", strings.NewReader(strings.Repeat("x", 17)))
-		res := httptest.NewRecorder()
-		limitRequestBody(16)(echoBody(&read, &readErr)).ServeHTTP(res, req)
-
-		assert.Equal(t, http.StatusRequestEntityTooLarge, res.Code)
-		assert.Zero(t, read)
-		assert.NoError(t, readErr)
-	})
-
-	T.Run("a body declaring no length is cut off at the bound", func(t *testing.T) {
-		t.Parallel()
-
-		var (
-			read    int
-			readErr error
-		)
-
-		// Chunked, or lying: there is no length to check up front, so the handler runs and the
-		// read is what fails.
-		req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/", strings.NewReader(strings.Repeat("x", 64)))
-		req.ContentLength = -1
-		res := httptest.NewRecorder()
-		limitRequestBody(16)(echoBody(&read, &readErr)).ServeHTTP(res, req)
-
-		var tooLarge *http.MaxBytesError
-		require.ErrorAs(t, readErr, &tooLarge)
-		assert.Equal(t, int64(16), tooLarge.Limit)
-	})
-
-	T.Run("a request with no body at all passes through", func(t *testing.T) {
-		t.Parallel()
-
-		var (
-			read    int
-			readErr error
-		)
-
-		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", http.NoBody)
-		res := httptest.NewRecorder()
-		limitRequestBody(16)(echoBody(&read, &readErr)).ServeHTTP(res, req)
-
-		assert.Equal(t, http.StatusOK, res.Code)
-		assert.Zero(t, read)
-		assert.NoError(t, readErr)
 	})
 }


### PR DESCRIPTION
Closes #1374.

`limitRequestBody` was merged in #1331 as the one marked exception to the park-it-upstream rule in #1335: four public **unauthenticated** routes — three OAuth2, one payment webhook — were registered with `Handle`, which in platform-go v11 had no binding step and so never saw `WithDefaultMaxRequestBody`. It carried a comment saying it was deletable once platform grew the bound itself.

It has. Verified against the `v13.0.0` tag in the module cache rather than assumed:

- `Router.Handle` applies `LimitRequestBody(r.maxRequestBody)` itself, outside the route's own middleware, so a webhook signature verifier that reads the body reads a bounded one (`routing/register.go:293-302`).
- `Router.Group` copies the Router by value, so the bound reaches the payments webhook subrouter (`register.go:327-332`).
- `routing.LimitRequestBody` is exported (`register.go:106`) and is byte-for-byte the logic the local copy had: over-declared `Content-Length` refused 413 before `next`, an undeclared length cut off mid-read by `MaxBytesReader`, and `res` passed so a client that keeps sending is stopped.
- The package doc says it in as many words: *"Every route means the Handle ones too."*

That was platform-go [#274](https://github.com/primandproper/platform-go/pull/274) closing [#273](https://github.com/primandproper/platform-go/issues/273), shipped in v12 and carried into the v13 this repo is on since #1367.

## What this deletes

- `limitRequestBody` and its doc comment
- `Test_limitRequestBody` — five subtests that now exercise platform's middleware, which platform tests itself
- the five `limitRequestBody(maxRequestBodyBytes)` arguments on the OAuth2 and payment-webhook `Handle` calls
- the paragraph explaining why the raw routes carried them

`WithDefaultMaxRequestBody(maxRequestBodyBytes)` stays, and is now the only place the 1 MiB is stated. Its doc comment was rewritten to record where the enforcement lives rather than where it doesn't.

## Behaviour

Unchanged on the five routes that carried the middleware — the argument they lost is now applied by `Handle`, with the same logic.

One route gains a bound it never had: `GET /.well-known/oauth-authorization-server` was the single `Handle` call registered *without* `limitRequestBody`, and now inherits the Router's. That is the bug the local workaround's shape made easy to write, and platform applying the bound uniformly is what fixes it.

The only visible difference anywhere is the refusal's plain-text body: `"request body too large"` becomes platform's `"request body exceeds the 1048576 byte limit"`. Nothing asserts on it, and the status code — the part a client acts on — is the same 413.

## Tests

`Test_ProvideAPIRouter_requestBodyBound` already drove both OAuth2 and webhook routes through the real router, so it holds the 413-before-the-handler property without changes. Deleting the unit test would have dropped the *cut off mid-read* half of the contract, so this adds one subtest for it at the router level, where it tests the wiring rather than platform's middleware in isolation: a `/token` request with `ContentLength = -1` and an oversized body reaches the handler and fails on the read, which the stub reports as a 400.

Package tests, `go vet`, and `golangci-lint` are clean.