### PR TITLE
Record why links is not adopted for email verification, and what that leaves standing

### DIFF
--- a/backend/docs/platform-go-v13-adoption.md
+++ b/backend/docs/platform-go-v13-adoption.md
@@ -141,6 +141,30 @@ than a side effect: the local tables could hide a signup and could not suppress 
 who unsubscribed was somebody the next form submission re-subscribed. #1378 did it — see below.
 `identity` is the largest by far and should be its own epic.
 
+## The one adoption blocked on infrastructure
+
+`links` — platform's single-use, expiring action links — was evaluated for email verification in
+[#1385](https://github.com/primandproper/dinnerdonebetter/issues/1385) and is not adopted. It is
+the only item so far blocked by something other than sequencing, and the reason is not in the
+table above because `links` replaces no store: it is a capability this repository has no equivalent
+of.
+
+`links.NewMinter` takes a `cache.Cache[Record]` and nothing else, and platform's `cache/config`
+offers `memory` and `redis`. Nothing but localdev provisions a Redis here. The memory provider is
+not a fallback for this package either — the mint happens in the async message handler that builds
+the email and the redemption in the API server that serves the click, so a per-process cache writes
+every link somewhere the redeemer cannot read it, at one replica each.
+
+Filed upstream as [platform-go#459](https://github.com/primandproper/platform-go/issues/459),
+asking for the `sessions` shape: a `Store` seam with a cache implementation and a `links/database`
+one. `sessions`, `webauthn` and `passwordreset` all offer a durable store; `links` is the only one
+that does not. `idempotency` has the identical gap, which is why the idempotency interceptor is
+switched off in the production config.
+
+Until one of those changes, email verification stays on the plaintext, never-expiring,
+replayable column it has always used — written down honestly in `docs/email_verification.md` so
+that the state is a known debt rather than an assumption.
+
 ## What adopting a *referenced* table costs
 
 `uploads/registry` (#1376) is the first store this repository adopted whose table other domains

--- a/docs/auth-flow.md
+++ b/docs/auth-flow.md
@@ -139,10 +139,33 @@ That is the one place it appears, and the email link is the one place it lands. 
 attached to a span, a log line, or an audit entry; `RelevantID` on the audit entries below is the
 row's ID, which cannot be exchanged for a token.
 
+The verification token rides on a message for a weaker reason — it is stored as itself, so it could
+be read back, and the resend path does exactly that. Do not read the sentence above as saying the
+two tokens are equals; see [Email Verification](#email-verification) below.
+
 Issuing and redeeming are both recorded in the audit log as `password_reset_tokens`
 created/updated, by a thin wrapper around the platform store — the platform has no opinion about
 who wants a record of a reset, and "was a link issued for this account before the takeover, and
 was it used?" is a question asked months later, after the sweeper has removed the row.
+
+## Email Verification
+
+Verification tokens are **not** the reset tokens' equal, and the resemblance of the two flows —
+both mail a link, both carry their secret on a data change message — hides that. A reset token is a
+digest in a platform-owned table with a thirty minute life and a single use the store enforces. A
+verification token is a plaintext column on the user's row (`users.email_address_verification_token`)
+that never expires, is never cleared, and can be replayed: the guarded `UPDATE` behind it is an
+`:exec` whose affected-row count is discarded, so a second click matches nothing, returns no error,
+and answers `Verified: true`.
+
+That is the current state rather than the intended one.
+[#1385](https://github.com/primandproper/dinnerdonebetter/issues/1385) decided to move this flow
+onto platform-go's `links`, which would have supplied expiry and single use together; it is blocked
+because `links` stores its records in a cache and nothing but localdev provisions one — filed
+upstream as [platform-go#459](https://github.com/primandproper/platform-go/issues/459).
+
+[email_verification.md](email_verification.md) has the full path, the four missing properties with
+the file each is checkable against, and what would unblock the adoption.
 
 ## Web App Auth Flow (Consumer / Admin)
 

--- a/docs/email_verification.md
+++ b/docs/email_verification.md
@@ -13,3 +13,126 @@ flowchart TD
     EmailVerifiedClick(button clicked) --> UserEmailVerified(email marked as verified)
     UserEmailVerified(email marked as verified) --> DataChangesChannel(Data changes function)
 ```
+
+## Where the token comes from, and where it goes
+
+The verification token is a column on the user's own row — `users.email_address_verification_token`
+([`00001_identity.sql`](../backend/internal/repositories/postgres/migrations/migration_files/00001_identity.sql))
+— not a table of its own. There is one per user, written once.
+
+**Minting.** `CreateUser` generates it inside the signup transaction: 32 random bytes,
+base64url encoded, from the repository's `random.Generator`
+([`postgres/identity/users.go`](../backend/internal/repositories/postgres/identity/users.go), in
+the `WithTransaction` block). It is written to the column in the same `INSERT` that creates the
+user, so a signup that rolls back takes its token with it.
+
+**Delivery.** The secret rides out on the transactional outbox event under
+`identitykeys.UserEmailVerificationTokenKey`, and the async handler turns that into the email:
+`identity.UserSignedUpServiceEventType` and `UserEmailAddressVerificationEmailRequestedEventType`
+both land in
+[`datachangemessagehandler/identity_handlers.go`](../backend/internal/functions/datachangemessagehandler/identity_handlers.go)
+and both call `BuildVerifyEmailAddressEmail`
+([`services/identity/emails/emails.go`](../backend/internal/services/identity/emails/emails.go)),
+which renders `{baseURL}/verify_email_address?t={token}`. `baseURL` is the only knob; there is no
+separate verification URL setting.
+
+The secret travels on the message here for a different reason than the password reset token does.
+The reset token is a digest in its table, so the message is the only place its secret can be read
+from; the verification token is stored as itself, so the message is a convenience rather than a
+necessity — the resend path below reads it straight back out of the database.
+
+**Redemption.** The email's button is a `GET` to the consumer frontend
+(`frontend/consumer/src/routes/verify_email_address/`), which posts the token to the
+unauthenticated gRPC `AuthService/VerifyEmailAddress`
+([`services/auth/grpc/auth.go`](../backend/internal/services/auth/grpc/auth.go)) →
+`AuthManager.VerifyUserEmailAddressByToken`
+([`domain/auth/managers/auth_manager.go`](../backend/internal/domain/auth/managers/auth_manager.go)),
+which looks the user up *by the token alone* and then calls `MarkUserEmailAddressAsVerified`. That
+write stamps `email_address_verified_at`, records an audit entry, and moves the account to
+`good_standing` with the explanation "verified email address", in one transaction.
+
+**Resending.** `RequestEmailVerificationEmail` (session required) reads the stored token back with
+`GetEmailAddressVerificationTokenForUser` and republishes the same event. The read filters on
+`email_address_verified_at IS NULL`, so an already-verified user gets an error rather than a second
+email. Resending does not rotate the token: the link in the second email is the link from the
+first.
+
+## What this token is not
+
+The reset-token section of [auth-flow.md](auth-flow.md#password-reset) describes four properties
+worth having. The verification token has none of them, and the difference is not stylistic — each
+of these is checkable against the file named.
+
+**It never expires.** There is no `expires_at` beside the column and no sweep that touches it. A
+verification link mailed three years ago still works today. The only thing that ends one is the
+verification it performs.
+
+**It is not single use, and the replay reports success.** `MarkEmailAddressAsVerified` guards on
+`email_address_verified_at IS NULL`, which looks like it settles the matter, but it is a `:exec`
+statement whose generated Go discards the affected-row count
+([`identity/generated/users.generated.sql_generated.go`](../backend/internal/repositories/postgres/identity/generated/users.generated.sql_generated.go)):
+
+```go
+func (q *Queries) MarkEmailAddressAsVerified(ctx context.Context, db DBTX, arg *MarkEmailAddressAsVerifiedParams) error {
+	_, err := db.ExecContext(ctx, markEmailAddressAsVerified, arg.ID, arg.EmailAddressVerificationToken)
+	return err
+}
+```
+
+A second click therefore updates nothing, returns `nil`, writes a *fresh* audit entry claiming an
+email address was verified, re-runs `SetUserAccountStatus`, publishes another
+`UserEmailAddressVerifiedEventType`, and answers the caller `Verified: true`. Nothing in the
+schema or the code distinguishes that from the first click. The token is never cleared, and
+`GetUserByEmailAddressVerificationToken` does not filter on verified state, so it stays a live
+lookup key for the account permanently.
+
+**It is stored as itself.** Plaintext in the column, indexed for lookup. A database copy — a
+backup, a read replica, a support engineer's `SELECT` — is a verified email address for every
+account that has not clicked yet. The reset token, by contrast, is a SHA-256 digest and the secret
+exists exactly once, in the `Issuance` the store returns.
+
+**It survives an address change.** `UpdateUserEmailAddress` sets `email_address_verified_at = NULL`
+but leaves the token alone, so the link mailed to the *old* address verifies the *new* one. The
+token is bound to the user, never to the address it was sent to.
+
+The one thing it does get right is the audit log. The verification entry records a change to
+`email_address_verification` and does not carry the token at all, so it never reaches the trail —
+and the catch-all in
+[`domain/audit/redaction.go`](../backend/internal/domain/audit/redaction.go) hashes any change
+field named `token` or `email_verification_token` anyway, for whatever writes one later.
+
+## Why this is not platform's `links`
+
+[primandproper/dinnerdonebetter#1385](https://github.com/primandproper/dinnerdonebetter/issues/1385)
+decided to adopt platform-go's `links` — single-use, expiring URLs — for exactly this flow, which
+would have supplied all four missing properties at once. It is blocked, and on infrastructure
+rather than on work.
+
+`links` is cache-backed. `links.NewMinter(store cache.Cache[Record], locker distributedlock.ScopedLocker, …)`
+is the whole storage seam, and platform's `cache/config` offers two providers: `memory` and
+`redis`. This repository provisions no Redis outside localdev — there is none in
+`infra/deploy/environments/prod/`, and `internal/config/environments/prod.go` already disables the
+idempotency interceptor for the same missing dependency.
+
+The memory provider is not a smaller version of the same thing here. The link would be minted by
+the async message handler, which builds the email, and redeemed by the API server, which serves the
+click — two separate deployments — so a per-process cache writes every link somewhere the redeemer
+cannot read. That is true at one replica each, so it is not a caveat a small deployment can accept.
+
+Filed upstream as
+[platform-go#459](https://github.com/primandproper/platform-go/issues/459): `links` is the only one
+of platform's four link-and-session packages with no durable store, where `sessions` has
+`sessions/database`, `webauthn` has a database provider, and `passwordreset` is SQL-only. Adoption
+becomes available again when either that ticket ships a `links/database` or this deployment gains a
+shared cache.
+
+Until then the token above is what verifies an email address, and the four properties it lacks are
+open work rather than accepted design.
+
+## Loose ends worth knowing about
+
+`AuthManager.VerifyUserEmailAddress` — the session-scoped variant taking an
+`EmailAddressVerificationRequestInput` — is unreachable from the gRPC surface. The handler calls
+`VerifyUserEmailAddressByToken` instead, which is the right choice for a link clicked out of an
+email by someone who may not be signed in. The session-scoped method and its converter in
+`services/auth/grpc/converters/converters.go` are dead in the request path.


### PR DESCRIPTION
Closes #1385, with "no" rather than with an adoption.

## The two questions the ticket asked first

- **Does this collapse into #1381?** No. Platform's `identity` does not import `links` at all — it
  keeps its own `email_address_verification_token` column on the user row and takes the token from
  the caller. Adopting `links` for `verify_email` is an independent choice either way.
- **Does `passwordreset` already cover the reset case?** Yes; #1372 landed, which is what left email
  verification as the sole driver.

## Why it is not adopted

`links` is cache-backed. `links.NewMinter(store cache.Cache[Record], locker distributedlock.ScopedLocker, …)`
is the whole storage seam, and platform's `cache/config` offers exactly two providers, `memory` and
`redis`. There is no Redis in `infra/deploy/environments/prod/` — terraform or kustomize — and
`internal/config/environments/prod.go` already disables the idempotency interceptor over the same
missing dependency, in a comment that reasons the case out correctly.

The memory provider is not a degraded mode here. The link would be minted by the **async message
handler**, which builds the email, and redeemed by the **API server**, which serves the click — two
separate deployments — so a per-process cache writes every link somewhere the redeemer never reads.
That holds at one replica each, so it is not a caveat a small deployment can accept.

The lock half was never the problem: `distributedlock` has a Postgres provider that this repository
already uses for sagas and the scheduler.

Filed upstream as [primandproper/platform-go#459](https://github.com/primandproper/platform-go/issues/459),
asking for the `sessions` shape — a `Store` seam with a cache implementation and a `links/database`
one. `sessions` has `sessions/database`, `webauthn` has a database provider, `passwordreset` is
SQL-only; `links` is the only one of the four with no durable store, and `idempotency` has the
identical gap.

## What that leaves standing

Not adopting means the hand-rolled token stays, so this PR writes down what it actually is. Each
claim is checkable against the file it names:

| | verification token | reset token |
| --- | --- | --- |
| storage | plaintext column on `users` | SHA-256 digest in its own table |
| expiry | none, ever | 30 minutes, refused rather than swept |
| single use | no — replay returns `Verified: true` | affected-row count inside one transaction |
| address change | old link verifies the new address | n/a |

The replay is the one worth reading twice. `MarkEmailAddressAsVerified` guards on
`email_address_verified_at IS NULL`, which looks like it settles it, but it is an `:exec` whose
generated Go discards the affected-row count. A second click matches no row, returns `nil`, then
writes a fresh audit entry claiming an email address was verified, re-runs `SetUserAccountStatus`,
publishes another `UserEmailAddressVerifiedEventType`, and answers `Verified: true`.

## Changes

Documentation only.

- `docs/email_verification.md` — was a title and a mermaid diagram. Now the full path from mint to
  redemption, the four missing properties, why `links` is blocked, and the dead session-scoped
  `VerifyUserEmailAddress` variant the gRPC surface does not call.
- `docs/auth-flow.md` — an Email Verification section after Password Reset, plus a qualification of
  the existing line "The email verification token travels the same way for the same reason", which
  is true about the message bus and misleading about everything else.
- `backend/docs/platform-go-v13-adoption.md` — one section recording the first adoption blocked by
  something other than sequencing.

## Testing

**No code changed, so no tests were added or run.** `git diff --name-only` is three `.md` files.
The verification that mattered was accuracy: every file cited was re-read before the claim next to
it was written, and the four defects were each confirmed against the generated SQL or Go rather
than inferred from the schema.

## Deliberately not in scope

Fixing the four defects locally (a `passwordreset`-shaped rework: own table, digest, TTL, guarded
UPDATE), provisioning Redis, and `account_invitations` — whose accept path is also read-then-write
rather than atomic, and which #1381 replaces wholesale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0192BHXmNuYYc7QQCVZrtcPA
