### PR TITLE
Cover the async outcomes by driving the workers directly

### DIFF
--- a/backend/deploy/environments/localdev/config_files/async_message_handler_config.json
+++ b/backend/deploy/environments/localdev/config_files/async_message_handler_config.json
@@ -8,6 +8,9 @@
 	"pushNotifications": {
 		"provider": "noop"
 	},
+	"encoding": {
+		"contentType": "application/json"
+	},
 	"events": {
 		"consumer": {
 			"provider": "redis",

--- a/backend/deploy/environments/prod/kustomize/configs/async_message_handler_config.json
+++ b/backend/deploy/environments/prod/kustomize/configs/async_message_handler_config.json
@@ -15,6 +15,9 @@
 		"fcm": {},
 		"provider": "apns_fcm"
 	},
+	"encoding": {
+		"contentType": "application/json"
+	},
 	"events": {
 		"consumer": {
 			"provider": "pubsub",

--- a/backend/deploy/environments/testing/config_files/async_message_handler_config.json
+++ b/backend/deploy/environments/testing/config_files/async_message_handler_config.json
@@ -8,6 +8,9 @@
 	"pushNotifications": {
 		"provider": "noop"
 	},
+	"encoding": {
+		"contentType": "application/json"
+	},
 	"events": {
 		"consumer": {
 			"provider": "redis",

--- a/backend/internal/build/jobs/scheduler/build.go
+++ b/backend/internal/build/jobs/scheduler/build.go
@@ -11,6 +11,8 @@ import (
 	"github.com/primandproper/dinnerdonebetter/backend/internal/domain/mealplanning/recipeanalysis"
 	notificationsmanager "github.com/primandproper/dinnerdonebetter/backend/internal/domain/notifications/manager"
 	"github.com/primandproper/dinnerdonebetter/backend/internal/domain/notifications/push"
+	settingsmanager "github.com/primandproper/dinnerdonebetter/backend/internal/domain/settings/manager"
+	waitlistsmanager "github.com/primandproper/dinnerdonebetter/backend/internal/domain/waitlists/manager"
 	queuescfg "github.com/primandproper/dinnerdonebetter/backend/internal/queues/config"
 	"github.com/primandproper/dinnerdonebetter/backend/internal/repositories/postgres/auditlogentries"
 	commentsrepo "github.com/primandproper/dinnerdonebetter/backend/internal/repositories/postgres/comments"
@@ -20,9 +22,7 @@ import (
 	issuereportsrepo "github.com/primandproper/dinnerdonebetter/backend/internal/repositories/postgres/issuereports"
 	mealplanningrepo "github.com/primandproper/dinnerdonebetter/backend/internal/repositories/postgres/mealplanning"
 	paymentsrepo "github.com/primandproper/dinnerdonebetter/backend/internal/repositories/postgres/payments"
-	settingsrepo "github.com/primandproper/dinnerdonebetter/backend/internal/repositories/postgres/settings"
 	uploadedmediarepo "github.com/primandproper/dinnerdonebetter/backend/internal/repositories/postgres/uploadedmedia"
-	waitlistsrepo "github.com/primandproper/dinnerdonebetter/backend/internal/repositories/postgres/waitlists"
 	webhooksrepo "github.com/primandproper/dinnerdonebetter/backend/internal/repositories/postgres/webhooks"
 	dataprivacycfg "github.com/primandproper/dinnerdonebetter/backend/internal/services/dataprivacy/config"
 	identityindexing "github.com/primandproper/dinnerdonebetter/backend/internal/services/identity/indexing"
@@ -97,9 +97,15 @@ func BuildInjector(
 	internalopsrepo.RegisterInternalOpsRepository(i)
 	issuereportsrepo.RegisterIssueReportsRepository(i)
 	paymentsrepo.RegisterPaymentsRepository(i)
-	settingsrepo.RegisterSettingsRepository(i)
 	uploadedmediarepo.RegisterUploadedMediaRepository(i)
-	waitlistsrepo.RegisterWaitlistsRepository(i)
+	// Settings and waitlists come in through their managers rather than their repositories,
+	// which is not a stylistic choice: their repository registrations provide the concrete
+	// *Repository and only the manager binds the domain interface the data privacy collectors
+	// ask for. Registering the repository alone left this process unable to build the privacy
+	// registry at all — and because samber/do resolves lazily, unable in a way nothing noticed
+	// until something actually asked for a subject's data.
+	settingsmanager.RegisterSettingsDataManager(i)
+	waitlistsmanager.RegisterWaitlistDataManager(i)
 	// This also registers the webhook Store and Dispatcher, which this process needs in both
 	// directions: dispatch happens inside the transaction that causes the event, and the meal
 	// plan finalizer emits events like any request does.

--- a/backend/internal/config/environment.go
+++ b/backend/internal/config/environment.go
@@ -493,7 +493,12 @@ func (s *EnvironmentConfigSet) Render(ctx context.Context, outputDir string) err
 	schedulerConfig.Observability.Profiling.ServiceName = schedulerConfigObservabilityServiceName
 
 	amhConfig := &AsyncMessageHandlerConfig{
-		Queues:            s.RootConfig.Queues,
+		Queues: s.RootConfig.Queues,
+		// The same encoder the API server writes its messages with, which is not a
+		// nicety: the handler decodes what the API published, and this section was
+		// missing entirely — a content type of "" is not a default, it is a decoder
+		// that refuses to be built, so the process could not boot at all.
+		Encoding:          s.RootConfig.Encoding,
 		Email:             s.RootConfig.Email,
 		Analytics:         s.RootConfig.Analytics,
 		Search:            s.RootConfig.TextSearch,

--- a/backend/internal/localdev/data_privacy_worker.go
+++ b/backend/internal/localdev/data_privacy_worker.go
@@ -1,0 +1,153 @@
+package localdev
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	schedulerbuild "github.com/primandproper/dinnerdonebetter/backend/internal/build/jobs/scheduler"
+	"github.com/primandproper/dinnerdonebetter/backend/internal/config"
+	dataprivacycfg "github.com/primandproper/dinnerdonebetter/backend/internal/services/dataprivacy/config"
+
+	"github.com/primandproper/platform-go/v13/clock"
+	"github.com/primandproper/platform-go/v13/database"
+	platformdataprivacy "github.com/primandproper/platform-go/v13/dataprivacy"
+	platformdataprivacycfg "github.com/primandproper/platform-go/v13/dataprivacy/config"
+	"github.com/primandproper/platform-go/v13/operations"
+
+	"github.com/samber/do/v2"
+)
+
+// DataPrivacyFulfillment is the half of data privacy that does not run in the API server: the
+// operations worker that fulfills a request, and the sweeper that expires what it produced.
+//
+// It exists for the reason StartSagaWorker does. The API server records a subject access
+// request and returns; the gather, the artifact, and the erasure all happen in the scheduler,
+// so an in-process harness that wants to assert an export was produced has to stand that half
+// up itself. What it stands up is the scheduler's own container — the same registry, the same
+// collectors, the same bucket and cipher — rather than a hand-assembled approximation of it,
+// because the failure this is here to catch is a domain missing from an export, and a
+// hand-assembled registry is one that cannot miss anything.
+//
+// Nothing here is a fake. The queue is the operations queue over the real table, the claim and
+// the lease are the ones production runs, and the artifact is written to the configured bucket
+// and read back through the API server's own Open. The only thing a caller supplies is when to
+// run: Worker.Run blocks and is stopped by cancelling its context, which is what lets a test
+// submit a request and then wait for an outcome rather than for a poll interval.
+type DataPrivacyFulfillment struct {
+	// Worker claims privacy operations and runs them. Run blocks until its context is done.
+	Worker *operations.Worker
+
+	// Sweeper expires artifacts past their window, lapses unconfirmed erasures, and reaps
+	// terminal request records. It is driven by a scheduled job in production, so a caller
+	// advances it by calling Sweep.
+	Sweeper *platformdataprivacy.Sweeper
+
+	// Registry is the set of collectors and erasers the worker fulfills through. An export is
+	// exactly what this holds, so a caller asserting on which domains an export covers asks it
+	// rather than reading a document that omits the domains a subject happens to be absent
+	// from.
+	Registry *platformdataprivacy.Registry
+
+	// Store is the request table. It is exposed because there are requests the API cannot be
+	// asked about: an erasure ends by deleting the subject, so the one principal entitled to
+	// read that request's outcome no longer exists. An operator reads the row; so does a test.
+	Store platformdataprivacy.Store
+
+	// Shutdown releases the container: the connection pool this half opened, and the queue's
+	// goroutine.
+	Shutdown func(context.Context) error
+
+	artifacts dataprivacycfg.ArtifactUploadManager
+	cfg       *platformdataprivacycfg.Config
+}
+
+// NewDataPrivacyFulfillment builds the fulfillment worker and the sweeper from a scheduler
+// configuration.
+//
+// It takes the scheduler's own configuration rather than deriving one from the API server's,
+// which makes the agreement between the two processes something a caller can test rather than
+// something this function arranges. They have to agree on the bucket, the cipher, the request
+// table and the operations queue — an artifact written under one key is not one the other can
+// open, and a request submitted under one queue name is not one anything else claims — and a
+// harness that fed both halves the same struct could never notice if they stopped.
+func NewDataPrivacyFulfillment(ctx context.Context, cfg *config.SchedulerConfig) (*DataPrivacyFulfillment, error) {
+	i := schedulerbuild.BuildInjector(ctx, cfg)
+
+	worker, err := do.Invoke[*operations.Worker](i)
+	if err != nil {
+		return nil, fmt.Errorf("building the operations worker: %w", err)
+	}
+
+	sweeper, err := do.Invoke[*platformdataprivacy.Sweeper](i)
+	if err != nil {
+		return nil, fmt.Errorf("building the data privacy sweeper: %w", err)
+	}
+
+	store, err := do.Invoke[platformdataprivacy.Store](i)
+	if err != nil {
+		return nil, fmt.Errorf("building the data privacy store: %w", err)
+	}
+
+	artifacts, err := do.Invoke[dataprivacycfg.ArtifactUploadManager](i)
+	if err != nil {
+		return nil, fmt.Errorf("building the artifact upload manager: %w", err)
+	}
+
+	registry, err := do.Invoke[*platformdataprivacy.Registry](i)
+	if err != nil {
+		return nil, fmt.Errorf("building the data privacy registry: %w", err)
+	}
+
+	return &DataPrivacyFulfillment{
+		Worker:   worker,
+		Sweeper:  sweeper,
+		Registry: registry,
+		Store:    store,
+		Shutdown: func(ctx context.Context) error {
+			if report := i.ShutdownWithContext(ctx); report != nil && !report.Succeed {
+				return report
+			}
+
+			return nil
+		},
+		artifacts: artifacts,
+		cfg: dataprivacycfg.PlatformConfig(
+			&cfg.DataPrivacy,
+			do.MustInvoke[database.Client](i),
+		),
+	}, nil
+}
+
+// SweeperAt returns a second Sweeper over the same store and bucket that believes the time is
+// now.
+//
+// An export artifact survives for a week, and a sweep is the thing that ends that. Neither
+// number is something a test can wait out, and neither is something to shorten in configuration
+// either: the TTL is stamped into the request row by the worker that completed it, so lowering
+// it would expire every artifact the rest of the suite produced. Moving one sweeper's clock
+// instead leaves the rows alone and asks the question the sweep actually answers — what is past
+// its window as of this instant.
+func (f *DataPrivacyFulfillment) SweeperAt(ctx context.Context, now time.Time) (*platformdataprivacy.Sweeper, error) {
+	return platformdataprivacycfg.NewSweeper(
+		ctx,
+		f.cfg,
+		f.Store,
+		f.artifacts.UploadManager,
+		platformdataprivacycfg.WithSweeperOptions(platformdataprivacy.WithSweeperClock(fixedClock{now: now})),
+	)
+}
+
+// fixedClock is a clock stopped at an instant. Only Now and Since are meaningful; the sweep
+// neither sleeps nor ticks.
+type fixedClock struct {
+	now time.Time
+}
+
+func (c fixedClock) Now() time.Time { return c.now }
+
+func (c fixedClock) Since(t time.Time) time.Duration { return c.now.Sub(t) }
+
+func (c fixedClock) Sleep(context.Context, time.Duration) error { return nil }
+
+func (c fixedClock) NewTicker(d time.Duration) clock.Ticker { return clock.NewClock().NewTicker(d) }

--- a/backend/internal/repositories/postgres/migrations/migration_files/00019_rbac.sql
+++ b/backend/internal/repositories/postgres/migrations/migration_files/00019_rbac.sql
@@ -209,7 +209,11 @@ INSERT INTO permissions (id, name, description) VALUES
     ('d74epksn9qd63pdj4460', 'create.subscriptions', 'Create subscriptions'),
     ('d74epksn9qd63pdj446g', 'read.subscriptions', 'Read subscriptions'),
     ('d74epksn9qd63pdj4470', 'update.subscriptions', 'Update subscriptions'),
-    ('d74epksn9qd63pdj447g', 'archive.subscriptions', 'Archive subscriptions');
+    ('d74epksn9qd63pdj447g', 'archive.subscriptions', 'Archive subscriptions'),
+    -- data privacy
+    ('d74epksn9qd63pdj45h0', 'create.user_data_reports', 'Request an export of one''s own data'),
+    ('d74epksn9qd63pdj45hg', 'read.user_data_reports', 'Read one''s own data privacy requests and artifacts'),
+    ('d74epksn9qd63pdj45i0', 'destroy.user_data', 'Request erasure of one''s own data');
 
 -- =============================================================================
 -- SEED DATA: core role-permission mappings
@@ -303,4 +307,11 @@ INSERT INTO user_role_permissions (id, role_id, permission_id) VALUES
     ('d74epksn9qd63pdj45eg', 'role_account_member', 'd74epksn9qd63pdj442g'),
     ('d74epksn9qd63pdj45f0', 'role_account_member', 'd74epksn9qd63pdj4430'),
     ('d74epksn9qd63pdj45fg', 'role_account_member', 'd74epksn9qd63pdj443g'),
-    ('d74epksn9qd63pdj45g0', 'role_account_member', 'd74epksn9qd63pdj446g');
+    ('d74epksn9qd63pdj45g0', 'role_account_member', 'd74epksn9qd63pdj446g'),
+    -- Data privacy, granted to the base role every principal inherits. A subject access
+    -- request is a right the subject holds, not an account privilege: it is asked for by a
+    -- person about themselves, and there is no role a real user could hold that should be
+    -- unable to ask.
+    ('d74epksn9qd63pdj45j0', 'role_account_member', 'd74epksn9qd63pdj45h0'),
+    ('d74epksn9qd63pdj45jg', 'role_account_member', 'd74epksn9qd63pdj45hg'),
+    ('d74epksn9qd63pdj45k0', 'role_account_member', 'd74epksn9qd63pdj45i0');

--- a/backend/internal/repositories/postgres/migrations/rbac_seed_test.go
+++ b/backend/internal/repositories/postgres/migrations/rbac_seed_test.go
@@ -1,0 +1,81 @@
+package migrations
+
+import (
+	"io/fs"
+	"strings"
+	"testing"
+
+	"github.com/primandproper/dinnerdonebetter/backend/internal/authorization"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRBACSeed_CoversEveryPermissionARoleHolds is the check that a permission a role holds in Go
+// is a permission that exists in the database.
+//
+// Authorization is decided against rows: a role's permissions come from user_role_permissions,
+// seeded here, while the slices in internal/authorization are what the method table and the
+// platform policy are written from. A permission declared there and never seeded is a method no
+// principal can call, and nothing says so — the request is simply denied, exactly as it would be
+// for a caller who genuinely lacked it.
+//
+// That is not hypothetical either. The three data privacy permissions were declared, mapped to
+// the data privacy service's methods, and listed under AccountMemberPermissions, and none of them
+// existed in the database — so no user could request an export of their own data, ask for it
+// back, or ask to be erased, and the only symptom was a permission denial that looked correct.
+//
+// It reads the migration text rather than a migrated database on purpose: the seed is what is
+// under test, and a test that needed a container would not run in the ordinary unit pass, which
+// is where a missing permission should be caught.
+func TestRBACSeed_CoversEveryPermissionARoleHolds(T *testing.T) {
+	T.Parallel()
+
+	T.Run("every declared permission is seeded", func(t *testing.T) {
+		t.Parallel()
+
+		seeded := seededMigrationText(t)
+
+		for _, set := range []struct {
+			name  string
+			perms []authorization.Permission
+		}{
+			{"service_admin", authorization.ServiceAdminPermissions},
+			{"service_data_admin", authorization.ServiceDataAdminPermissions},
+			{"account_admin", authorization.AccountAdminPermissions},
+			{"account_member", authorization.AccountMemberPermissions},
+		} {
+			for _, permission := range set.perms {
+				assert.Contains(t, seeded, "'"+string(permission)+"'",
+					"%s holds %q, which no migration seeds", set.name, permission)
+			}
+		}
+	})
+}
+
+// seededMigrationText is every migration file's text, concatenated.
+//
+// All of them rather than the RBAC file alone: permissions are seeded in more than one place —
+// the core set with the RBAC tables, the meal planning set with the meal planning schema — and a
+// test that knew which file a permission ought to live in would fail the next time somebody
+// chose differently, for no reason a reader could act on.
+func seededMigrationText(t *testing.T) string {
+	t.Helper()
+
+	files, err := fs.Sub(rawMigrations, "migration_files")
+	require.NoError(t, err)
+
+	entries, err := fs.ReadDir(files, ".")
+	require.NoError(t, err)
+	require.NotEmpty(t, entries)
+
+	var sql strings.Builder
+	for _, entry := range entries {
+		contents, readErr := fs.ReadFile(files, entry.Name())
+		require.NoError(t, readErr)
+
+		sql.Write(contents)
+	}
+
+	return sql.String()
+}

--- a/backend/internal/repositories/postgres/webhooks/delivery_lifecycle_test.go
+++ b/backend/internal/repositories/postgres/webhooks/delivery_lifecycle_test.go
@@ -1,0 +1,329 @@
+package webhooks
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	types "github.com/primandproper/dinnerdonebetter/backend/internal/domain/webhooks"
+	"github.com/primandproper/dinnerdonebetter/backend/internal/domain/webhooks/converters"
+	"github.com/primandproper/dinnerdonebetter/backend/internal/domain/webhooks/fakes"
+	"github.com/primandproper/dinnerdonebetter/backend/internal/repositories/postgres/events"
+	pgtesting "github.com/primandproper/dinnerdonebetter/backend/internal/repositories/postgres/testing"
+
+	"github.com/primandproper/platform-go/v13/clock"
+	"github.com/primandproper/platform-go/v13/database"
+	loggingnoop "github.com/primandproper/platform-go/v13/observability/logging/noop"
+	"github.com/primandproper/platform-go/v13/webhooks"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The retention window and the reap cadence these tests run the worker with.
+//
+// They are the configuration's own floors rather than something smaller, because the floors are
+// validated: a retention under a minute and a reap interval under a second are rejected outright,
+// on the grounds that a deployment configured that way is deleting its delivery log faster than
+// anybody could read it. A test cannot wait a minute either, which is what advanceableClock is
+// for.
+const (
+	testRetention    = time.Minute
+	testReapInterval = time.Second
+)
+
+// advanceableClock is the wall clock with an offset a test can move forward.
+//
+// The reap window is "delivered more than Retention ago", measured against the worker's own
+// clock, and Retention cannot be configured below a minute — a deployment sweeping its delivery
+// log faster than that is deleting evidence nobody could have read. Waiting out a minute per
+// test is not an option either, and skewing the clock from the start buys nothing: the worker
+// stamps delivered_at from the same clock it measures the window with, so a constant offset
+// moves both ends together.
+//
+// Moving it after the delivery lands is what actually reaches the window, and it reaches it
+// through the same arithmetic the worker does in production.
+//
+// Only Now and Since are offset. Sleep and NewTicker stay on the wall clock, because the poll
+// and reap loops have to run at real speed for a test to observe them at all — a fake ticker
+// would mean driving the loop rather than watching it.
+type advanceableClock struct {
+	wall   clock.WallClock
+	offset atomic.Int64
+}
+
+// newAdvanceableClock returns a clock that starts in step with the wall clock.
+func newAdvanceableClock() *advanceableClock {
+	return &advanceableClock{wall: clock.NewClock()}
+}
+
+// advance moves the clock forward. It is safe to call while the worker is running, which is the
+// only way it is ever called.
+func (c *advanceableClock) advance(d time.Duration) { c.offset.Add(int64(d)) }
+
+func (c *advanceableClock) Now() time.Time {
+	return c.wall.Now().Add(time.Duration(c.offset.Load()))
+}
+
+func (c *advanceableClock) Since(t time.Time) time.Duration { return c.Now().Sub(t) }
+
+func (c *advanceableClock) Sleep(ctx context.Context, d time.Duration) error {
+	return c.wall.Sleep(ctx, d)
+}
+
+func (c *advanceableClock) NewTicker(d time.Duration) clock.Ticker { return c.wall.NewTicker(d) }
+
+// dispatchState is what the delivery worker has written about one dispatch row.
+//
+// It is read with SQL rather than through the Store because the Store deliberately offers no
+// way to read one back: Claim, MarkDelivered and RecordFailure are the whole of its dispatch
+// surface, because nothing in production needs to ask what state a dispatch is in. A test
+// asserting that a dispatch was marked dead rather than lost does, and the row is the fact.
+type dispatchState struct {
+	lastError string
+	attempts  int
+	dead      bool
+	delivered bool
+}
+
+// onlyDispatch reads the single dispatch row in this test's database.
+//
+// Single because every test here stands up an isolated database and emits one event to one
+// subscriber, so a second row would mean the fan-out did something nobody asked for — which is
+// worth failing on rather than filtering out.
+func onlyDispatch(t *testing.T, ctx context.Context, pgc database.Client) dispatchState {
+	t.Helper()
+
+	rows, err := pgc.Reader().QueryContext(ctx,
+		"SELECT attempts, dead, delivered_at IS NOT NULL, COALESCE(last_error, '') FROM webhooks_dispatches")
+	require.NoError(t, err)
+
+	defer func() { assert.NoError(t, rows.Close()) }()
+
+	var states []dispatchState
+	for rows.Next() {
+		var state dispatchState
+		require.NoError(t, rows.Scan(&state.attempts, &state.dead, &state.delivered, &state.lastError))
+		states = append(states, state)
+	}
+	require.NoError(t, rows.Err())
+
+	require.Len(t, states, 1, "expected exactly one dispatch row")
+
+	return states[0]
+}
+
+// countRows counts a table, for the reaper's assertions.
+func countRows(t *testing.T, ctx context.Context, pgc database.Client, table string) int {
+	t.Helper()
+
+	var count int
+	require.NoError(t, pgc.Reader().QueryRowContext(ctx, "SELECT COUNT(*) FROM "+table).Scan(&count))
+
+	return count
+}
+
+// subscribeAndEmit registers a subscriber for eventType and emits one event to it, returning
+// nothing: every assertion below is about what the worker did afterwards, not about the write.
+//
+// The emit goes through the Emitter inside a transaction, which is the only way this
+// application dispatches — a delivery row and the state change that caused it commit together.
+func subscribeAndEmit(t *testing.T, ctx context.Context, repo *repository, emitter *events.Emitter, pgc database.Client, subscriberURL, eventType string) {
+	t.Helper()
+
+	user := pgtesting.CreateUserForTest(t, nil, repo.writeDB)
+	account := pgtesting.CreateAccountForTest(t, nil, user.ID, repo.writeDB)
+
+	webhook := fakes.BuildFakeWebhook()
+	webhook.BelongsToAccount = account.ID
+	webhook.CreatedByUser = user.ID
+	webhook.URL = subscriberURL
+	webhook.TriggerConfigs[0].EventType = eventType
+
+	_, err := repo.CreateWebhook(ctx, converters.ConvertWebhookToWebhookDatabaseCreationInput(webhook))
+	require.NoError(t, err)
+
+	require.NoError(t, pgc.WithTransaction(ctx, func(tx database.Tx) error {
+		return emitter.Emit(ctx, tx, loggingnoop.NewLogger(), eventType, account.ID, nil)
+	}))
+}
+
+// runWorker starts the delivery loop and stops it when the test ends.
+func runWorker(t *testing.T, worker *webhooks.Worker) {
+	t.Helper()
+
+	go worker.Run()
+
+	t.Cleanup(func() {
+		// A background context: t.Context() is already cancelled by the time cleanups run,
+		// and a Close given an expired deadline reports a failure that is only about the
+		// deadline.
+		closeCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		assert.NoError(t, worker.Close(closeCtx))
+	})
+}
+
+// TestIntegration_WebhookDelivery_RetriesThenDies is the failure half of delivery.
+//
+// A subscriber that is down is the ordinary case, and the property that matters is that the
+// dispatch is retried a bounded number of times and then marked dead — not retried forever, and
+// not quietly forgotten. Dead is a row an operator can find and replay; lost is an event a
+// subscriber will never see and nobody can name.
+//
+// Two attempts rather than production's ten, and a backoff of milliseconds rather than an hour,
+// because the point is to reach the ceiling. Both are plain config fields, so nothing here
+// reaches past the worker's constructor to get there.
+func TestIntegration_WebhookDelivery_RetriesThenDies(t *testing.T) {
+	ctx := t.Context()
+
+	repo, emitter, worker, pgc := buildDeliveryHarness(t, func(tuning *deliveryTuning) {
+		tuning.Config.Worker.Backoff.MaxAttempts = 2
+		tuning.Config.Worker.Backoff.InitialDelay = 25 * time.Millisecond
+		tuning.Config.Worker.Backoff.MaxDelay = 25 * time.Millisecond
+		// Jitter would make the second attempt land anywhere in a window, which is right in
+		// production and only makes this test's budget wider.
+		tuning.Config.Worker.Backoff.UseJitter = false
+	})
+
+	// 500 rather than a 4xx: a subscriber that understood and refused goes straight to dead
+	// without a retry, which would pass this test while proving nothing about the schedule.
+	subscriber, received := newTestSubscriber(t, func() int { return http.StatusInternalServerError })
+
+	subscribeAndEmit(t, ctx, repo, emitter, pgc, subscriber.URL, types.WebhookCreatedServiceEventType)
+
+	runWorker(t, worker)
+
+	// Dead is the terminal state, and reaching it is what bounds the retries.
+	var final dispatchState
+	require.Eventually(t, func() bool {
+		final = onlyDispatch(t, ctx, pgc)
+
+		return final.dead
+	}, 30*time.Second, 25*time.Millisecond, "expected the dispatch to be marked dead once it ran out of attempts")
+
+	assert.Equal(t, 2, final.attempts, "a dispatch must die at its attempt ceiling, not before or after it")
+	assert.False(t, final.delivered, "a dead dispatch was never delivered")
+	assert.NotEmpty(t, final.lastError, "the row has to say why it died, or dead is indistinguishable from lost")
+
+	// Every attempt reached the subscriber, numbered, so a receiver can tell a retry from a
+	// second event.
+	deliveries := received()
+	require.Len(t, deliveries, 2, "expected exactly one request per attempt")
+	for i, delivery := range deliveries {
+		assert.Equal(t, strconv.Itoa(i+1), delivery.headers.Get(webhooks.AttemptHeader))
+	}
+
+	// And nothing further. A dead dispatch is excluded from the claim, so a worker that kept
+	// running has nothing to re-serve.
+	assert.Never(t, func() bool {
+		return len(received()) > 2
+	}, time.Second, 50*time.Millisecond, "a dead dispatch must stop being retried")
+}
+
+// TestIntegration_WebhookDelivery_ReapsDeliveredDispatches covers the other end of the
+// lifecycle.
+//
+// The delivery log is the record of what a subscriber was sent, and it grows with every event
+// this deployment publishes. Nothing else trims it: retention has no scheduled job of its own,
+// because the worker's own tick reaps — so a worker that delivers and does not reap is a table
+// that only grows, and the absence would be invisible until the disk was.
+//
+// The reap interval is a plain config field and is turned right down. The retention window
+// cannot be — its floor is a minute — so the clock is moved past it once the delivery has
+// landed, which is the same window the worker computes in production.
+func TestIntegration_WebhookDelivery_ReapsDeliveredDispatches(t *testing.T) {
+	ctx := t.Context()
+
+	workerClock := newAdvanceableClock()
+
+	repo, emitter, worker, pgc := buildDeliveryHarness(t, func(tuning *deliveryTuning) {
+		tuning.Config.Worker.ReapInterval = testReapInterval
+		tuning.Config.Worker.Retention = testRetention
+		tuning.Clock = workerClock
+	})
+
+	subscriber, received := newTestSubscriber(t, func() int { return http.StatusOK })
+
+	subscribeAndEmit(t, ctx, repo, emitter, pgc, subscriber.URL, types.WebhookCreatedServiceEventType)
+
+	runWorker(t, worker)
+
+	require.Eventually(t, func() bool {
+		return len(received()) > 0
+	}, 30*time.Second, 25*time.Millisecond, "expected the subscriber to receive the delivery")
+
+	// Delivered, and now older than the retention window. Advanced only after the delivery has
+	// landed: the worker stamps delivered_at from this same clock, so moving it beforehand
+	// would carry the row's age forward with it and never reach the window.
+	require.Eventually(t, func() bool {
+		return onlyDispatch(t, ctx, pgc).delivered
+	}, 30*time.Second, 25*time.Millisecond, "expected the dispatch to be marked delivered")
+
+	workerClock.advance(2 * testRetention)
+
+	// The dispatch, the delivery it belonged to, and the attempts recorded against it all go.
+	// Reaping the dispatch alone would leave the payload behind forever, which is the row that
+	// actually holds the event's contents.
+	require.Eventually(t, func() bool {
+		return countRows(t, ctx, pgc, "webhooks_dispatches") == 0 &&
+			countRows(t, ctx, pgc, "webhooks_deliveries") == 0 &&
+			countRows(t, ctx, pgc, "webhooks_attempts") == 0
+	}, 30*time.Second, 25*time.Millisecond, "expected the delivered dispatch, its delivery, and its attempts to be reaped")
+
+	// The endpoint outlives its deliveries: reaping the log must not unsubscribe anybody.
+	assert.Equal(t, 1, countRows(t, ctx, pgc, "webhooks_endpoints"))
+	assert.Positive(t, countRows(t, ctx, pgc, "webhooks_subscriptions"))
+}
+
+// TestIntegration_WebhookDelivery_UndeliveredIsNotReaped pins the half of retention that would
+// be silent if it broke.
+//
+// The reaper deletes delivered dispatches. One still owed to a subscriber that has been down for
+// longer than the retention window must survive it — reaping by age alone would delete exactly
+// the events a subscriber has not seen, which is the opposite of what retention is for.
+func TestIntegration_WebhookDelivery_UndeliveredIsNotReaped(t *testing.T) {
+	ctx := t.Context()
+
+	workerClock := newAdvanceableClock()
+
+	repo, emitter, worker, pgc := buildDeliveryHarness(t, func(tuning *deliveryTuning) {
+		tuning.Config.Worker.ReapInterval = testReapInterval
+		tuning.Config.Worker.Retention = testRetention
+		tuning.Clock = workerClock
+		// Long enough that the dispatch stays outstanding for the whole test rather than
+		// dying and being reaped for some other reason. The clock below moves past the
+		// retention window but not past this, so the row is still owed a retry throughout.
+		tuning.Config.Worker.Backoff.MaxAttempts = 100
+		tuning.Config.Worker.Backoff.InitialDelay = time.Hour
+		tuning.Config.Worker.Backoff.MaxDelay = time.Hour
+		tuning.Config.Worker.Backoff.UseJitter = false
+	})
+
+	subscriber, received := newTestSubscriber(t, func() int { return http.StatusInternalServerError })
+
+	subscribeAndEmit(t, ctx, repo, emitter, pgc, subscriber.URL, types.WebhookCreatedServiceEventType)
+
+	runWorker(t, worker)
+
+	require.Eventually(t, func() bool {
+		return len(received()) > 0
+	}, 30*time.Second, 25*time.Millisecond, "expected the subscriber to be attempted at least once")
+
+	// Older than the retention window, and still undelivered.
+	workerClock.advance(2 * testRetention)
+
+	// Several reap intervals, all of them past the retention window.
+	assert.Never(t, func() bool {
+		return countRows(t, ctx, pgc, "webhooks_dispatches") == 0
+	}, 4*testReapInterval, 50*time.Millisecond, "an undelivered dispatch must survive retention")
+
+	state := onlyDispatch(t, ctx, pgc)
+	assert.False(t, state.delivered)
+	assert.False(t, state.dead)
+	assert.Positive(t, state.attempts)
+}

--- a/backend/internal/repositories/postgres/webhooks/delivery_test.go
+++ b/backend/internal/repositories/postgres/webhooks/delivery_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/primandproper/dinnerdonebetter/backend/internal/repositories/postgres/events"
 	pgtesting "github.com/primandproper/dinnerdonebetter/backend/internal/repositories/postgres/testing"
 
+	"github.com/primandproper/platform-go/v13/clock"
 	"github.com/primandproper/platform-go/v13/cryptography/requestsigning"
 	"github.com/primandproper/platform-go/v13/database"
 	"github.com/primandproper/platform-go/v13/database/dialect"
@@ -76,10 +77,29 @@ func newTestSubscriber(t *testing.T, status func() int) (subscriber *httptest.Se
 	}
 }
 
+// deliveryTuning is what a test may change about the delivery worker before it is built.
+//
+// Two things, because the worker's timings come from two places. The retry schedule and the
+// poll are plain config fields; the retention window is one too, but its floor is a minute, so
+// the only way to reach a reap inside a test is to move the clock the window is measured
+// against. Both seams are the worker's own — see webhooks.WithWorkerClock.
+type deliveryTuning struct {
+	// Config is the worker's configuration, with its defaults already filled in.
+	Config *webhookscfg.Config
+
+	// Clock drives the poll loop, the leases, the backoff, and the reap window. Leaving it
+	// nil is the wall clock, which is what every test that is not asserting on retention
+	// wants.
+	Clock clock.Clock
+}
+
 // buildDeliveryHarness wires the whole webhook path over one database: the repository that
 // registers endpoints, the Emitter that dispatches inside a transaction, and the Worker that
 // delivers.
-func buildDeliveryHarness(t *testing.T) (*repository, *events.Emitter, *webhooks.Worker, database.Client) {
+//
+// tune runs after the worker's defaults are filled and before it is built, which is how a test
+// asks for a retry schedule or a retention window it can actually reach.
+func buildDeliveryHarness(t *testing.T, tune ...func(*deliveryTuning)) (*repository, *events.Emitter, *webhooks.Worker, database.Client) {
 	t.Helper()
 
 	ctx := t.Context()
@@ -126,13 +146,23 @@ func buildDeliveryHarness(t *testing.T) (*repository, *events.Emitter, *webhooks
 	// A short poll so a test spends milliseconds waiting rather than a second.
 	workerCfg.Worker.PollInterval = 10 * time.Millisecond
 
+	tuning := &deliveryTuning{Config: workerCfg}
+	for _, apply := range tune {
+		apply(tuning)
+	}
+
+	workerOpts := []webhooks.WorkerOption{
+		webhooks.WithWorkerURLChecker(allowLoopback),
+		// The subscriber's certificate is self-signed, which is what httptest issues.
+		webhooks.WithHTTPClient(&http.Client{Transport: insecureTransport()}),
+	}
+	if tuning.Clock != nil {
+		workerOpts = append(workerOpts, webhooks.WithWorkerClock(tuning.Clock))
+	}
+
 	worker, err := webhookscfg.NewWorker(ctx, workerCfg, store,
 		webhookscfg.WithLogger(loggingnoop.NewLogger()),
-		webhookscfg.WithWorkerOptions(
-			webhooks.WithWorkerURLChecker(allowLoopback),
-			// The subscriber's certificate is self-signed, which is what httptest issues.
-			webhooks.WithHTTPClient(&http.Client{Transport: insecureTransport()}),
-		),
+		webhookscfg.WithWorkerOptions(workerOpts...),
 	)
 	require.NoError(t, err)
 

--- a/backend/internal/services/dataprivacy/grpc/service.go
+++ b/backend/internal/services/dataprivacy/grpc/service.go
@@ -125,8 +125,11 @@ func (s *serviceImpl) FetchUserDataReport(ctx context.Context, request *datapriv
 	artifact, err := s.requests.Open(ctx, stored.ID)
 	if err != nil {
 		// Unavailable covers an erasure, an export that has not completed, and one whose
-		// artifact has expired and been deleted. All three are "there is nothing here to
-		// give you", which is NotFound rather than an error about our storage.
+		// artifact has expired and been deleted. The code that reaches the client is
+		// FailedPrecondition rather than the NotFound named here: platform-go's mapper
+		// recognizes this sentinel and overrides the default, because the request exists and
+		// the caller may see it — it is only not in a state this call can serve. The default
+		// stands for a future error that is not this one.
 		if errors.Is(err, platformdataprivacy.ErrArtifactUnavailable) {
 			return nil, errorsgrpc.PrepareAndLogGRPCStatus(err, logger, span, codes.NotFound, "artifact is unavailable")
 		}

--- a/backend/testing/integration/apiserver/dataprivacy_fulfillment_test.go
+++ b/backend/testing/integration/apiserver/dataprivacy_fulfillment_test.go
@@ -1,0 +1,384 @@
+package integration
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	ddbdataprivacy "github.com/primandproper/dinnerdonebetter/backend/internal/domain/dataprivacy"
+	dataprivacygrpc "github.com/primandproper/dinnerdonebetter/backend/internal/grpc/generated/services/dataprivacy"
+	"github.com/primandproper/dinnerdonebetter/backend/pkg/client"
+
+	platformdataprivacy "github.com/primandproper/platform-go/v13/dataprivacy"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// fulfillmentBudget is how long a test waits for the operations worker to pick a request up and
+// finish it.
+//
+// It is generous because the wait is mostly the queue's poll: nothing wakes the worker when a
+// request is enqueued in this deployment, so a submission sits until the next poll comes round.
+// That is the production configuration, and running the suite against a shorter one would be
+// asserting on timings nothing deploys.
+const fulfillmentBudget = 90 * time.Second
+
+// dataPrivacySweepMu orders the data privacy tests against each other.
+//
+// The sweep is database-wide and destructive: it deletes the artifact of every completed export
+// whose expiry has passed, not this test's. A sweeper running on a clock a week ahead —
+// which is the only way a test can reach an artifact's window at all — would therefore delete an
+// artifact a sibling test is about to fetch, and the sibling would fail for a reason that has
+// nothing to do with it.
+//
+// Only the tests in this file take the lock, and the rest of the suite is unaffected: nothing
+// else produces an export.
+var dataPrivacySweepMu sync.Mutex
+
+// serializeDataPrivacy holds that order for the whole of a test, from before it submits a
+// request until after its last assertion about the artifact.
+func serializeDataPrivacy(t *testing.T) {
+	t.Helper()
+
+	dataPrivacySweepMu.Lock()
+	t.Cleanup(dataPrivacySweepMu.Unlock)
+}
+
+// awaitTerminalPrivacyRequest polls a request until it stops moving, and returns it.
+//
+// It polls the request rather than the operation behind it because that is what a subject can
+// see: the row is the answer to "is my export ready", and an operation that finished without
+// moving the row would be a request nobody could ever collect.
+func awaitTerminalPrivacyRequest(t *testing.T, ctx context.Context, c client.Client, requestID string) *dataprivacygrpc.DataPrivacyRequest {
+	t.Helper()
+
+	var request *dataprivacygrpc.DataPrivacyRequest
+
+	require.Eventually(t, func() bool {
+		response, err := c.GetDataPrivacyRequest(ctx, &dataprivacygrpc.GetDataPrivacyRequestRequest{
+			DataPrivacyRequestId: requestID,
+		})
+		if err != nil {
+			return false
+		}
+
+		request = response.GetRequest()
+
+		return platformdataprivacy.Status(request.GetStatus()).Terminal()
+	}, fulfillmentBudget, 250*time.Millisecond, "expected the fulfillment worker to reach a terminal state")
+
+	return request
+}
+
+// awaitTerminalStoredRequest polls the request row directly until it stops moving.
+//
+// The API is the right way to read a request and the wrong way to read this one — see the
+// erasure test. Everything else about the fulfillment is the same, including the worker that
+// wrote the row.
+func awaitTerminalStoredRequest(t *testing.T, ctx context.Context, requestID string) *platformdataprivacy.Request {
+	t.Helper()
+
+	var request *platformdataprivacy.Request
+
+	require.Eventually(t, func() bool {
+		stored, err := dataPrivacyFulfillment.Store.Get(ctx, requestID)
+		if err != nil {
+			return false
+		}
+
+		request = stored
+
+		return request.Status.Terminal()
+	}, fulfillmentBudget, 250*time.Millisecond, "expected the fulfillment worker to reach a terminal state")
+
+	return request
+}
+
+// submitExport asks for the caller's data and returns the request's ID.
+func submitExport(t *testing.T, ctx context.Context, c client.Client) string {
+	t.Helper()
+
+	response, err := c.AggregateUserDataReport(ctx, &dataprivacygrpc.AggregateUserDataReportRequest{})
+	require.NoError(t, err)
+
+	request := response.GetRequest()
+	require.NotEmpty(t, request.GetId())
+	assert.Equal(t, string(platformdataprivacy.RequestExport), request.GetRequestType())
+
+	// Recorded, not fulfilled. The whole reason the worker below exists is that this call
+	// returns before any of the work has happened.
+	assert.False(t, platformdataprivacy.Status(request.GetStatus()).Terminal(),
+		"a submission must return before the export has been produced")
+
+	return request.GetId()
+}
+
+// fetchExportDocument reads a completed export back through the API and decodes it.
+//
+// Through the API rather than out of the bucket, because the bucket holds ciphertext: artifacts
+// are encrypted at rest, and the reader's compressor and cipher agreeing with the writer's is
+// exactly the thing that has no other way of being checked.
+func fetchExportDocument(t *testing.T, ctx context.Context, c client.Client, requestID string) (document *platformdataprivacy.Document, artifact []byte) {
+	t.Helper()
+
+	response, err := c.FetchUserDataReport(ctx, &dataprivacygrpc.FetchUserDataReportRequest{
+		DataPrivacyRequestId: requestID,
+	})
+	require.NoError(t, err)
+
+	artifact = response.GetArtifact()
+	require.NotEmpty(t, artifact)
+
+	document = new(platformdataprivacy.Document)
+	require.NoError(t, json.Unmarshal(artifact, document))
+
+	return document, artifact
+}
+
+// userRowCount counts a user's row, for the erasure's assertions.
+func userRowCount(t *testing.T, ctx context.Context, userID string) int {
+	t.Helper()
+
+	var count int
+	require.NoError(t, databaseClient.Reader().
+		QueryRowContext(ctx, "SELECT COUNT(*) FROM users WHERE id = $1", userID).Scan(&count))
+
+	return count
+}
+
+// TestDataPrivacy_Export is the assertion an export has never had.
+//
+// A subject access request is a legal obligation with a shape: a subject asks, and within a
+// statutory window they are handed everything the application knows about them, and nothing
+// about anybody else. Every part of that spans two processes — the API server records the
+// request, the operations worker gathers over eleven collectors and writes an encrypted
+// artifact, and the API server reads it back — so no unit test can reach it, and until now
+// nothing did.
+//
+// The strongest assertion here is the empty failure map. Each collector is registered against a
+// key and runs against the real schema; a collector whose query no longer matches its tables
+// fails on its own and the export is still delivered, with the gap named in the manifest. That
+// is the right behavior and it is also why the failure would be silent — an export missing three
+// sections still completes.
+func TestDataPrivacy_Export(T *testing.T) {
+	T.Parallel()
+
+	T.Run("produces an artifact holding the subject's data and nobody else's", func(t *testing.T) {
+		t.Parallel()
+		serializeDataPrivacy(t)
+
+		ctx := t.Context()
+
+		subject, subjectClient := createUserAndClientForTest(t)
+
+		// A second user, whose data must not appear. Created before the export is submitted,
+		// so a collector reading a whole table rather than a subject's rows would pick them up.
+		stranger, strangerClient := createUserAndClientForTest(t)
+		createWebhookForTest(t, strangerClient)
+
+		// Something of the subject's own beyond the user row, so the export has to reach past
+		// the identity collector to be right.
+		subjectWebhook := createWebhookForTest(t, subjectClient)
+
+		requestID := submitExport(t, ctx, subjectClient)
+
+		request := awaitTerminalPrivacyRequest(t, ctx, subjectClient, requestID)
+		require.Equal(t, string(platformdataprivacy.StatusCompleted), request.GetStatus(),
+			"the export did not complete: %v", request.GetFailures())
+		assert.Empty(t, request.GetFailures(), "every registered collector must succeed against the real schema")
+		assert.NotNil(t, request.GetExpiresAt(), "a completed export's artifact has to have an expiry")
+
+		document, artifact := fetchExportDocument(t, ctx, subjectClient, requestID)
+
+		assert.True(t, document.Complete(), "a document with failures is a partial export")
+		assert.Equal(t, subject.ID, document.Manifest.Subject.ID)
+		assert.Equal(t, requestID, document.Manifest.RequestID)
+
+		// Every section in the document is one the registry registered. The converse does not
+		// hold and must not be asserted: a collector that finds nothing returns no fragment and
+		// its section is omitted, which is the difference between an artifact that reads as an
+		// answer and one that reads as a form. Which domains are registered at all is asserted
+		// against the registry itself, in TestWorkerWiring_Scheduler.
+		registered := dataPrivacyFulfillment.Registry.CollectorKeys()
+		for _, section := range document.Manifest.Sections {
+			assert.Contains(t, registered, section, "the export carries a section nothing registered")
+			assert.Contains(t, document.Data, section, "a manifest section with no data behind it")
+		}
+
+		// The three this subject certainly has data in: they registered, they own a webhook,
+		// and both of those were audited.
+		for _, key := range []string{
+			ddbdataprivacy.CollectorKeyIdentity,
+			ddbdataprivacy.CollectorKeyWebhooks,
+			ddbdataprivacy.CollectorKeyAuditLog,
+		} {
+			assert.Contains(t, document.Data, key, "the export is missing the %q section", key)
+			assert.Contains(t, document.Manifest.Sections, key)
+		}
+
+		// The subject's own data is in it, from two different collectors.
+		assert.Contains(t, string(document.Data[ddbdataprivacy.CollectorKeyIdentity]), subject.Username)
+		assert.Contains(t, string(document.Data[ddbdataprivacy.CollectorKeyWebhooks]), subjectWebhook.ID)
+
+		// And nobody else's, anywhere in the artifact. Searched over the whole document rather
+		// than per section, because a leak would not announce which collector caused it.
+		assert.NotContains(t, string(artifact), stranger.Username,
+			"another user's data reached this subject's export")
+		assert.NotContains(t, string(artifact), stranger.EmailAddress,
+			"another user's data reached this subject's export")
+	})
+
+	T.Run("refuses to hand an artifact to anybody but its subject", func(t *testing.T) {
+		t.Parallel()
+		serializeDataPrivacy(t)
+
+		ctx := t.Context()
+
+		_, subjectClient := createUserAndClientForTest(t)
+		_, strangerClient := createUserAndClientForTest(t)
+
+		requestID := submitExport(t, ctx, subjectClient)
+
+		request := awaitTerminalPrivacyRequest(t, ctx, subjectClient, requestID)
+		require.Equal(t, string(platformdataprivacy.StatusCompleted), request.GetStatus())
+
+		// NotFound rather than PermissionDenied, in both the missing and the not-yours case: a
+		// distinct denial would confirm that a given request ID exists, and whether somebody
+		// has asked for their data is itself a fact about them.
+		_, err := strangerClient.FetchUserDataReport(ctx, &dataprivacygrpc.FetchUserDataReportRequest{
+			DataPrivacyRequestId: requestID,
+		})
+		require.Error(t, err)
+		assert.Equal(t, codes.NotFound, status.Code(err))
+
+		_, err = strangerClient.GetDataPrivacyRequest(ctx, &dataprivacygrpc.GetDataPrivacyRequestRequest{
+			DataPrivacyRequestId: requestID,
+		})
+		require.Error(t, err)
+		assert.Equal(t, codes.NotFound, status.Code(err))
+	})
+}
+
+// TestDataPrivacy_Erasure is the other half of the obligation, and the one that cannot be undone.
+//
+// The request path records and returns; the erasure itself happens inside one transaction in the
+// worker, over a registry of erasers. What this asserts is that it actually erased — that the
+// user row is gone, and with it everything the schema cascades from one — rather than that a row
+// somewhere says it did.
+func TestDataPrivacy_Erasure(T *testing.T) {
+	T.Parallel()
+
+	T.Run("destroys the subject's data", func(t *testing.T) {
+		t.Parallel()
+		serializeDataPrivacy(t)
+
+		ctx := t.Context()
+
+		subject, subjectClient := createUserAndClientForTest(t)
+		createWebhookForTest(t, subjectClient)
+
+		// A bystander, to show the erasure is scoped to its subject rather than to the table.
+		bystander, _ := createUserAndClientForTest(t)
+
+		require.Equal(t, 1, userRowCount(t, ctx, subject.ID))
+
+		response, err := subjectClient.DestroyAllUserData(ctx, &dataprivacygrpc.DestroyAllUserDataRequest{})
+		require.NoError(t, err)
+
+		request := response.GetRequest()
+		require.NotEmpty(t, request.GetId())
+		assert.Equal(t, string(platformdataprivacy.RequestErasure), request.GetRequestType())
+		// Queued, not deleted. The confirmation window is zero, so nothing further is needed
+		// from the subject — but the deletion still happens in the worker's transaction rather
+		// than on the request path, where a timeout halfway through would leave a subject in a
+		// state no status could describe.
+		assert.False(t, platformdataprivacy.Status(request.GetStatus()).Terminal())
+
+		// Read off the row rather than through the API, and that is not a shortcut: an
+		// erasure ends by deleting its subject, and the API scopes every read of a privacy
+		// request to the subject it belongs to. The one principal entitled to ask how this
+		// request ended no longer exists by the time it has. An operator reads the row.
+		erasure := awaitTerminalStoredRequest(t, ctx, request.GetId())
+		require.Equal(t, platformdataprivacy.StatusCompleted, erasure.Status,
+			"the erasure did not complete: %v", erasure.Failures)
+		assert.Empty(t, erasure.Failures, "every registered eraser must succeed against the real schema")
+
+		assert.Zero(t, userRowCount(t, ctx, subject.ID), "the subject's user row survived their erasure")
+		assert.Equal(t, 1, userRowCount(t, ctx, bystander.ID), "an erasure took somebody else's data with it")
+
+		// An erasure produces no artifact, so there is nothing for the sweep to expire and
+		// nothing for anybody to fetch.
+		assert.Empty(t, erasure.ArtifactRef)
+		assert.True(t, erasure.ExpiresAt.IsZero(), "an erasure has nothing that expires")
+	})
+}
+
+// TestDataPrivacy_Sweeper covers the chore whose absence is invisible.
+//
+// An export artifact is everything the application knows about one person, in a single object.
+// Without the sweep, every one ever written stays in the bucket forever and nothing about the
+// request rows suggests otherwise — the fulfillment worker would look entirely healthy, and the
+// only symptom would be a bucket nobody had reason to look in.
+//
+// The sweep runs on a clock a week ahead rather than against a shortened TTL, because the TTL is
+// stamped onto the request row by the worker that completed it: lowering it in configuration
+// would expire every artifact this suite produces, not this test's.
+func TestDataPrivacy_Sweeper(T *testing.T) {
+	T.Parallel()
+
+	T.Run("expires an artifact past its window", func(t *testing.T) {
+		t.Parallel()
+		serializeDataPrivacy(t)
+
+		ctx := t.Context()
+
+		_, subjectClient := createUserAndClientForTest(t)
+
+		requestID := submitExport(t, ctx, subjectClient)
+
+		request := awaitTerminalPrivacyRequest(t, ctx, subjectClient, requestID)
+		require.Equal(t, string(platformdataprivacy.StatusCompleted), request.GetStatus())
+		require.NotNil(t, request.GetExpiresAt())
+
+		// Readable before the sweep, or the assertion after it proves nothing.
+		fetchExportDocument(t, ctx, subjectClient, requestID)
+
+		// One second past the expiry this artifact was actually stamped with, so the sweep is
+		// asked the same question it is asked in production rather than a broader one.
+		sweeper, err := dataPrivacyFulfillment.SweeperAt(ctx, request.GetExpiresAt().AsTime().Add(time.Second))
+		require.NoError(t, err)
+
+		result, err := sweeper.Sweep(ctx)
+		require.NoError(t, err)
+		assert.Positive(t, result.ArtifactsExpired, "the sweep deleted no artifacts")
+
+		// The row survives — a subject is entitled to know what was asked in their name — and
+		// says the artifact is gone.
+		after, err := subjectClient.GetDataPrivacyRequest(ctx, &dataprivacygrpc.GetDataPrivacyRequestRequest{
+			DataPrivacyRequestId: requestID,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, string(platformdataprivacy.StatusExpired), after.GetRequest().GetStatus())
+
+		// And the artifact is unavailable rather than an internal error about our storage.
+		//
+		// FailedPrecondition, not NotFound. The service asks for NotFound and does not get it:
+		// platform-go's error mapper recognizes ErrArtifactUnavailable and overrides the
+		// default code with its own, on the grounds that the request exists and the caller may
+		// see it — it is simply not in a state this call can serve. That is the behavior a
+		// client has to handle, so it is the behavior pinned here.
+		_, err = subjectClient.FetchUserDataReport(ctx, &dataprivacygrpc.FetchUserDataReportRequest{
+			DataPrivacyRequestId: requestID,
+		})
+		require.Error(t, err)
+		assert.Equal(t, codes.FailedPrecondition, status.Code(err))
+		assert.Contains(t, strings.ToLower(status.Convert(err).Message()), "artifact",
+			"the refusal should say the artifact is unavailable")
+	})
+}

--- a/backend/testing/integration/apiserver/init.go
+++ b/backend/testing/integration/apiserver/init.go
@@ -20,11 +20,24 @@ import (
 
 	"github.com/primandproper/platform-go/v13/database"
 	"github.com/primandproper/platform-go/v13/identifiers"
+	msgconfig "github.com/primandproper/platform-go/v13/messagequeue/config"
 	"github.com/primandproper/platform-go/v13/random"
 )
 
 const (
 	apiConfigurationFilepath = "../../../deploy/environments/testing/config_files/integration-tests-config.json"
+
+	// The other two workloads' rendered configurations, loaded rather than derived from the
+	// API server's.
+	//
+	// Derived would be easier and would prove less. The three processes have to agree about
+	// several things that live in all three files — the operations queue's name, the data
+	// privacy bucket and cipher, the data changes topic — and every one of those agreements is
+	// invisible when it breaks: a request submitted to a queue nothing claims, an artifact
+	// written under a key nothing can open. Reading what a testing deployment actually renders
+	// is what makes those agreements assertions rather than assumptions.
+	schedulerConfigurationFilepath           = "../../../deploy/environments/testing/config_files/scheduler_config.json"
+	asyncMessageHandlerConfigurationFilepath = "../../../deploy/environments/testing/config_files/async_message_handler_config.json"
 )
 
 var (
@@ -34,6 +47,15 @@ var (
 	apiServiceConfig                     *config.APIServiceConfig
 	notifsRepo                           notifications.Repository
 	httpTestServerAddress                string
+
+	// dataPrivacyFulfillment is the scheduler's half of a subject access request, run in this
+	// process. See the note beside where it is started.
+	dataPrivacyFulfillment *localdev.DataPrivacyFulfillment
+
+	// The other two workloads' configurations, pointed at this suite's containers. They are
+	// what the container-resolution tests build their injectors from.
+	schedulerConfig           *config.SchedulerConfig
+	asyncMessageHandlerConfig *config.AsyncMessageHandlerConfig
 )
 
 // getFreePort asks the OS for a free open port that is ready to use.
@@ -151,6 +173,50 @@ func init() {
 	if _, err = localdev.StartSagaWorker(ctx, pillars.Logger, pillars.TracerProvider, databaseClient); err != nil {
 		log.Fatal(err)
 	}
+
+	// The other two workloads' configurations, as a testing deployment renders them.
+	if schedulerConfig, err = config.LoadConfigFromPath[config.SchedulerConfig](schedulerConfigurationFilepath); err != nil {
+		log.Fatal(err)
+	}
+	if asyncMessageHandlerConfig, err = config.LoadConfigFromPath[config.AsyncMessageHandlerConfig](asyncMessageHandlerConfigurationFilepath); err != nil {
+		log.Fatal(err)
+	}
+
+	// The two things a rendered config cannot know: which containers this suite started. Both
+	// are addresses rather than behavior, so everything else in those files is the deployment's
+	// own.
+	for _, workload := range []struct {
+		database *dbcfg.Config
+		events   *msgconfig.Config
+	}{
+		{&schedulerConfig.Database, &schedulerConfig.Events},
+		{&asyncMessageHandlerConfig.Database, &asyncMessageHandlerConfig.Events},
+	} {
+		workload.database.WriteConnection = cfg.Database.WriteConnection
+		workload.database.ReadConnection = cfg.Database.ReadConnection
+		// Migrations are the API server's job — see backend/docs/migrations.md — and a worker
+		// that ran them here would race the one that already has.
+		workload.database.RunMigrations = false
+		*workload.events = cfg.Events
+	}
+
+	// The other half the API server does not run: data privacy fulfillment. Submitting a
+	// subject access request records a row and returns; the gather, the artifact, and the
+	// erasure all happen in an operations worker that lives in the scheduler, so without one
+	// here every export would stay in progress forever and the tests asserting on one would be
+	// asserting on work nothing ever ran.
+	//
+	// Never stopped, for the same reason the saga worker is not: this process exits when the
+	// suite does, and an operation mid-flight at that point has nothing to hand back to.
+	if dataPrivacyFulfillment, err = localdev.NewDataPrivacyFulfillment(ctx, schedulerConfig); err != nil {
+		log.Fatal(err)
+	}
+
+	go func() {
+		if runErr := dataPrivacyFulfillment.Worker.Run(ctx); runErr != nil {
+			log.Fatal(runErr)
+		}
+	}()
 
 	// Release the reserved ports immediately before the server takes them. Everything that
 	// could have stolen one — every container this suite starts — has already been mapped.

--- a/backend/testing/integration/apiserver/wiring_test.go
+++ b/backend/testing/integration/apiserver/wiring_test.go
@@ -1,0 +1,160 @@
+package integration
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	datachangemessagehandlerbuild "github.com/primandproper/dinnerdonebetter/backend/internal/build/functions/data_change_message_handler"
+	schedulerbuild "github.com/primandproper/dinnerdonebetter/backend/internal/build/jobs/scheduler"
+	ddbdataprivacy "github.com/primandproper/dinnerdonebetter/backend/internal/domain/dataprivacy"
+	"github.com/primandproper/dinnerdonebetter/backend/internal/functions/datachangemessagehandler"
+	queuetest "github.com/primandproper/dinnerdonebetter/backend/internal/services/internalops/workers/queue_test"
+	mealplanfinalization "github.com/primandproper/dinnerdonebetter/backend/internal/services/mealplanning/workers/meal_plan_finalization"
+	mealplantasknotifications "github.com/primandproper/dinnerdonebetter/backend/internal/services/mealplanning/workers/meal_plan_task_notifications"
+
+	platformdataprivacy "github.com/primandproper/platform-go/v13/dataprivacy"
+	"github.com/primandproper/platform-go/v13/dataprivacy/auditerasure"
+	"github.com/primandproper/platform-go/v13/jobs"
+	"github.com/primandproper/platform-go/v13/metering"
+	"github.com/primandproper/platform-go/v13/operations"
+	"github.com/primandproper/platform-go/v13/outbox"
+	"github.com/primandproper/platform-go/v13/retention"
+	"github.com/primandproper/platform-go/v13/saga"
+	"github.com/primandproper/platform-go/v13/webhooks"
+
+	"github.com/samber/do/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The two worker processes' containers are the one thing driving a worker directly cannot see.
+//
+// Every other test in this suite builds a worker's dependencies for it, which is exactly what
+// makes those tests worth having and exactly what makes them blind here: a handler hung off the
+// wrong pool, or a component that quietly stopped being registered, is invisible to a test that
+// supplies the component itself. samber/do resolves lazily, so an absent registration is not a
+// startup error either — it is an error the first time something asks, which for a background
+// worker can be the first time a subject asks for their data.
+//
+// That is not hypothetical. The data privacy registry could not be built in the scheduler at all
+// until this test was written: the container registered the settings and waitlists repositories
+// but not the domain interfaces two collectors ask for, so the fulfillment worker failed to
+// resolve — and nothing said so, because nothing had ever resolved it.
+//
+// These tests resolve; they do not run. Running is what the rest of the suite does.
+
+// buildSchedulerInjector stands up the scheduler's container over this suite's database and
+// releases it when the test ends.
+func buildSchedulerInjector(t *testing.T) do.Injector {
+	t.Helper()
+
+	i := schedulerbuild.BuildInjector(context.Background(), schedulerConfig)
+
+	shutdownInjector(t, i)
+
+	return i
+}
+
+// shutdownInjector releases a container's resources after the test.
+func shutdownInjector(t *testing.T, i *do.RootScope) {
+	t.Helper()
+
+	t.Cleanup(func() {
+		// A background context: t.Context() is already cancelled by the time cleanups run,
+		// and these shutdowns close connection pools and queue goroutines.
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		if report := i.ShutdownWithContext(ctx); report != nil {
+			assert.True(t, report.Succeed, "releasing the container: %v", report)
+		}
+	})
+}
+
+// TestWorkerWiring_Scheduler resolves everything the scheduler process runs.
+//
+// One entry per thing that is started or ticked in that process. A registration deleted, or a
+// dependency added to one of these constructors without being registered beside it, is a
+// resolution failure here rather than a crash loop in an environment.
+func TestWorkerWiring_Scheduler(T *testing.T) {
+	T.Parallel()
+
+	T.Run("resolves every component it runs", func(t *testing.T) {
+		t.Parallel()
+
+		i := buildSchedulerInjector(t)
+
+		// The loops, each of which service.New starts and cmd/ddb shuts down.
+		require.NotNil(t, do.MustInvoke[*jobs.Scheduler](i))
+		require.NotNil(t, do.MustInvoke[*outbox.Relay](i))
+		require.NotNil(t, do.MustInvoke[*saga.Worker](i))
+		require.NotNil(t, do.MustInvoke[*webhooks.Worker](i))
+		require.NotNil(t, do.MustInvoke[*operations.Worker](i))
+
+		// The scheduled jobs. Each is resolved from inside its own closure at tick time rather
+		// than at registration, so building the Scheduler above proves nothing about them — a
+		// job whose dependency stopped being registered would tick, panic, and be recorded as a
+		// failed run for as long as nobody read the metric.
+		require.NotNil(t, do.MustInvoke[*mealplanfinalization.Starter](i))
+		require.NotNil(t, do.MustInvoke[*mealplantasknotifications.Worker](i))
+		require.NotNil(t, do.MustInvoke[*queuetest.Job](i))
+		require.NotNil(t, do.MustInvoke[*platformdataprivacy.Sweeper](i))
+		require.NotNil(t, do.MustInvoke[*retention.Sweeper](i))
+		require.NotNil(t, do.MustInvoke[*metering.Flusher](i))
+	})
+
+	T.Run("registers every data privacy collector and eraser", func(t *testing.T) {
+		t.Parallel()
+
+		i := buildSchedulerInjector(t)
+
+		registry := do.MustInvoke[*platformdataprivacy.Registry](i)
+
+		// The exported document's sections are exactly these keys, minus the ones the subject
+		// happens to hold nothing under — so a domain that stopped being registered produces an
+		// export that is complete by its own manifest and missing a domain's worth of somebody's
+		// data. There is no other place that would notice.
+		assert.ElementsMatch(t, []string{
+			ddbdataprivacy.CollectorKeyIdentity,
+			ddbdataprivacy.CollectorKeyMealPlanning,
+			ddbdataprivacy.CollectorKeyWebhooks,
+			ddbdataprivacy.CollectorKeySettings,
+			ddbdataprivacy.CollectorKeyNotifications,
+			ddbdataprivacy.CollectorKeyPayments,
+			ddbdataprivacy.CollectorKeyAuditLog,
+			ddbdataprivacy.CollectorKeyIssueReports,
+			ddbdataprivacy.CollectorKeyUploadedMedia,
+			ddbdataprivacy.CollectorKeyWaitlists,
+			ddbdataprivacy.CollectorKeyComments,
+		}, registry.CollectorKeys())
+
+		// The erasers are the destructive half, and the audit one is a policy decision that is
+		// on in this deployment. An eraser missing here is data that survives a right-to-be-
+		// forgotten request.
+		assert.ElementsMatch(t, []string{
+			ddbdataprivacy.EraserKeyComments,
+			ddbdataprivacy.EraserKeyIdentity,
+			auditerasure.DefaultKey,
+		}, registry.EraserKeys())
+	})
+}
+
+// TestWorkerWiring_AsyncMessageHandler resolves the data change consumer.
+//
+// It is one component rather than a list, because that process is one component: a handler the
+// pools hand messages to. What this catches is the same thing — a dependency added to the handler
+// without being registered — in the process where the symptom would be a broker topic nothing
+// drains.
+func TestWorkerWiring_AsyncMessageHandler(T *testing.T) {
+	T.Parallel()
+
+	T.Run("resolves its handler", func(t *testing.T) {
+		t.Parallel()
+
+		i := datachangemessagehandlerbuild.BuildInjector(context.Background(), asyncMessageHandlerConfig)
+		shutdownInjector(t, i)
+
+		require.NotNil(t, do.MustInvoke[*datachangemessagehandler.AsyncDataChangeMessageHandler](i))
+	})
+}


### PR DESCRIPTION
Closes #1407.

Covers the three async outcomes the ticket names, by driving the workers directly rather than
booting a process: data privacy fulfillment, webhook delivery's failure and retention halves, and
the two worker containers' wiring.

Writing the coverage found three defects, all of which are fixed here. Each is the kind the ticket
predicted: silent, and reachable only by running the thing end to end.

## What was added

**Data privacy fulfillment** — `testing/integration/apiserver/dataprivacy_fulfillment_test.go`, the
first coverage this path has ever had. `internal/localdev/data_privacy_worker.go` stands the
scheduler's own container up over the suite's database and hands back the operations worker and the
sweeper; the suite runs the worker for the length of the run, the way it already runs the saga
worker. Nothing is faked — real queue, real claim and lease, real collectors, real bucket and
cipher.

- An export completes with no collector failures, and the artifact reads back through the API
  server's own `Open` — which is what proves the reader's cipher and compressor still match the
  writer's, since the stored object is ciphertext.
- The artifact holds the subject's data from two collectors and holds no trace of a second user
  created alongside them.
- An erasure actually erases: the subject's user row is gone, a bystander's is not. Its outcome is
  read off the request row rather than through the API, because an erasure ends by deleting the one
  principal the API would let read it.
- The sweeper expires an artifact past its window, and the request afterwards says `expired` and
  serves nothing.

**Webhook delivery** — `internal/repositories/postgres/webhooks/delivery_lifecycle_test.go`, beside
the delivery harness that already existed. The ticket says nothing asserts a dispatch is delivered,
signed, retried or reaped; the first two were already covered by `delivery_test.go`, so this adds
the other two:

- A failing subscriber is retried to its attempt ceiling and then marked dead — with `last_error`
  set, so dead is distinguishable from lost — and is not retried again.
- A delivered dispatch, its delivery, and its attempts are reaped past retention, and the endpoint
  and its subscriptions survive.
- An undelivered dispatch past the same window is **not** reaped.

`buildDeliveryHarness` now takes a tuning hook carrying the worker config and an optional clock.
The retry schedule is plain config; retention cannot go below a minute, so the reap tests move the
worker's clock forward after the delivery lands (`webhooks.WithWorkerClock`, exactly the seam the
ticket names).

**Worker container wiring** — `testing/integration/apiserver/wiring_test.go` resolves everything the
scheduler process runs and the async message handler's one component, from the configs a testing
deployment actually renders. Also asserts the data privacy registry holds all eleven collectors and
all three erasers, which is the one thing an export document cannot tell you: a section is omitted
when the subject holds nothing under it, so a domain that stopped being registered produces an
export that is complete by its own manifest.

## The three defects

1. **The scheduler could not build the data privacy registry.** It registered the settings and
   waitlists *repositories*, which provide the concrete `*Repository`; only their managers bind the
   `settings.Repository` / `waitlists.Repository` interfaces two collectors ask for. `samber/do`
   resolves lazily, so this was not a startup failure — the operations worker simply failed to
   resolve the first time anything asked, which is the first time a subject asks for their data.
   Fixed by registering the managers, as the async message handler already does.

2. **No role could ask for its own data.** `create.user_data_reports`, `read.user_data_reports` and
   `destroy.user_data` are declared in `internal/authorization`, mapped to the data privacy
   service's methods, and listed under `AccountMemberPermissions` — and none of them existed in the
   seeded `permissions` table. Every call was `PermissionDenied`, indistinguishable from a caller
   who genuinely lacked it. Seeded and granted to `role_account_member`, the base role every
   principal inherits. `internal/repositories/postgres/migrations/rbac_seed_test.go` is the
   regression test: every permission a role holds in Go must be seeded by some migration. Those
   three were the only drift.

3. **`ddb worker async-messages` could not boot.** The rendered config carried no `encoding`
   section, and a content type of `""` is not a default — it is a decoder that refuses to be
   constructed. Added to the render and regenerated all three environments' files.

Also corrected a comment in the data privacy service: it says an unavailable artifact is `NotFound`,
but platform-go's error mapper recognizes `ErrArtifactUnavailable` and overrides that with
`FailedPrecondition`. The tests pin the behavior a client actually sees.

## ⚠️ This edits an applied migration

`00019_rbac.sql` gains three permission rows and three grants. Per `backend/docs/migrations.md`,
goose keys applied migrations by version and does not checksum their bodies, so **anyone with an
existing local Postgres volume has to drop and recreate it** — otherwise the edit is silently
skipped and data privacy stays unreachable locally.

## Testing

- `testing/integration/apiserver` — full suite green (152s), including the 6 new tests.
- `internal/repositories/postgres/webhooks` and `.../migrations` — green with containers.
- `go test -short ./internal/... ./pkg/...` — green.
- `golangci-lint run` over every touched package — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UV69b8m7RWjNZ1ab6RhrZ6
